### PR TITLE
Guarantee DV_KIND comes before DV_PARAM in options

### DIFF
--- a/SU2_PY/SU2/io/config.py
+++ b/SU2_PY/SU2/io/config.py
@@ -152,8 +152,8 @@ class Config(ordered_bunch):
         dv_old = [ dv_old[i]*dv_scl for i,dv_scl in enumerate(dv_scales) ]
         
         # Change the parameters of the design variables
-        self.update({ 'DV_KIND'      : def_dv['KIND']      ,
-                      'DV_MARKER'    : def_dv['MARKER'][0] ,
+        self['DV_KIND'] = def_dv['KIND']
+        self.update({ 'DV_MARKER'    : def_dv['MARKER'][0] ,
                       'DV_PARAM'     : def_dv['PARAM']     ,
                       'DV_VALUE_OLD' : dv_old              ,
                       'DV_VALUE_NEW' : dv_new              })


### PR DESCRIPTION
This makes sure DV_KIND comes before DV_PARAM when a config file is
output by the python scripts. The python dict passed to update doesn't
guarantee order. This issue occured when DV_KIND and DV_PARAM
were not previously defined in a config file passed to
shape_optimization.py
