### PR TITLE
Update solver_direct_mean.cpp

### DIFF
--- a/SU2_CFD/src/solver_direct_mean.cpp
+++ b/SU2_CFD/src/solver_direct_mean.cpp
@@ -9809,7 +9809,7 @@ void CNSSolver::Viscous_Forces(CGeometry *geometry, CConfig *config) {
           
           GradTemperature = 0.0;
           for (iDim = 0; iDim < nDim; iDim++)
-            GradTemperature += Grad_PrimVar[0][iDim]*(-Normal[iDim]);
+            GradTemperature += Grad_PrimVar[0][iDim]*(-UnitNormal[iDim]);
           
           Cp = (Gamma / Gamma_Minus_One) * Gas_Constant;
           thermal_conductivity = Cp * Viscosity/Prandtl_Lam;


### PR DESCRIPTION
Heatflux computation fixed by using UnitNormal, rather than Normal
