### PR TITLE
Use CGNS_ENUMT and CGNS_ENUMV to properly scope type and variable names

### DIFF
--- a/Common/src/geometry_structure.cpp
+++ b/Common/src/geometry_structure.cpp
@@ -6471,11 +6471,11 @@ void CPhysicalGeometry::Read_CGNS_Format(CConfig *config, string val_mesh_filena
   char basename[CGNS_STRING_SIZE], zonename[CGNS_STRING_SIZE];
   char coordname[CGNS_STRING_SIZE];
   cgsize_t* cgsize; cgsize = new cgsize_t[3];
-  ZoneType_t zonetype;
-  DataType_t datatype;
+  CGNS_ENUMT(ZoneType_t) zonetype;
+  CGNS_ENUMT(DataType_t) datatype;
   double** coordArray = NULL;
   double*** gridCoords = NULL;
-  ElementType_t elemType;
+  CGNS_ENUMT(ElementType_t) elemType;
   cgsize_t range_min, range_max, startE, endE;
   range_min = 1;
   string currentElem;
@@ -6636,7 +6636,7 @@ void CPhysicalGeometry::Read_CGNS_Format(CConfig *config, string val_mesh_filena
       for ( int k = 1; k <= ncoords; k++ ) {
         
         /*--- Read the coordinate info. This will retrieve the
-         data type (either RealSingle or RealDouble) as
+r        data type (either CGNS_ENUMV(RealSingle) or CGNS_ENUMV(RealDouble)) as
          well as the coordname which will specifiy the
          type of data that it is based in the SIDS convention.
          This might be "CoordinateX," for instance. ---*/
@@ -6645,7 +6645,7 @@ void CPhysicalGeometry::Read_CGNS_Format(CConfig *config, string val_mesh_filena
         cout << "Reading " << coordname << " values from file." << endl;
         
         /*--- Always retrieve the grid coords in double precision. ---*/
-        datatype = RealDouble;
+        datatype = CGNS_ENUMV(RealDouble);
         if ( cg_coord_read(fn, i, j, coordname, datatype, &range_min,
                            &range_max, coordArray[j-1]) ) cg_error_exit();
         
@@ -6715,43 +6715,43 @@ void CPhysicalGeometry::Read_CGNS_Format(CConfig *config, string val_mesh_filena
          SU2 recognizes elements by their VTK number. ---*/
         
         switch (elemType) {
-          case NODE:
+          case CGNS_ENUMV(NODE):
             currentElem      = "Vertex";
             elemTypeVTK[j-1][s-1] = 1;
             break;
-          case BAR_2:
+          case CGNS_ENUMV(BAR_2):
             currentElem      = "Line";
             elemTypeVTK[j-1][s-1] = 3;
             break;
-          case BAR_3:
+          case CGNS_ENUMV(BAR_3):
             currentElem      = "Line";
             elemTypeVTK[j-1][s-1] = 3;
             break;
-          case TRI_3:
+          case CGNS_ENUMV(TRI_3):
             currentElem      = "Triangle";
             elemTypeVTK[j-1][s-1] = 5;
             break;
-          case QUAD_4:
+          case CGNS_ENUMV(QUAD_4):
             currentElem      = "Quadrilateral";
             elemTypeVTK[j-1][s-1] = 9;
             break;
-          case TETRA_4:
+          case CGNS_ENUMV(TETRA_4):
             currentElem      = "Tetrahedron";
             elemTypeVTK[j-1][s-1] = 10;
             break;
-          case HEXA_8:
+          case CGNS_ENUMV(HEXA_8):
             currentElem      = "Hexahedron";
             elemTypeVTK[j-1][s-1] = 12;
             break;
-          case PENTA_6:
+          case CGNS_ENUMV(PENTA_6):
             currentElem      = "Prism";
             elemTypeVTK[j-1][s-1] = 13;
             break;
-          case PYRA_5:
+          case CGNS_ENUMV(PYRA_5):
             currentElem      = "Pyramid";
             elemTypeVTK[j-1][s-1] = 14;
             break;
-          case HEXA_20:
+          case CGNS_ENUMV(HEXA_20):
             printf( "\n\n   !!! Error !!!\n" );
             printf( " HEXA-20 element type not supported\n");
             printf(" Section %d, npe=%d\n", s, npe);
@@ -6759,7 +6759,7 @@ void CPhysicalGeometry::Read_CGNS_Format(CConfig *config, string val_mesh_filena
             printf( " Now exiting...\n\n");
             exit(EXIT_FAILURE);
             break;
-          case MIXED:
+          case CGNS_ENUMV(MIXED):
             currentElem      = "Mixed";
             elemTypeVTK[j-1][s-1] = -1;
             break;
@@ -6867,7 +6867,7 @@ void CPhysicalGeometry::Read_CGNS_Format(CConfig *config, string val_mesh_filena
           int counter = 0;
           
           for ( int ii = 0; ii < nElems[j-1][s-1]; ii++ ) {
-            ElementType_t elmt_type = ElementType_t (connElemTemp[counter]);
+            CGNS_ENUMT(ElementType_t) elmt_type = CGNS_ENUMT(ElementType_t) (connElemTemp[counter]);
             cg_npe( elmt_type, &npe);
             
             /*--- Mixed element support for 2D added here by Shlomy Shitrit ---*/
@@ -6942,34 +6942,34 @@ void CPhysicalGeometry::Read_CGNS_Format(CConfig *config, string val_mesh_filena
               if (elemTypeVTK[k][s] == -1 ) {
                 
                 /*--- Mixed-element support. ---*/
-                ElementType_t elmt_type = ElementType_t (connElems[k][s][0][i]);
+                CGNS_ENUMT(ElementType_t) elmt_type = CGNS_ENUMT(ElementType_t) (connElems[k][s][0][i]);
                 cg_npe( elmt_type, &npe);
                 switch (elmt_type) {
-                  case NODE:
+                  case CGNS_ENUMV(NODE):
                     fprintf( SU2File, "%2i\t", 1);
                     break;
-                  case BAR_2:
+                  case CGNS_ENUMV(BAR_2):
                     fprintf( SU2File, "%2i\t", 3);
                     break;
-                  case BAR_3:
+                  case CGNS_ENUMV(BAR_3):
                     fprintf( SU2File, "%2i\t", 3);
                     break;
-                  case TRI_3:
+                  case CGNS_ENUMV(TRI_3):
                     fprintf( SU2File, "%2i\t", 5);
                     break;
-                  case QUAD_4:
+                  case CGNS_ENUMV(QUAD_4):
                     fprintf( SU2File, "%2i\t", 9);
                     break;
-                  case TETRA_4:
+                  case CGNS_ENUMV(TETRA_4):
                     fprintf( SU2File, "%2i\t", 10);
                     break;
-                  case HEXA_8:
+                  case CGNS_ENUMV(HEXA_8):
                     fprintf( SU2File, "%2i\t", 12);
                     break;
-                  case PENTA_6:
+                  case CGNS_ENUMV(PENTA_6):
                     fprintf( SU2File, "%2i\t", 13);
                     break;
-                  case PYRA_5:
+                  case CGNS_ENUMV(PYRA_5):
                     fprintf( SU2File, "%2i\t", 14);
                     break;
                   default:
@@ -7030,34 +7030,34 @@ void CPhysicalGeometry::Read_CGNS_Format(CConfig *config, string val_mesh_filena
               /*--- Mixed-element support. ---*/
               
               for ( int i = 0; i < nElems[k][s]; i++ ) {
-                ElementType_t elmt_type = ElementType_t (connElems[k][s][0][i]);
+                CGNS_ENUMT(ElementType_t) elmt_type = CGNS_ENUMT(ElementType_t) (connElems[k][s][0][i]);
                 cg_npe( elmt_type, &npe);
                 switch (elmt_type) {
-                  case NODE:
+                  case CGNS_ENUMV(NODE):
                     fprintf( SU2File, "%2i\t", 1);
                     break;
-                  case BAR_2:
+                  case CGNS_ENUMV(BAR_2):
                     fprintf( SU2File, "%2i\t", 3);
                     break;
-                  case BAR_3:
+                  case CGNS_ENUMV(BAR_3):
                     fprintf( SU2File, "%2i\t", 3);
                     break;
-                  case TRI_3:
+                  case CGNS_ENUMV(TRI_3):
                     fprintf( SU2File, "%2i\t", 5);
                     break;
-                  case QUAD_4:
+                  case CGNS_ENUMV(QUAD_4):
                     fprintf( SU2File, "%2i\t", 9);
                     break;
-                  case TETRA_4:
+                  case CGNS_ENUMV(TETRA_4):
                     fprintf( SU2File, "%2i\t", 10);
                     break;
-                  case HEXA_8:
+                  case CGNS_ENUMV(HEXA_8):
                     fprintf( SU2File, "%2i\t", 12);
                     break;
-                  case PENTA_6:
+                  case CGNS_ENUMV(PENTA_6):
                     fprintf( SU2File, "%2i\t", 13);
                     break;
-                  case PYRA_5:
+                  case CGNS_ENUMV(PYRA_5):
                     fprintf( SU2File, "%2i\t", 14);
                     break;
                   default: // error
@@ -7126,34 +7126,34 @@ void CPhysicalGeometry::Read_CGNS_Format(CConfig *config, string val_mesh_filena
           if (elemTypeVTK[k][s] == -1 ) {
             
             /*--- Mixed-element support. ---*/
-            ElementType_t elmt_type = ElementType_t (connElems[k][s][0][i]);
+            CGNS_ENUMT(ElementType_t) elmt_type = CGNS_ENUMT(ElementType_t) (connElems[k][s][0][i]);
             cg_npe( elmt_type, &npe);
             switch (elmt_type) {
-              case NODE:
+              case CGNS_ENUMV(NODE):
                 VTK_Type = 1;
                 break;
-              case BAR_2:
+              case CGNS_ENUMV(BAR_2):
                 VTK_Type = 3;
                 break;
-              case BAR_3:
+              case CGNS_ENUMV(BAR_3):
                 VTK_Type = 3;
                 break;
-              case TRI_3:
+              case CGNS_ENUMV(TRI_3):
                 VTK_Type = 5;
                 break;
-              case QUAD_4:
+              case CGNS_ENUMV(QUAD_4):
                 VTK_Type = 9;
                 break;
-              case TETRA_4:
+              case CGNS_ENUMV(TETRA_4):
                 VTK_Type = 10;
                 break;
-              case HEXA_8:
+              case CGNS_ENUMV(HEXA_8):
                 VTK_Type = 12;
                 break;
-              case PENTA_6:
+              case CGNS_ENUMV(PENTA_6):
                 VTK_Type = 13;
                 break;
-              case PYRA_5:
+              case CGNS_ENUMV(PYRA_5):
                 VTK_Type = 14;
                 break;
               default: // error
@@ -7292,18 +7292,18 @@ void CPhysicalGeometry::Read_CGNS_Format(CConfig *config, string val_mesh_filena
             if (elemTypeVTK[k][s] == -1 ) {
               
               /*--- Mixed-element support. ---*/
-              ElementType_t elmt_type = ElementType_t (connElems[k][s][0][i]);
+              CGNS_ENUMT(ElementType_t) elmt_type = CGNS_ENUMT(ElementType_t) (connElems[k][s][0][i]);
               cg_npe( elmt_type, &npe);
               switch (elmt_type) {
-                case NODE: VTK_Type = 1; break;
-                case BAR_2: VTK_Type = 3; break;
-                case BAR_3: VTK_Type = 3; break;
-                case TRI_3: VTK_Type = 5; break;
-                case QUAD_4: VTK_Type = 9; break;
-                case TETRA_4: VTK_Type = 10; break;
-                case HEXA_8: VTK_Type = 12; break;
-                case PENTA_6: VTK_Type = 13; break;
-                case PYRA_5: VTK_Type = 14; break;
+                case CGNS_ENUMV(NODE): VTK_Type = 1; break;
+                case CGNS_ENUMV(BAR_2): VTK_Type = 3; break;
+                case CGNS_ENUMV(BAR_3): VTK_Type = 3; break;
+                case CGNS_ENUMV(TRI_3): VTK_Type = 5; break;
+                case CGNS_ENUMV(QUAD_4): VTK_Type = 9; break;
+                case CGNS_ENUMV(TETRA_4): VTK_Type = 10; break;
+                case CGNS_ENUMV(HEXA_8): VTK_Type = 12; break;
+                case CGNS_ENUMV(PENTA_6): VTK_Type = 13; break;
+                case CGNS_ENUMV(PYRA_5): VTK_Type = 14; break;
                 default: cout << "Kind of element not suppported!" << endl; break;  // error
               }
               /*--- Transfer the nodes for this element. ---*/
@@ -7457,11 +7457,11 @@ void CPhysicalGeometry::Read_CGNS_Format_Parallel(CConfig *config, string val_me
   char basename[CGNS_STRING_SIZE], zonename[CGNS_STRING_SIZE];
   char coordname[CGNS_STRING_SIZE];
   cgsize_t* cgsize; cgsize = new cgsize_t[3];
-  ZoneType_t zonetype;
-  DataType_t datatype;
+  CGNS_ENUMT(ZoneType_t) zonetype;
+  CGNS_ENUMT(DataType_t) datatype;
   double** coordArray = NULL;
   double*** gridCoords = NULL;
-  ElementType_t elemType;
+  CGNS_ENUMT(ElementType_t) elemType;
   cgsize_t range_min, range_max, startE, endE;
   range_min = 1;
   string currentElem;
@@ -7757,7 +7757,7 @@ void CPhysicalGeometry::Read_CGNS_Format_Parallel(CConfig *config, string val_me
       for (int k = 1; k <= ncoords; k++) {
         
         /*--- Read the coordinate info. This will retrieve the
-         data type (either RealSingle or RealDouble) as
+         data type (either CGNS_ENUMV(RealSingle) or CGNS_ENUMV(RealDouble)) as
          well as the coordname which will specifiy the
          type of data that it is based in the SIDS convention.
          This might be "CoordinateX," for instance. ---*/
@@ -7771,7 +7771,7 @@ void CPhysicalGeometry::Read_CGNS_Format_Parallel(CConfig *config, string val_me
         
         /*--- Always retrieve the grid coords in double precision. ---*/
         
-        if (datatype != RealDouble) {
+        if (datatype != CGNS_ENUMV(RealDouble)) {
           printf("\n\n   !!! Error !!!\n" );
           printf(" CGNS coordinates are not double precision.\n");
           printf(" Now exiting...\n\n");
@@ -7909,8 +7909,8 @@ void CPhysicalGeometry::Read_CGNS_Format_Parallel(CConfig *config, string val_me
           /*--- If we have a mixed element section, we need to check the elem
            type one by one. Set the flag to true if mixed. ---*/
           
-          if (elemType == MIXED) {
-            ElementType_t elmt_type = ElementType_t(connElemCGNS[counter]);
+          if (elemType == CGNS_ENUMV(MIXED)) {
+            CGNS_ENUMT(ElementType_t) elmt_type = CGNS_ENUMT(ElementType_t)(connElemCGNS[counter]);
             cg_npe( elmt_type, &npe);
             elemType = elmt_type;
             counter++; for ( int jj = 0; jj < npe; jj++ ) counter++;
@@ -7931,43 +7931,43 @@ void CPhysicalGeometry::Read_CGNS_Format_Parallel(CConfig *config, string val_me
            their VTK number. ---*/
           
           switch (elemType) {
-            case NODE:
+            case CGNS_ENUMV(NODE):
               currentElem   = "Vertex";
               elemTypes[ii] = 1;
               break;
-            case BAR_2:
+            case CGNS_ENUMV(BAR_2):
               currentElem   = "Line";
               elemTypes[ii] = 3;
               break;
-            case BAR_3:
+            case CGNS_ENUMV(BAR_3):
               currentElem   = "Line";
               elemTypes[ii] = 3;
               break;
-            case TRI_3:
+            case CGNS_ENUMV(TRI_3):
               currentElem   = "Triangle";
               elemTypes[ii] = 5;
               break;
-            case QUAD_4:
+            case CGNS_ENUMV(QUAD_4):
               currentElem   = "Quadrilateral";
               elemTypes[ii] = 9;
               break;
-            case TETRA_4:
+            case CGNS_ENUMV(TETRA_4):
               currentElem   = "Tetrahedron";
               elemTypes[ii] = 10;
               break;
-            case HEXA_8:
+            case CGNS_ENUMV(HEXA_8):
               currentElem   = "Hexahedron";
               elemTypes[ii] = 12;
               break;
-            case PENTA_6:
+            case CGNS_ENUMV(PENTA_6):
               currentElem   = "Prism";
               elemTypes[ii] = 13;
               break;
-            case PYRA_5:
+            case CGNS_ENUMV(PYRA_5):
               currentElem   = "Pyramid";
               elemTypes[ii] = 14;
               break;
-            case HEXA_20:
+            case CGNS_ENUMV(HEXA_20):
               if (rank == MASTER_NODE) {
                 printf("\n\n   !!! Error !!!\n" );
                 printf(" HEXA-20 element type not supported\n");
@@ -8094,34 +8094,34 @@ void CPhysicalGeometry::Read_CGNS_Format_Parallel(CConfig *config, string val_me
              SU2 recognizes elements by their VTK number. ---*/
             
             switch (elemType) {
-              case NODE:
+              case CGNS_ENUMV(NODE):
                 elemTypeVTK[j-1][s-1] = 1;
                 break;
-              case BAR_2:
+              case CGNS_ENUMV(BAR_2):
                 elemTypeVTK[j-1][s-1] = 3;
                 break;
-              case BAR_3:
+              case CGNS_ENUMV(BAR_3):
                 elemTypeVTK[j-1][s-1] = 3;
                 break;
-              case TRI_3:
+              case CGNS_ENUMV(TRI_3):
                 elemTypeVTK[j-1][s-1] = 5;
                 break;
-              case QUAD_4:
+              case CGNS_ENUMV(QUAD_4):
                 elemTypeVTK[j-1][s-1] = 9;
                 break;
-              case TETRA_4:
+              case CGNS_ENUMV(TETRA_4):
                 elemTypeVTK[j-1][s-1] = 10;
                 break;
-              case HEXA_8:
+              case CGNS_ENUMV(HEXA_8):
                 elemTypeVTK[j-1][s-1] = 12;
                 break;
-              case PENTA_6:
+              case CGNS_ENUMV(PENTA_6):
                 elemTypeVTK[j-1][s-1] = 13;
                 break;
-              case PYRA_5:
+              case CGNS_ENUMV(PYRA_5):
                 elemTypeVTK[j-1][s-1] = 14;
                 break;
-              case HEXA_20:
+              case CGNS_ENUMV(HEXA_20):
                 printf( "\n\n   !!! Error !!!\n" );
                 printf( " HEXA-20 element type not supported\n");
                 printf(" Section %d, npe=%d\n", s, npe);
@@ -8134,7 +8134,7 @@ void CPhysicalGeometry::Read_CGNS_Format_Parallel(CConfig *config, string val_me
                 MPI_Finalize();
 #endif
                 break;
-              case MIXED:
+              case CGNS_ENUMV(MIXED):
                 currentElem = "Mixed";
                 elemTypeVTK[j-1][s-1] = -1;
                 break;
@@ -8179,7 +8179,7 @@ void CPhysicalGeometry::Read_CGNS_Format_Parallel(CConfig *config, string val_me
             if (elemTypeVTK[j-1][s-1] == -1) {
               int counter = 0;
               for ( int ii = 0; ii < nElems[j-1][s-1]; ii++ ) {
-                ElementType_t elmt_type = ElementType_t(connElemTemp[counter]);
+                CGNS_ENUMT(ElementType_t) elmt_type = CGNS_ENUMT(ElementType_t)(connElemTemp[counter]);
                 cg_npe( elmt_type, &npe);
                 counter++;
                 connElems[j-1][s-1][0][ii] = elmt_type;
@@ -8848,19 +8848,19 @@ void CPhysicalGeometry::Read_CGNS_Format_Parallel(CConfig *config, string val_me
                 
                 /*--- Mixed-element support. Check the elem type. ---*/
                 
-                ElementType_t elmt_type = ElementType_t(connElems[k][s][0][i]);
+                CGNS_ENUMT(ElementType_t) elmt_type = CGNS_ENUMT(ElementType_t)(connElems[k][s][0][i]);
                 cg_npe( elmt_type, &npe);
                 
                 switch (elmt_type) {
-                  case NODE:    VTK_Type = 1;  break;
-                  case BAR_2:   VTK_Type = 3;  break;
-                  case BAR_3:   VTK_Type = 3;  break;
-                  case TRI_3:   VTK_Type = 5;  break;
-                  case QUAD_4:  VTK_Type = 9;  break;
-                  case TETRA_4: VTK_Type = 10; break;
-                  case HEXA_8:  VTK_Type = 12; break;
-                  case PENTA_6: VTK_Type = 13; break;
-                  case PYRA_5:  VTK_Type = 14; break;
+                  case CGNS_ENUMV(NODE):    VTK_Type = 1;  break;
+                  case CGNS_ENUMV(BAR_2):   VTK_Type = 3;  break;
+                  case CGNS_ENUMV(BAR_3):   VTK_Type = 3;  break;
+                  case CGNS_ENUMV(TRI_3):   VTK_Type = 5;  break;
+                  case CGNS_ENUMV(QUAD_4):  VTK_Type = 9;  break;
+                  case CGNS_ENUMV(TETRA_4): VTK_Type = 10; break;
+                  case CGNS_ENUMV(HEXA_8):  VTK_Type = 12; break;
+                  case CGNS_ENUMV(PENTA_6): VTK_Type = 13; break;
+                  case CGNS_ENUMV(PYRA_5):  VTK_Type = 14; break;
                   default:
                     cout << "Kind of element not suppported!" << endl;
 #ifndef HAVE_MPI

--- a/SU2_CFD/src/output_cgns.cpp
+++ b/SU2_CFD/src/output_cgns.cpp
@@ -84,12 +84,12 @@ void COutput::SetCGNS_Coordinates(CConfig *config, CGeometry *geometry, unsigned
 //		if (cgns_err) cg_error_print();
     
 		/*--- write CGNS node coordinates ---*/
-		cgns_err = cg_coord_write(cgns_file,cgns_base,cgns_zone,RealDouble,"x",Coords[0],&cgns_coord);
+		cgns_err = cg_coord_write(cgns_file,cgns_base,cgns_zone,CGNS_ENUMV(RealDouble),"x",Coords[0],&cgns_coord);
 		if (cgns_err) cg_error_print();
-		cgns_err = cg_coord_write(cgns_file,cgns_base,cgns_zone,RealDouble,"y",Coords[1],&cgns_coord);
+		cgns_err = cg_coord_write(cgns_file,cgns_base,cgns_zone,CGNS_ENUMV(RealDouble),"y",Coords[1],&cgns_coord);
 		if (cgns_err) cg_error_print();
 		if (geometry->GetnDim() == 3){
-			cgns_err = cg_coord_write(cgns_file,cgns_base,cgns_zone,RealDouble,"z",Coords[2],&cgns_coord);
+			cgns_err = cg_coord_write(cgns_file,cgns_base,cgns_zone,CGNS_ENUMV(RealDouble),"z",Coords[2],&cgns_coord);
 			if (cgns_err) cg_error_print();
 		}
     
@@ -117,7 +117,7 @@ void COutput::SetCGNS_Coordinates(CConfig *config, CGeometry *geometry, unsigned
 		isize[2][0] = 0;						// boundary vertex size (zero if elements not sorted)
 
 		/*--- write CGNS zone data ---*/
-		cgns_err = cg_zone_write(cgns_file,cgns_base_results,"SU2 Zone",isize[0],Unstructured,&cgns_zone_results);
+		cgns_err = cg_zone_write(cgns_file,cgns_base_results,"SU2 Zone",isize[0],CGNS_ENUMV(Unstructured),&cgns_zone_results);
 		if (cgns_err) cg_error_print();
 
 		cgns_err = cg_goto(cgns_file,cgns_base_results,"Zone_t",cgns_zone_results,"end");
@@ -127,12 +127,12 @@ void COutput::SetCGNS_Coordinates(CConfig *config, CGeometry *geometry, unsigned
 		if (config->GetGrid_Movement()) {
       
 			/*--- write CGNS node coordinates ---*/
-			cgns_err = cg_coord_write(cgns_file,cgns_base_results,cgns_zone_results,RealDouble,"x",Coords[0],&cgns_coord);
+			cgns_err = cg_coord_write(cgns_file,cgns_base_results,cgns_zone_results,CGNS_ENUMV(RealDouble),"x",Coords[0],&cgns_coord);
 			if (cgns_err) cg_error_print();
-			cgns_err = cg_coord_write(cgns_file,cgns_base_results,cgns_zone_results,RealDouble,"y",Coords[1],&cgns_coord);
+			cgns_err = cg_coord_write(cgns_file,cgns_base_results,cgns_zone_results,CGNS_ENUMV(RealDouble),"y",Coords[1],&cgns_coord);
 			if (cgns_err) cg_error_print();
 			if (geometry->GetnDim() == 3){
-				cgns_err = cg_coord_write(cgns_file,cgns_base_results,cgns_zone_results,RealDouble,"z",Coords[2],&cgns_coord);
+				cgns_err = cg_coord_write(cgns_file,cgns_base_results,cgns_zone_results,CGNS_ENUMV(RealDouble),"z",Coords[2],&cgns_coord);
 				if (cgns_err) cg_error_print();
 			}
 		}
@@ -228,18 +228,18 @@ void COutput::SetCGNS_Connectivity(CConfig *config, CGeometry *geometry, unsigne
 		if (cgns_err) cg_error_print();
     switch (config->GetKind_Solver()) {
       case EULER:
-        cgns_err = cg_governing_write(Euler); break;
+        cgns_err = cg_governing_write(CGNS_ENUMV(Euler)); break;
       case NAVIER_STOKES:
-        cgns_err = cg_governing_write(NSLaminar); break;
+        cgns_err = cg_governing_write(CGNS_ENUMV(NSLaminar)); break;
       case RANS:
-        cgns_err = cg_governing_write(NSTurbulent); break;
+        cgns_err = cg_governing_write(CGNS_ENUMV(NSTurbulent)); break;
       default:
         break; // cgns_err = cg_governing_write(CG_UserDefined);
     }
     if (cgns_err) cg_error_print();
     
-		if (unsteady) cgns_err = cg_simulation_type_write(cgns_file,cgns_base,TimeAccurate);
-		else cgns_err = cg_simulation_type_write(cgns_file,cgns_base,NonTimeAccurate);
+		if (unsteady) cgns_err = cg_simulation_type_write(cgns_file,cgns_base,CGNS_ENUMV(TimeAccurate));
+		else cgns_err = cg_simulation_type_write(cgns_file,cgns_base,CGNS_ENUMV(NonTimeAccurate));
 		if (cgns_err) cg_error_print();
     
 		cgns_err = cg_descriptor_write("Solver Information","SU2 version 3.2.8.1 \"eagle\"");
@@ -250,7 +250,7 @@ void COutput::SetCGNS_Connectivity(CConfig *config, CGeometry *geometry, unsigne
 		isize[2][0] = 0;						// boundary vertex size (zero if elements not sorted)
     
 		/*--- write CGNS zone data ---*/
-		cgns_err = cg_zone_write(cgns_file,cgns_base,"SU2 Zone",isize[0],Unstructured,&cgns_zone);
+		cgns_err = cg_zone_write(cgns_file,cgns_base,"SU2 Zone",isize[0],CGNS_ENUMV(Unstructured),&cgns_zone);
 		if (cgns_err) cg_error_print();
 
     cgns_err = cg_goto(cgns_file,cgns_base,"Zone_t",cgns_zone,"end");
@@ -268,37 +268,37 @@ void COutput::SetCGNS_Connectivity(CConfig *config, CGeometry *geometry, unsigne
 			elem_start = 1; elem_end = (int)nGlobal_Tria;
       N = (int)nGlobal_Tria*N_POINTS_TRIANGLE;
 			cgns_err = cg_section_write(cgns_file,cgns_base,cgns_zone,
-                                  "Triangle Elements",TRI_3,elem_start,elem_end,
+                                  "Triangle Elements",CGNS_ENUMV(TRI_3),elem_start,elem_end,
                                   0,(cgsize_t *)Conn_Tria,&cgns_section);
     }
 		if (nGlobal_Quad > 0) {
 			elem_start = 1; elem_end = (int)nGlobal_Quad; N = (int)nGlobal_Quad*N_POINTS_QUADRILATERAL;
-			cgns_err = cg_section_write(cgns_file,cgns_base,cgns_zone,"Quadrilateral Elements",QUAD_4,
+			cgns_err = cg_section_write(cgns_file,cgns_base,cgns_zone,"Quadrilateral Elements",CGNS_ENUMV(QUAD_4),
                                   elem_start,elem_end,0,(cgsize_t *)Conn_Quad,&cgns_section);
 		}
 		if (nGlobal_Tetr > 0) {
 			elem_start = 1; elem_end = (int)nGlobal_Tetr; N = (int)nGlobal_Tetr*N_POINTS_TETRAHEDRON;
-			cgns_err = cg_section_write(cgns_file,cgns_base,cgns_zone,"Tetrahedral Elements",TETRA_4,
+			cgns_err = cg_section_write(cgns_file,cgns_base,cgns_zone,"Tetrahedral Elements",CGNS_ENUMV(TETRA_4),
                                   elem_start,elem_end,0,(cgsize_t *)Conn_Tetr,&cgns_section);
 		}
 		if (nGlobal_Hexa > 0) {
 			elem_start = 1; elem_end = (int)nGlobal_Hexa; N = (int)nGlobal_Hexa*N_POINTS_HEXAHEDRON;
-			cgns_err = cg_section_write(cgns_file,cgns_base,cgns_zone,"Hexahedral Elements",HEXA_8,
+			cgns_err = cg_section_write(cgns_file,cgns_base,cgns_zone,"Hexahedral Elements",CGNS_ENUMV(HEXA_8),
                                   elem_start,elem_end,0,(cgsize_t *)Conn_Hexa,&cgns_section);
 		}
 		if (nGlobal_Pyra > 0) {
 			elem_start = 1; elem_end = (int)nGlobal_Pyra; N = (int)nGlobal_Pyra*N_POINTS_PYRAMID;
-			cgns_err = cg_section_write(cgns_file,cgns_base,cgns_zone,"Pyramid Elements",PYRA_5,
+			cgns_err = cg_section_write(cgns_file,cgns_base,cgns_zone,"Pyramid Elements",CGNS_ENUMV(PYRA_5),
                                   elem_start,elem_end,0,(cgsize_t *)Conn_Pyra,&cgns_section);
 		}
 		if (nGlobal_Wedg > 0) {
 			elem_start = 1; elem_end = (int)nGlobal_Wedg; N = (int)nGlobal_Wedg*N_POINTS_WEDGE;
-			cgns_err = cg_section_write(cgns_file,cgns_base,cgns_zone,"Wedge Elements",PENTA_6,
+			cgns_err = cg_section_write(cgns_file,cgns_base,cgns_zone,"Wedge Elements",CGNS_ENUMV(PENTA_6),
                                   elem_start,elem_end,0,(cgsize_t *)Conn_Wedg,&cgns_section);
 		}
 		if (nGlobal_Line > 0) {
 			elem_start = 1; elem_end = (int)nGlobal_Line; N = (int)nGlobal_Line*N_POINTS_LINE;
-			cgns_err = cg_section_write(cgns_file,cgns_base,cgns_zone,"Line Elements",BAR_2,
+			cgns_err = cg_section_write(cgns_file,cgns_base,cgns_zone,"Line Elements",CGNS_ENUMV(BAR_2),
                                   elem_start,elem_end,0,(cgsize_t *)Conn_Line,&cgns_section);
 		}
 		if (cgns_err) cg_error_print();
@@ -370,13 +370,13 @@ void COutput::SetCGNS_Solution(CConfig *config, CGeometry *geometry, unsigned sh
       if (cgns_err) cg_error_print();
       
 			/*--- Create a CGNS solution node ---*/
-			cgns_err = cg_sol_write(cgns_file,cgns_base,cgns_zone,"Solution",Vertex,&cgns_flow);
+			cgns_err = cg_sol_write(cgns_file,cgns_base,cgns_zone,"Solution",CGNS_ENUMV(Vertex),&cgns_flow);
 			if (cgns_err) cg_error_print();
       
 			cgns_err = cg_goto(cgns_file,cgns_base,"Zone_t",cgns_zone,"FlowSolution_t",cgns_flow,"end");
 			if (cgns_err) cg_error_print();
       
-			cgns_err = cg_gridlocation_write(Vertex);
+			cgns_err = cg_gridlocation_write(CGNS_ENUMV(Vertex));
 			if (cgns_err) cg_error_print();
 		}
 
@@ -407,13 +407,13 @@ void COutput::SetCGNS_Solution(CConfig *config, CGeometry *geometry, unsigned sh
 		if (cgns_err) cg_error_print();
     
 		/*--- Write a CGNS solution node for this time step ---*/
-		cgns_err = cg_sol_write(cgns_file,cgns_base_results,cgns_zone_results,"Solution",Vertex,&cgns_flow);
+		cgns_err = cg_sol_write(cgns_file,cgns_base_results,cgns_zone_results,"Solution",CGNS_ENUMV(Vertex),&cgns_flow);
 		if (cgns_err) cg_error_print();
     
 		cgns_err = cg_goto(cgns_file,cgns_base_results,"Zone_t",cgns_zone_results,"FlowSolution_t",cgns_flow,"end");
 		if (cgns_err) cg_error_print();
     
-		cgns_err = cg_gridlocation_write(Vertex);
+		cgns_err = cg_gridlocation_write(CGNS_ENUMV(Vertex));
 		if (cgns_err) cg_error_print();
     
       cgns_base = cgns_base_results;
@@ -435,7 +435,7 @@ void COutput::SetCGNS_Solution(CConfig *config, CGeometry *geometry, unsigned sh
 	/*--- Write conservative variables to CGNS file ---*/
 	for (iVar = 0; iVar < nVar_Consv; iVar++) {
 		name.str(string()); name << "Conservative Variable " << iVar+1;
-		cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,RealDouble,(char *)name.str().c_str(),Data[iVar],&cgns_field);
+		cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,CGNS_ENUMV(RealDouble),(char *)name.str().c_str(),Data[iVar],&cgns_field);
 		if (cgns_err) cg_error_print();
 	}
   
@@ -443,7 +443,7 @@ void COutput::SetCGNS_Solution(CConfig *config, CGeometry *geometry, unsigned sh
   if (config->GetWrt_Limiters()){
     for (jVar = 0; jVar < nVar_Consv; jVar++) {
       name.str(string()); name << "Primitive Limiter " << jVar+1;
-      cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,RealDouble,(char *)name.str().c_str(),Data[iVar],&cgns_field); iVar++;
+      cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,CGNS_ENUMV(RealDouble),(char *)name.str().c_str(),Data[iVar],&cgns_field); iVar++;
       if (cgns_err) cg_error_print();
     }
   }
@@ -452,19 +452,19 @@ void COutput::SetCGNS_Solution(CConfig *config, CGeometry *geometry, unsigned sh
   if (config->GetWrt_Residuals()){
     for (jVar = 0; jVar < nVar_Consv; jVar++) {
       name.str(string()); name << "Conservative Residual " << jVar+1;
-      cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,RealDouble,(char *)name.str().c_str(),Data[iVar],&cgns_field); iVar++;
+      cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,CGNS_ENUMV(RealDouble),(char *)name.str().c_str(),Data[iVar],&cgns_field); iVar++;
       if (cgns_err) cg_error_print();
     }
   }
   
 	/*--- Write grid velocities to CGNS file, if applicable ---*/
 	if (config->GetGrid_Movement()) {
-		cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,RealDouble,"Grid Velocity X",Data[iVar],&cgns_field); iVar++;
+		cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,CGNS_ENUMV(RealDouble),"Grid Velocity X",Data[iVar],&cgns_field); iVar++;
 		if (cgns_err) cg_error_print();
-		cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,RealDouble,"Grid Velocity Y",Data[iVar],&cgns_field); iVar++;
+		cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,CGNS_ENUMV(RealDouble),"Grid Velocity Y",Data[iVar],&cgns_field); iVar++;
 		if (cgns_err) cg_error_print();
 		if (geometry->GetnDim() == 3) {
-			cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,RealDouble,"Grid Velocity Z",Data[iVar],&cgns_field); iVar++;
+			cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,CGNS_ENUMV(RealDouble),"Grid Velocity Z",Data[iVar],&cgns_field); iVar++;
 			if (cgns_err) cg_error_print();
 		}
 	}
@@ -474,35 +474,35 @@ void COutput::SetCGNS_Solution(CConfig *config, CGeometry *geometry, unsigned sh
         
         /*--- Write pressure and Mach data to CGNS file ---*/
       case EULER:
-        cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,RealDouble,"Pressure",Data[iVar],&cgns_field); iVar++;
+        cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,CGNS_ENUMV(RealDouble),"Pressure",Data[iVar],&cgns_field); iVar++;
         if (cgns_err) cg_error_print();
-        cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,RealDouble,"Mach",Data[iVar],&cgns_field); iVar++;
+        cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,CGNS_ENUMV(RealDouble),"Mach",Data[iVar],&cgns_field); iVar++;
         if (cgns_err) cg_error_print();
         break;
         
         /*--- Write temperature and laminar viscosity to CGNS file, if applicable ---*/
       case NAVIER_STOKES:
-        cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,RealDouble,"Pressure",Data[iVar],&cgns_field); iVar++;
+        cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,CGNS_ENUMV(RealDouble),"Pressure",Data[iVar],&cgns_field); iVar++;
         if (cgns_err) cg_error_print();
-        cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,RealDouble,"Mach",Data[iVar],&cgns_field); iVar++;
+        cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,CGNS_ENUMV(RealDouble),"Mach",Data[iVar],&cgns_field); iVar++;
         if (cgns_err) cg_error_print();
-        cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,RealDouble,"Temperature",Data[iVar],&cgns_field); iVar++;
+        cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,CGNS_ENUMV(RealDouble),"Temperature",Data[iVar],&cgns_field); iVar++;
         if (cgns_err) cg_error_print();
-        cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,RealDouble,"Viscosity",Data[iVar],&cgns_field); iVar++;
+        cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,CGNS_ENUMV(RealDouble),"Viscosity",Data[iVar],&cgns_field); iVar++;
         if (cgns_err) cg_error_print();
         break;
         
         /*--- Write eddy viscosity to CGNS file, if applicable ---*/
       case RANS:
-        cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,RealDouble,"Pressure",Data[iVar],&cgns_field); iVar++;
+        cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,CGNS_ENUMV(RealDouble),"Pressure",Data[iVar],&cgns_field); iVar++;
         if (cgns_err) cg_error_print();
-        cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,RealDouble,"Mach",Data[iVar],&cgns_field); iVar++;
+        cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,CGNS_ENUMV(RealDouble),"Mach",Data[iVar],&cgns_field); iVar++;
         if (cgns_err) cg_error_print();
-        cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,RealDouble,"Temperature",Data[iVar],&cgns_field); iVar++;
+        cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,CGNS_ENUMV(RealDouble),"Temperature",Data[iVar],&cgns_field); iVar++;
         if (cgns_err) cg_error_print();
-        cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,RealDouble,"Viscosity",Data[iVar],&cgns_field); iVar++;
+        cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,CGNS_ENUMV(RealDouble),"Viscosity",Data[iVar],&cgns_field); iVar++;
         if (cgns_err) cg_error_print();
-        cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,RealDouble,"Eddy Viscosity",Data[iVar],&cgns_field); iVar++;
+        cgns_err = cg_field_write(cgns_file,cgns_base,cgns_zone,cgns_flow,CGNS_ENUMV(RealDouble),"Eddy Viscosity",Data[iVar],&cgns_field); iVar++;
         if (cgns_err) cg_error_print();
         break;
         


### PR DESCRIPTION
If cgns is built with the flag CG_BUILD_SCOPE, all type and variable names are prefixed with 'CG_', which makes SU2 uncompilable.
Prefixing all CGNS variables and types with the macros CGNS_ENUMV and CGNS_ENUMT takes care of this.
These macros are defined in cgnslib.h:

``` c
#ifdef CGNS_SCOPE_ENUMS
/* set scope prefix for values only */
#define CGNS_ENUMV( e ) CG_ ## e
/* set scope prefix for types */
#define CGNS_ENUMT( e ) CG_ ## e
/* set scope prefix for defines */
#define CGNS_ENUMD( e ) CG_ ## e
/* set scope prefix for variables (lowercase same as functions) */
#define CGNS_ENUMF( e ) cg_ ## e
#else
#define CGNS_ENUMV( e ) e
#define CGNS_ENUMT( e ) e
#define CGNS_ENUMD( e ) e
#define CGNS_ENUMF( e ) e
#endif
```
