### PR TITLE
Volume based Element Reorientation

### DIFF
--- a/Common/src/dual_grid_structure.cpp
+++ b/Common/src/dual_grid_structure.cpp
@@ -385,7 +385,7 @@ su2double CEdge::GetVolume(su2double *val_coord_Edge_CG, su2double *val_coord_Fa
 	vec_d[1] = -(vec_a[0]*vec_b[2]-vec_a[2]*vec_b[0]);
 	vec_d[2] = vec_a[0]*vec_b[1]-vec_a[1]*vec_b[0];
 
-	Local_Volume = fabs(vec_c[0]*vec_d[0] + vec_c[1]*vec_d[1] + vec_c[2]*vec_d[2])/6.0;
+	Local_Volume = (vec_c[0]*vec_d[0] + vec_c[1]*vec_d[1] + vec_c[2]*vec_d[2])/6.0;
 	
 	return Local_Volume;
 }
@@ -399,7 +399,7 @@ su2double CEdge::GetVolume(su2double *val_coord_Edge_CG, su2double *val_coord_El
 		vec_b[iDim] = val_coord_Edge_CG[iDim]-val_coord_Point[iDim];
 	}
 
-	Local_Volume = 0.5*fabs(vec_a[0]*vec_b[1]-vec_a[1]*vec_b[0]);
+	Local_Volume = 0.5*(vec_a[0]*vec_b[1]-vec_a[1]*vec_b[0]);
 	
 	return Local_Volume;
 }

--- a/Common/src/geometry_structure.cpp
+++ b/Common/src/geometry_structure.cpp
@@ -10313,7 +10313,7 @@ void CPhysicalGeometry::SetControlVolume(CConfig *config, unsigned short action)
             /*--- Two dimensional problem ---*/
             if (change_face_orientation) edge[iEdge]->SetNodes_Coord(Coord_Elem_CG, Coord_Edge_CG);
             else edge[iEdge]->SetNodes_Coord(Coord_Edge_CG, Coord_Elem_CG);
-            Area = edge[iEdge]->GetVolume(Coord_FaceiPoint, Coord_Elem_CG, Coord_Edge_CG);
+            Area = edge[iEdge]->GetVolume(Coord_FaceiPoint, Coord_Edge_CG, Coord_Elem_CG);
             node[face_iPoint]->AddVolume(fabs(Area)); my_DomainVolume +=fabs(Area);
             Area = edge[iEdge]->GetVolume(Coord_FacejPoint, Coord_Edge_CG, Coord_Elem_CG);
             node[face_jPoint]->AddVolume(fabs(Area)); my_DomainVolume +=fabs(Area);

--- a/Common/src/primal_grid_structure.cpp
+++ b/Common/src/primal_grid_structure.cpp
@@ -601,4 +601,11 @@ CPyramid::~CPyramid() {
   
 }
 
-void CPyramid::Change_Orientation(void) { cout << "Not defined orientation change" << endl; }
+void CPyramid::Change_Orientation(void) {
+       unsigned long Point_0, Point_2;
+       Point_0 = Nodes[0];
+       Point_2 = Nodes[2];
+       
+       Nodes[0] = Point_2;
+       Nodes[2] = Point_0;
+}

--- a/SU2_CFD/src/definition_structure.cpp
+++ b/SU2_CFD/src/definition_structure.cpp
@@ -223,7 +223,6 @@ void Geometrical_Preprocessing(CGeometry ***geometry, CConfig **config, unsigned
     
     if (rank == MASTER_NODE) cout << "Checking the numerical grid orientation." << endl;
     geometry[iZone][MESH_0]->SetBoundVolume();
-    geometry[iZone][MESH_0]->Check_IntElem_Orientation(config[iZone]);
     geometry[iZone][MESH_0]->Check_BoundElem_Orientation(config[iZone]);
 
     /*--- Create the edge structure ---*/


### PR DESCRIPTION
This pull request changes the criteria for element reorientation so that an element is reoriented if it has negative volume. This is based on comments made in #162.  It calculates the element volumes by reusing the edge volume calculations, which gives a volume of an element of the component tetrahedra. I did some limited checking on 3D elements, and I believe its calculating the element volumes correctly.  There's still more to be done to complete this, but let me know if this looks useful.

TODO:
- [x] Apply to 2-dimensional elements as well
- [ ] Make sure adjacent functions aren't affected, since this check now occurs at a later point in SU2_CFD
- [ ] Look into other SU2_\* binaries, and see if this is easy to apply
