### PR TITLE
Add option to disable element reorientation

### DIFF
--- a/Common/include/config_structure.hpp
+++ b/Common/include/config_structure.hpp
@@ -394,6 +394,7 @@ private:
   CFLFineGrid,		/*!< \brief CFL of the finest grid. */
   Max_DeltaTime,  		/*!< \brief Max delta time. */
   Unst_CFL;		/*!< \brief Unsteady CFL number. */
+  bool ReorientElements;		/*!< \brief Flag for enabling element reorientation. */
   bool AddIndNeighbor;			/*!< \brief Include indirect neighbor in the agglomeration process. */
   unsigned short nDV,		/*!< \brief Number of design variables. */
   nObj, nObjW;              /*! \brief Number of objective functions. */
@@ -2395,6 +2396,12 @@ public:
    * \return CFL number for unsteady simulations.
    */
   su2double GetUnst_CFL(void);
+
+  /*!
+   * \brief Get information about element reorientation
+   * \return 	<code>TRUE</code> means that elements can be reoriented if suspected unhealthy
+   */
+  bool GetReorientElements(void);
   
   /*!
    * \brief Get the Courant Friedrich Levi number for unsteady simulations.

--- a/Common/include/config_structure.inl
+++ b/Common/include/config_structure.inl
@@ -295,6 +295,8 @@ inline long CConfig::GetUnst_RestartIter(void) { return Unst_RestartIter; }
 
 inline long CConfig::GetUnst_AdjointIter(void) { return Unst_AdjointIter; }
 
+inline bool CConfig::GetReorientElements(void) { return ReorientElements; }
+
 inline unsigned long CConfig::GetIter_Avg_Objective(void) { return Iter_Avg_Objective ; }
 
 inline long CConfig::GetDyn_RestartIter(void) { return Dyn_RestartIter; }

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -1283,6 +1283,9 @@ void CConfig::SetConfig_Options(unsigned short val_iZone, unsigned short val_nZo
    * \n DESCRIPTION: Remove sharp edges from the sensitivity evaluation  \n Format: SENS_REMOVE_SHARP = YES \n DEFAULT: NO \ingroup Config*/
   addBoolOption("SENS_REMOVE_SHARP", Sens_Remove_Sharp, false);
 
+  /* DESCRIPTION: Automatically reorient elements that seem flipped */
+  addBoolOption("REORIENT_ELEMENTS",ReorientElements, true);
+
   /*!\par CONFIG_CATEGORY: Input/output files and formats \ingroup Config */
   /*--- Options related to input/output files and formats ---*/
 

--- a/SU2_CFD/src/driver_structure.cpp
+++ b/SU2_CFD/src/driver_structure.cpp
@@ -599,10 +599,12 @@ void CDriver::Geometrical_Preprocessing() {
 
     /*--- Check the orientation before computing geometrical quantities ---*/
 
-    if (rank == MASTER_NODE) cout << "Checking the numerical grid orientation." << endl;
     geometry_container[iZone][MESH_0]->SetBoundVolume();
-    geometry_container[iZone][MESH_0]->Check_IntElem_Orientation(config_container[iZone]);
-    geometry_container[iZone][MESH_0]->Check_BoundElem_Orientation(config_container[iZone]);
+    if (config_container[iZone]->GetReorientElements()) {
+      if (rank == MASTER_NODE) cout << "Checking the numerical grid orientation." << endl;
+      geometry_container[iZone][MESH_0]->Check_IntElem_Orientation(config_container[iZone]);
+      geometry_container[iZone][MESH_0]->Check_BoundElem_Orientation(config_container[iZone]);
+    }
 
     /*--- Create the edge structure ---*/
 

--- a/SU2_DEF/src/SU2_DEF.cpp
+++ b/SU2_DEF/src/SU2_DEF.cpp
@@ -155,10 +155,12 @@ int main(int argc, char *argv[]) {
 
     /*--- Check the orientation before computing geometrical quantities ---*/
 
-    if (rank == MASTER_NODE) cout << "Checking the numerical grid orientation of the interior elements." <<endl;
     geometry_container[iZone]->SetBoundVolume();
-    geometry_container[iZone]->Check_IntElem_Orientation(config_container[iZone]);
-    geometry_container[iZone]->Check_BoundElem_Orientation(config_container[iZone]);
+    if (config_container[iZone]->GetReorientElements()) {
+      if (rank == MASTER_NODE) cout << "Checking the numerical grid orientation of the interior elements." <<endl;
+      geometry_container[iZone]->Check_IntElem_Orientation(config_container[iZone]);
+      geometry_container[iZone]->Check_BoundElem_Orientation(config_container[iZone]);
+    }
 
     /*--- Create the edge structure ---*/
 

--- a/SU2_DOT/src/SU2_DOT.cpp
+++ b/SU2_DOT/src/SU2_DOT.cpp
@@ -159,10 +159,12 @@ int main(int argc, char *argv[]) {
   
   /*--- Check the orientation before computing geometrical quantities ---*/
   
-    if (rank == MASTER_NODE) cout << "Checking the numerical grid orientation of the elements." <<endl;
     geometry_container[iZone]->SetBoundVolume();
-    geometry_container[iZone]->Check_IntElem_Orientation(config_container[iZone]);
-    geometry_container[iZone]->Check_BoundElem_Orientation(config_container[iZone]);
+    if (config_container[iZone]->GetReorientElements()) {
+      if (rank == MASTER_NODE) cout << "Checking the numerical grid orientation of the elements." <<endl;
+      geometry_container[iZone]->Check_IntElem_Orientation(config_container[iZone]);
+      geometry_container[iZone]->Check_BoundElem_Orientation(config_container[iZone]);
+    }
   
   /*--- Create the edge structure ---*/
   

--- a/SU2_GEO/src/SU2_GEO.cpp
+++ b/SU2_GEO/src/SU2_GEO.cpp
@@ -189,8 +189,10 @@ int main(int argc, char *argv[]) {
   
   /*--- Check the orientation before computing geometrical quantities ---*/
   
-  if (rank == MASTER_NODE) cout << "Checking the numerical grid orientation of the interior elements." <<endl;
-  geometry_container[ZONE_0]->Check_IntElem_Orientation(config_container[ZONE_0]);
+  if (config_container[ZONE_0]->GetReorientElements()) {
+    if (rank == MASTER_NODE) cout << "Checking the numerical grid orientation of the interior elements." <<endl;
+    geometry_container[ZONE_0]->Check_IntElem_Orientation(config_container[ZONE_0]);
+  }
   
   /*--- Create the edge structure ---*/
   

--- a/SU2_MSH/src/SU2_MSH.cpp
+++ b/SU2_MSH/src/SU2_MSH.cpp
@@ -138,9 +138,11 @@ int main(int argc, char *argv[]) {
 	geometry_container[ZONE_0]->SetPoint_Connectivity(); geometry_container[ZONE_0]->SetElement_Connectivity();
 	
 	/*--- Check the orientation before computing geometrical quantities ---*/
-  
-	cout << "Check numerical grid orientation." <<endl;
-	geometry_container[ZONE_0]->SetBoundVolume(); geometry_container[ZONE_0]->Check_IntElem_Orientation(config_container[ZONE_0]); geometry_container[ZONE_0]->Check_BoundElem_Orientation(config_container[ZONE_0]);
+  geometry_container[ZONE_0]->SetBoundVolume();
+  if (config_container[ZONE_0]->GetReorientElements()) {
+		cout << "Check numerical grid orientation." <<endl;
+		geometry_container[ZONE_0]->Check_IntElem_Orientation(config_container[ZONE_0]); geometry_container[ZONE_0]->Check_BoundElem_Orientation(config_container[ZONE_0]);
+  }
 	
 	/*--- Create the edge structure ---*/
   
@@ -228,7 +230,10 @@ int main(int argc, char *argv[]) {
 		if (config_container[ZONE_0]->GetSmoothNumGrid()) {
 			cout << "Preprocessing for doing the implicit smoothing." << endl;
 			geo_adapt->SetPoint_Connectivity(); geo_adapt->SetElement_Connectivity();
-			geo_adapt->SetBoundVolume(); geo_adapt->Check_IntElem_Orientation(config_container[ZONE_0]); geo_adapt->Check_BoundElem_Orientation(config_container[ZONE_0]);
+			geo_adapt->SetBoundVolume();
+			if (config_container[ZONE_0]->GetReorientElements()) {
+				geo_adapt->Check_IntElem_Orientation(config_container[ZONE_0]); geo_adapt->Check_BoundElem_Orientation(config_container[ZONE_0]);
+			}
 			geo_adapt->SetEdges(); geo_adapt->SetVertex(config_container[ZONE_0]);
 			cout << "Implicit smoothing of the numerical grid coordinates." << endl;
 			geo_adapt->SetCoord_Smoothing(5, 1.5, config_container[ZONE_0]);

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -46,6 +46,9 @@ DISCARD_INFILES= NO
 %                                       psf = lbf/ft^2, Density = slug/ft^3, 
 %                                       Speed = ft/s, Equiv. Area = ft^2 )
 SYSTEM_MEASUREMENTS= SI
+%
+% Reorient elements based on potential negative volumes (YES/NO)
+REORIENT_ELEMENTS= YES
 
 % -------------------- COMPRESSIBLE FREE-STREAM DEFINITION --------------------%
 %


### PR DESCRIPTION
Added this option to disable automatic element reorientation. It was giving me problems for meshes that had a small number of badly skewed elements. It looks like the check for negative volume elements isn't very elaborate, so its just easier for me to disable the reorientation when I know the elements are oriented in the way that I expect.
