### PR TITLE
Changed all instances of ADJOINT to CONTINUOUS_ADJOINT.

### DIFF
--- a/Common/include/option_structure.hpp
+++ b/Common/include/option_structure.hpp
@@ -345,14 +345,14 @@ const int VISC_BOUND_TERM = 5;       /*!< \brief Position of the viscous boundar
  * \brief types of mathematical problem to solve
  */
 enum ENUM_MATH_PROBLEM {
-  DIRECT_PROBLEM = 0,		/*!< \brief Direct problem */
-  ADJOINT_PROBLEM = 1,		/*!< \brief Adjoint problem */
-  LINEARIZED_PROBLEM = 2 /*< \brief Linearized numerical method */
+  DIRECT = 0,		/*!< \brief Direct problem */
+  CONTINUOUS_ADJOINT = 1,		/*!< \brief Continuous adjoint problem */
+  LINEARIZED = 2 /*< \brief Linearized numerical method */
 };
 static const map<string, ENUM_MATH_PROBLEM> Math_Problem_Map = CCreateMap<string, ENUM_MATH_PROBLEM>
-("DIRECT", DIRECT_PROBLEM)
-("ADJOINT", ADJOINT_PROBLEM)
-("LINEARIZED", LINEARIZED_PROBLEM);
+("DIRECT", DIRECT)
+("CONTINUOUS_ADJOINT", CONTINUOUS_ADJOINT)
+("LINEARIZED", LINEARIZED);
 
 /*!
  * \brief types of spatial discretizations
@@ -1785,6 +1785,9 @@ public:
     if (out.compare("") != 0) {
       return out;
     }
+    if (option_value[0] == "ADJOINT") {
+      return badValue(option_value, "math problem (try CONTINUOUS_ADJOINT)", this->name);
+    }
     if (Math_Problem_Map.find(option_value[0]) == Math_Problem_Map.end()) {
       return badValue(option_value, "math problem", this->name);
     }
@@ -1794,7 +1797,7 @@ public:
       this->restart = false;
       return "";
     }
-    if (option_value[0] == "ADJOINT") {
+    if (option_value[0] == "CONTINUOUS_ADJOINT") {
       this->adjoint= true;
       this->restart= true;
       this->linearized = false;

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -225,7 +225,7 @@ void CConfig::SetConfig_Options(unsigned short val_iZone, unsigned short val_nZo
   
   /*!\brief PHYSICAL_PROBLEM \n DESCRIPTION: Physical governing equations \n Options: see \link Solver_Map \endlink \n Default: NO_SOLVER \ingroup Config*/
   addEnumOption("PHYSICAL_PROBLEM", Kind_Solver, Solver_Map, NO_SOLVER);
-  /*!\brief MATH_PROBLEM  \n DESCRIPTION: Mathematical problem \n  Options: DIRECT, ADJOINT \ingroup Config*/
+  /*!\brief MATH_PROBLEM  \n DESCRIPTION: Mathematical problem \n  Options: DIRECT, CONTINUOUS_ADJOINT \ingroup Config*/
   addMathProblemOption("MATH_PROBLEM" , Adjoint, false , Linearized, false, Restart_Flow, false);
   /*!\brief KIND_TURB_MODEL \n DESCRIPTION: Specify turbulence model \n Options: see \link Turb_Model_Map \endlink \n Default: NO_TURB_MODEL \ingroup Config*/
   addEnumOption("KIND_TURB_MODEL", Kind_Turb_Model, Turb_Model_Map, NO_TURB_MODEL);

--- a/QuickStart/inv_NACA0012.cfg
+++ b/QuickStart/inv_NACA0012.cfg
@@ -5,7 +5,7 @@
 % Author: Thomas D. Economon                                                   %
 % Institution: Stanford University                                             %
 % Date: 2014.06.11                                                             %
-% File Version 4.0.0 "Cardinal"                                                   %
+% File Version 4.0.0 "Cardinal"                                                %
 %                                                                              %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -17,7 +17,7 @@
 %                               POISSON_EQUATION)
 PHYSICAL_PROBLEM= EULER
 %
-% Mathematical problem (DIRECT, ADJOINT)
+% Mathematical problem (DIRECT, CONTINUOUS_ADJOINT)
 MATH_PROBLEM= DIRECT
 %
 % Restart solution (NO, YES)

--- a/SU2_PY/SU2/eval/design.py
+++ b/SU2_PY/SU2/eval/design.py
@@ -80,7 +80,7 @@ class Design(object):
             Fucntional Interface
             The following methods take an objective function name for input.
             func(func_name)                  - function of specified name
-            grad(func_name,method='ADJOINT') - gradient of specified name
+            grad(func_name,method='CONTINUOUS_ADJOINT') - gradient of specified name
     """
     
     def __init__(self, config, state=None, folder='DESIGNS/DSN_*'):
@@ -180,7 +180,7 @@ class Design(object):
         """ Evaluates SU2 Design Functions by Name """
         return self._eval(su2func,func_name)
     
-    def grad(self,func_name,method='ADJOINT'):
+    def grad(self,func_name,method='CONTINUOUS_ADJOINT'):
         """ Evaluates SU2 Design Gradients by Name """
         return self._eval(su2grad,func_name,method)
     
@@ -267,7 +267,7 @@ def obj_df(dvs,config,state=None):
     # unpack config and state
     config.unpack_dvs(dvs)
     state = su2io.State(state)
-    grad_method = config.get('GRADIENT_METHOD','ADJOINT')
+    grad_method = config.get('GRADIENT_METHOD','CONTINUOUS_ADJOINT')
     
     def_objs = config['OPT_OBJECTIVE']
     objectives = def_objs.keys()
@@ -363,7 +363,7 @@ def con_dceq(dvs,config,state=None):
     # unpack state and config
     config.unpack_dvs(dvs)
     state = su2io.State(state)
-    grad_method = config.get('GRADIENT_METHOD','ADJOINT')
+    grad_method = config.get('GRADIENT_METHOD','CONTINUOUS_ADJOINT')
     
     def_cons = config['OPT_CONSTRAINT']['EQUALITY']
     constraints = def_cons.keys()
@@ -461,7 +461,7 @@ def con_dcieq(dvs,config,state=None):
     # unpack state and config
     config.unpack_dvs(dvs)
     state = su2io.State(state)
-    grad_method = config.get('GRADIENT_METHOD','ADJOINT')
+    grad_method = config.get('GRADIENT_METHOD','CONTINUOUS_ADJOINT')
     
     def_cons = config['OPT_CONSTRAINT']['INEQUALITY']
     constraints = def_cons.keys()

--- a/SU2_PY/SU2/eval/gradients.py
+++ b/SU2_PY/SU2/eval/gradients.py
@@ -65,7 +65,7 @@ def gradient( func_name, method, config, state=None ):
 
         Inputs:
             func_name - SU2 objective function name
-            method    - 'ADJOINT' or 'FINDIFF'
+            method    - 'CONTINUOUS_ADJOINT' or 'FINDIFF'
             config    - an SU2 config
             state     - optional, an SU2 state
 
@@ -83,7 +83,7 @@ def gradient( func_name, method, config, state=None ):
     if not state['GRADIENTS'].has_key(func_name):
 
         # Adjoint Gradients
-        if method == 'ADJOINT':
+        if method == 'CONTINUOUS_ADJOINT':
 
             # Aerodynamics
             if func_name in su2io.optnames_aero:
@@ -308,7 +308,7 @@ def stability( func_name, config, state=None, step=1e-2 ):
     # ----------------------------------------------------    
 
     # will run in ADJOINT/
-    grads_0 = gradient(base_name,'ADJOINT',config,state)
+    grads_0 = gradient(base_name,'CONTINUOUS_ADJOINT',config,state)
 
 
     # ----------------------------------------------------    
@@ -354,7 +354,7 @@ def stability( func_name, config, state=None, step=1e-2 ):
             #ztate.find_files(konfig)
 
             # the gradient
-            grads_1 = gradient(base_name,'ADJOINT',konfig,ztate)
+            grads_1 = gradient(base_name,'CONTINUOUS_ADJOINT',konfig,ztate)
 
             ## direct files to store
             #name = ztate.FILES[ADJ_NAME]

--- a/SU2_PY/SU2/io/config.py
+++ b/SU2_PY/SU2/io/config.py
@@ -201,7 +201,7 @@ class Config(ordered_bunch):
                     keys, each with values of a list of the different 
                     config values.
                 for example: 
-                config_diff.MATH_PROBLEM = ['DIRECT','ADJOINT']
+                config_diff.MATH_PROBLEM = ['DIRECT','CONTINUOUS_ADJOINT']
                 
         """
         

--- a/SU2_PY/SU2/io/config_options.py
+++ b/SU2_PY/SU2/io/config_options.py
@@ -53,7 +53,7 @@ class MathProblem(Option):
 
     def __init__(self,*args,**kwarg):
         super(MathProblem,self).__init__(*args,**kwarg)
-        self.validoptions = ['DIRECT','ADJOINT','LINEARIZED']
+        self.validoptions = ['DIRECT','CONTINUOUS_ADJOINT','LINEARIZED']
 
     def __set__(self,newval):
         if not self.newval in self.validoptions:

--- a/SU2_PY/SU2/io/tools.py
+++ b/SU2_PY/SU2/io/tools.py
@@ -885,7 +885,7 @@ def restart2solution(config,state={}):
         if state: state.FILES.DIRECT = solution
         
     # adjoint solution
-    elif config.MATH_PROBLEM == 'ADJOINT':
+    elif config.MATH_PROBLEM == 'CONTINUOUS_ADJOINT':
         restart  = config.RESTART_ADJ_FILENAME
         solution = config.SOLUTION_ADJ_FILENAME           
         # add suffix

--- a/SU2_PY/SU2/opt/project.py
+++ b/SU2_PY/SU2/opt/project.py
@@ -87,7 +87,7 @@ class Project(object):
             The following methods take an objective function name for input.
             func(func_name,config)        - function of specified name
             grad(func_name,method,config) - gradient of specified name,
-                                            where method is 'ADJOINT' or 'FINDIFF'
+                                            where method is 'CONTINUOUS_ADJOINT' or 'FINDIFF'
             setup config for given dvs with 
             config = project.unpack_dvs(dvs)
     """  

--- a/SU2_PY/SU2/run/adjoint.py
+++ b/SU2_PY/SU2/run/adjoint.py
@@ -72,7 +72,7 @@ def adjoint( config ):
     konfig = copy.deepcopy(config)
     
     # setup problem    
-    konfig['MATH_PROBLEM']  = 'ADJOINT'
+    konfig['MATH_PROBLEM']  = 'CONTINUOUS_ADJOINT'
     konfig['CONV_FILENAME'] = konfig['CONV_FILENAME'] + '_adjoint'
     
     # Run Solution

--- a/SU2_PY/compute_stability.py
+++ b/SU2_PY/compute_stability.py
@@ -63,7 +63,7 @@ state.find_files(config)
 drag_alpha = SU2.eval.func('D_DRAG_D_ALPHA',config,state)
 moment_y_alpha= SU2.eval.func('D_MOMENT_Z_D_ALPHA',config,state)
 
-grad_moment_y_alpha= SU2.eval.grad('D_MOMENT_Z_D_ALPHA','ADJOINT',config,state)
+grad_moment_y_alpha= SU2.eval.grad('D_MOMENT_Z_D_ALPHA','CONTINUOUS_ADJOINT',config,state)
 
 print 'D_DRAG_D_ALPHA     =' , drag_alpha
 print 'D_MOMENT_Y_D_ALPHA =' , moment_y_alpha

--- a/SU2_PY/continuous_adjoint.py
+++ b/SU2_PY/continuous_adjoint.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python 
 
 ## \file continuous_adjoint.py
-#  \brief Python script for doing the continuous adjoint computation using the SU2 suite.
+#  \brief Python script for continuous adjoint computation using the SU2 suite.
 #  \author F. Palacios, T. Economon, T. Lukaczyk
 #  \version 4.0.0 "Cardinal"
 #
@@ -138,7 +138,7 @@ def continuous_design( filename           ,
         state.FILES.MESH = config.MESH_FILENAME    
     
     # Adjoint Gradient
-    grads = SU2.eval.grad( ADJ_NAME, 'ADJOINT', config, state )
+    grads = SU2.eval.grad( ADJ_NAME, 'CONTINUOUS_ADJOINT', config, state )
     
     return state
 

--- a/SU2_PY/documentation.txt
+++ b/SU2_PY/documentation.txt
@@ -61,7 +61,7 @@ SU2.run.direct(config)
 SU2.run.adjoint(config)
 	checks decomp
 	ensures config:
-		'MATH_PROBLEM' = 'ADJOINT'
+		'MATH_PROBLEM' = 'CONTINUOUS_ADJOINT'
 		'CONV_FILENAME' = 'CONFIG_FILENAME' + '_adjoint'	
 	run CFD
 	read history

--- a/SU2_PY/package_tests.py
+++ b/SU2_PY/package_tests.py
@@ -178,12 +178,12 @@ def level2():
         
         with SU2.io.redirect_folder(folder='JOB_001',link='mesh_NACA0012.su2'):
             func  = SU2.eval.func( 'LIFT', config, state )
-            grads = SU2.eval.grad( 'LIFT', 'ADJOINT', config, state )
+            grads = SU2.eval.grad( 'LIFT', 'CONTINUOUS_ADJOINT', config, state )
         
         with SU2.io.redirect_folder(folder='JOB_001',link='mesh_NACA0012.su2'):
             func  = SU2.eval.func( 'DRAG', config, state ) # will not run direct
-            grads = SU2.eval.grad( 'LIFT', 'ADJOINT', config, state ) # will not run adjoint
-            grads = SU2.eval.grad( 'DRAG', 'ADJOINT', config, state ) # will run adjoint
+            grads = SU2.eval.grad( 'LIFT', 'CONTINUOUS_ADJOINT', config, state ) # will not run adjoint
+            grads = SU2.eval.grad( 'DRAG', 'CONTINUOUS_ADJOINT', config, state ) # will run adjoint
     
     wait = 0
     
@@ -213,7 +213,7 @@ def level3():
         vals = design.con_cieq(dv_new)
         vals = design.con_dcieq(dv_new)
         vals = design.func('LIFT')
-        vals = design.grad('LIFT','ADJOINT')
+        vals = design.grad('LIFT','CONTINUOUS_ADJOINT')
         
         SU2.io.save_data('design.pkl',design)
         data = SU2.io.load_data('design.pkl')

--- a/SU2_PY/parallel_computation.py
+++ b/SU2_PY/parallel_computation.py
@@ -91,7 +91,7 @@ def parallel_computation( filename           ,
     # Solution merging
     if config.MATH_PROBLEM == 'DIRECT':
         config.SOLUTION_FLOW_FILENAME = config.RESTART_FLOW_FILENAME
-    elif config.MATH_PROBLEM == 'ADJOINT':
+    elif config.MATH_PROBLEM == 'CONTINUOUS_ADJOINT':
         config.SOLUTION_ADJ_FILENAME = config.RESTART_ADJ_FILENAME
     info = SU2.run.merge(config)
     state.update(info)

--- a/SU2_PY/parse_config.py
+++ b/SU2_PY/parse_config.py
@@ -137,7 +137,7 @@ def parse_config(config_cpp, config_hpp):
             print "enum_options: ",enum_options
             sys.exit(1)
         elif option_type=='AddMathProblem':
-          values = ['DIRECT','ADJOINT','LINEARIZED']
+          values = ['DIRECT','CONTINUOUS_ADJOINT','LINEARIZED']
         elif option_type=='AddScalarOption':
           values = ['A scalar constant']
         elif option_type in ('AddMarkerOption', 'AddMarkerPeriodic', 'AddMarkerDirichlet', 'AddMarkerInlet', 'AddMarkerOutlet', 'AddMarkerDisplacement', 'AddMarkerLoad', 'AddMarkerFlowLoad'):

--- a/SU2_PY/shape_optimization.py
+++ b/SU2_PY/shape_optimization.py
@@ -47,8 +47,8 @@ def main():
                       help="try to restart from project file NAME", metavar="NAME")
     parser.add_option("-n", "--partitions", dest="partitions", default=1,
                       help="number of PARTITIONS", metavar="PARTITIONS")
-    parser.add_option("-g", "--gradient", dest="gradient", default="Adjoint",
-                      help="Method for computing the GRADIENT (ADJOINT, FINDIFF, NONE)", metavar="GRADIENT")
+    parser.add_option("-g", "--gradient", dest="gradient", default="CONTINUOUS_ADJOINT",
+                      help="Method for computing the GRADIENT (CONTINUOUS_ADJOINT, FINDIFF, NONE)", metavar="GRADIENT")
     parser.add_option("-q", "--quiet", dest="quiet", default="True",
                       help="True/False Quiet all SU2 output (optimizer output only)", metavar="QUIET")
     
@@ -103,7 +103,7 @@ def main():
 def shape_optimization( filename                , 
                         projectname = ''        ,
                         partitions  = 0         , 
-                        gradient    = 'ADJOINT' ,
+                        gradient    = 'CONTINUOUS_ADJOINT' ,
                         quiet       = False      ):
   
     # Config

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -20,7 +20,7 @@ PHYSICAL_PROBLEM= EULER
 % Specify turbulence model (NONE, SA, SA_NEG, SST)
 KIND_TURB_MODEL= NONE
 %
-% Mathematical problem (DIRECT, ADJOINT)
+% Mathematical problem (DIRECT, CONTINUOUS_ADJOINT)
 MATH_PROBLEM= DIRECT
 %
 % Restart solution (NO, YES)
@@ -710,8 +710,8 @@ GEO_VOLUME_SECTIONS= 101
 
 % ------------------------- GRID ADAPTATION STRATEGY --------------------------%
 %
-% Kind of grid adaptation (NONE, PERIODIC, FULL, FULL_FLOW, GRAD_FLOW, FULL_ADJOINT,
-%                          GRAD_ADJOINT, GRAD_FLOW_ADJ, ROBUST,
+% Kind of grid adaptation (NONE, PERIODIC, FULL, FULL_FLOW, GRAD_FLOW,
+%                          FULL_ADJOINT, GRAD_ADJOINT, GRAD_FLOW_ADJ, ROBUST,
 %                          FULL_LINEAR, COMPUTABLE, COMPUTABLE_ROBUST,
 %                          REMAINING, WAKE, SMOOTHING, SUPERSONIC_SHOCK)
 KIND_ADAPT= FULL_FLOW

--- a/config_template_basic.cfg
+++ b/config_template_basic.cfg
@@ -17,7 +17,7 @@ PHYSICAL_PROBLEM= EULER
 % Specify turbulence model (NONE, SA, SA_NEG, SST)
 KIND_TURB_MODEL= NONE
 %
-% Mathematical problem (DIRECT, ADJOINT)
+% Mathematical problem (DIRECT, CONTINUOUS_ADJOINT)
 MATH_PROBLEM= DIRECT
 %
 % Restart solution (NO, YES)


### PR DESCRIPTION
This is the first of a number of important changes to make way for the discrete adjoint framework. With this change, one must use CONTINUOUS_ADJOINT instead of ADJOINT in config files to run the continuous adjoint problem. Contains all necessary changes to the C++ and Python source.