### PR TITLE
Feature restart multizone

### DIFF
--- a/Common/include/config_structure.hpp
+++ b/Common/include/config_structure.hpp
@@ -3929,6 +3929,12 @@ public:
 	 * \brief Get the name of the restart file for the flow variables.
 	 * \return Name of the restart file for the flow variables.
 	 */
+	string GetRestart_FlowFileName(string val_filename, int val_iZone);
+    
+    /*!
+	 * \brief Get the name of the restart file for the flow variables.
+	 * \return Name of the restart file for the flow variables.
+	 */
 	string GetRestart_FlowFileName(void);
 
 	/*!

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -5680,6 +5680,21 @@ string CConfig::GetUnsteady_FileName(string val_filename, int val_iter) {
   return UnstFilename;
 }
 
+string CConfig::GetRestart_FlowFileName(string val_filename, int val_iZone) {
+
+    string multizone_filename = val_filename;
+    char buffer[50];
+    
+    if (GetnZone() > 1){
+        unsigned short lastindex = multizone_filename.find_last_of(".");
+        multizone_filename = multizone_filename.substr(0, lastindex);
+        SPRINTF (buffer, "_%d.dat", SU2_TYPE::Int(val_iZone));
+        multizone_filename.append(string(buffer));
+    }
+    
+    return multizone_filename;
+}
+
 string CConfig::GetObjFunc_Extension(string val_filename) {
 
   string AdjExt, Filename = val_filename;

--- a/SU2_CFD/src/output_structure.cpp
+++ b/SU2_CFD/src/output_structure.cpp
@@ -3794,6 +3794,7 @@ void COutput::SetRestart(CConfig *config, CGeometry *geometry, CSolver **solver,
     filename = config->GetObjFunc_Extension(filename);
   } else {
     filename = config->GetRestart_FlowFileName();
+    filename = config->GetRestart_FlowFileName(filename, val_iZone);
   }
   
   /*--- Unsteady problems require an iteration number to be appended. ---*/

--- a/SU2_CFD/src/solver_direct_mean.cpp
+++ b/SU2_CFD/src/solver_direct_mean.cpp
@@ -474,8 +474,8 @@ CEulerSolver::CEulerSolver(CGeometry *geometry, CConfig *config, unsigned short 
       
       filename = config->GetUnsteady_FileName(filename, Unst_RestartIter);
     }
-      if (nZone >1)
-          filename= config->GetRestart_FlowFileName(filename, iZone);
+    if (nZone >1)
+      filename= config->GetRestart_FlowFileName(filename, iZone);
 
     /*--- Open the restart file, throw an error if this fails. ---*/
     
@@ -10501,7 +10501,7 @@ CNSSolver::CNSSolver(CGeometry *geometry, CConfig *config, unsigned short iMesh)
   su2double Density, Velocity2, Pressure, Temperature, dull_val, StaticEnergy;
   int Unst_RestartIter;
   ifstream restart_file;
-
+  unsigned short iZone = config->GetiZone();
   unsigned short nZone = geometry->GetnZone();
   bool restart = (config->GetRestart() || config->GetRestart_Flow());
   bool compressible = (config->GetKind_Regime() == COMPRESSIBLE);
@@ -10911,7 +10911,7 @@ CNSSolver::CNSSolver(CGeometry *geometry, CConfig *config, unsigned short iMesh)
    the farfield values bc the solver will immediately interpolate
    the solution from the finest mesh to the coarser levels. ---*/
   
-  if (!restart || (iMesh != MESH_0) || nZone > 1) {
+  if (!restart || (iMesh != MESH_0)) {
     
     /*--- Restart the solution from the free-stream state ---*/
     
@@ -10934,7 +10934,11 @@ CNSSolver::CNSSolver(CGeometry *geometry, CConfig *config, unsigned short iMesh)
         Unst_RestartIter = SU2_TYPE::Int(config->GetUnst_RestartIter())-2;
       
       filename = config->GetUnsteady_FileName(filename, Unst_RestartIter);
+        
     }
+      
+    if (nZone >1)
+      filename= config->GetRestart_FlowFileName(filename, iZone);
     
     /*--- Open the restart file, throw an error if this fails. ---*/
     

--- a/SU2_CFD/src/solver_direct_mean.cpp
+++ b/SU2_CFD/src/solver_direct_mean.cpp
@@ -96,7 +96,7 @@ CEulerSolver::CEulerSolver(CGeometry *geometry, CConfig *config, unsigned short 
   su2double StaticEnergy, Density, Velocity2, Pressure, Temperature, dull_val;
   int Unst_RestartIter;
   ifstream restart_file;
-
+  unsigned short iZone = config->GetiZone();
   unsigned short nZone = geometry->GetnZone();
   bool restart = (config->GetRestart() || config->GetRestart_Flow());
   bool compressible = (config->GetKind_Regime() == COMPRESSIBLE);
@@ -453,16 +453,14 @@ CEulerSolver::CEulerSolver(CGeometry *geometry, CConfig *config, unsigned short 
    the farfield values bc the solver will immediately interpolate
    the solution from the finest mesh to the coarser levels. ---*/
   
-  if (!restart || (iMesh != MESH_0) || nZone > 1) {
+  if (!restart || (iMesh != MESH_0)) {
 
     /*--- Restart the solution from the free-stream state ---*/
     
     for (iPoint = 0; iPoint < nPoint; iPoint++)
       node[iPoint] = new CEulerVariable(Density_Inf, Velocity_Inf, Energy_Inf, nDim, nVar, config);
     
-  }
-
-  else {
+  } else {
 
     /*--- Modify file name for an unsteady restart ---*/
     
@@ -476,6 +474,8 @@ CEulerSolver::CEulerSolver(CGeometry *geometry, CConfig *config, unsigned short 
       
       filename = config->GetUnsteady_FileName(filename, Unst_RestartIter);
     }
+      if (nZone >1)
+          filename= config->GetRestart_FlowFileName(filename, iZone);
 
     /*--- Open the restart file, throw an error if this fails. ---*/
     

--- a/SU2_CFD/src/solver_direct_turbulent.cpp
+++ b/SU2_CFD/src/solver_direct_turbulent.cpp
@@ -984,7 +984,9 @@ CTurbSASolver::CTurbSASolver(CGeometry *geometry, CConfig *config, unsigned shor
   unsigned short iVar, iDim, nLineLets;
   unsigned long iPoint, index;
   su2double Density_Inf, Viscosity_Inf, Factor_nu_Inf, Factor_nu_Engine, dull_val;
-
+  
+  unsigned short iZone = config->GetiZone();
+  unsigned short nZone = geometry->GetnZone();
   bool restart = (config->GetRestart() || config->GetRestart_Flow());
   bool adjoint = config->GetAdjoint();
   bool compressible = (config->GetKind_Regime() == COMPRESSIBLE);
@@ -1148,6 +1150,9 @@ CTurbSASolver::CTurbSASolver(CGeometry *geometry, CConfig *config, unsigned shor
         Unst_RestartIter = SU2_TYPE::Int(config->GetUnst_RestartIter())-2;
       filename = config->GetUnsteady_FileName(filename, Unst_RestartIter);
     }
+    if (nZone >1)
+      filename= config->GetRestart_FlowFileName(filename, iZone);
+  
     
     /*--- Open the restart file, throw an error if this fails. ---*/
     restart_file.open(filename.data(), ios::in);
@@ -2464,6 +2469,8 @@ CTurbSSTSolver::CTurbSSTSolver(CGeometry *geometry, CConfig *config, unsigned sh
   ifstream restart_file;
   string text_line;
   
+  unsigned short iZone = config->GetiZone();
+  unsigned short nZone = geometry->GetnZone();
   bool restart = (config->GetRestart() || config->GetRestart_Flow());
   bool adjoint = config->GetAdjoint();
   bool compressible = (config->GetKind_Regime() == COMPRESSIBLE);
@@ -2632,6 +2639,9 @@ CTurbSSTSolver::CTurbSSTSolver(CGeometry *geometry, CConfig *config, unsigned sh
       Unst_RestartIter = SU2_TYPE::Int(config->GetUnst_RestartIter())-2;
       filename = config->GetUnsteady_FileName(filename, Unst_RestartIter);
     }
+    if (nZone >1)
+      filename= config->GetRestart_FlowFileName(filename, iZone);
+  
     
     /*--- Open the restart file, throw an error if this fails. ---*/
     restart_file.open(filename.data(), ios::in);


### PR DESCRIPTION
Dear all,
SU2 now prints  N restart file for each of the zone, of course if a multizone flow problem is run.

If in the config file we specify something like this

% Output file restart flow
RESTART_FLOW_FILENAME= restart_flow.dat

It will automatically create nZone restart file:
"restart_flow_0.dat "  "restart_flow_1.dat"  .... "restart_flow_N.dat"

Nothing changed also for the input restart file. We can still specify a single solution file 

% Restart flow input file
SOLUTION_FLOW_FILENAME= restart_flow.dat

and it automatically crate the numbered file using the root =  restart_flow


cheers


sv


 
 