### PR TITLE
Allocate linear system for volumetric deformation in class constructor.

### DIFF
--- a/Common/include/grid_movement_structure.hpp
+++ b/Common/include/grid_movement_structure.hpp
@@ -757,7 +757,7 @@ public:
 	/*! 
 	 * \brief Constructor of the class.
 	 */
-	CVolumetricMovement(CGeometry *geometry);
+	CVolumetricMovement(CGeometry *geometry, CConfig *config);
 	
 	/*! 
 	 * \brief Destructor of the class. 

--- a/Common/src/grid_movement_structure.cpp
+++ b/Common/src/grid_movement_structure.cpp
@@ -59,11 +59,7 @@ CVolumetricMovement::CVolumetricMovement(CGeometry *geometry, CConfig *config) :
 
 CVolumetricMovement::~CVolumetricMovement(void) {
 
-	  /*--- Deallocate vectors for the linear system. ---*/
 
-	  LinSysSol.~CSysVector();
-	  LinSysRes.~CSysVector();
-	  StiffMatrix.~CSysMatrix();
 }
 
 

--- a/SU2_CFD/src/SU2_CFD.cpp
+++ b/SU2_CFD/src/SU2_CFD.cpp
@@ -210,7 +210,7 @@ int main(int argc, char *argv[]) {
         (config_container[iZone]->GetDirectDiff() == D_DESIGN)) {
       if (rank == MASTER_NODE)
         cout << "Setting dynamic mesh structure." << endl;
-      grid_movement[iZone] = new CVolumetricMovement(geometry_container[iZone][MESH_0]);
+      grid_movement[iZone] = new CVolumetricMovement(geometry_container[iZone][MESH_0], config_container[iZone]);
       FFDBox[iZone] = new CFreeFormDefBox*[MAX_NUMBER_FFD];
       surface_movement[iZone] = new CSurfaceMovement();
       surface_movement[iZone]->CopyBoundary(geometry_container[iZone][MESH_0], config_container[iZone]);

--- a/SU2_DEF/src/SU2_DEF.cpp
+++ b/SU2_DEF/src/SU2_DEF.cpp
@@ -190,7 +190,7 @@ int main(int argc, char *argv[]) {
       cout << endl << "----------------------- Volumetric grid deformation ---------------------" << endl;
     
     /*--- Definition of the Class for grid movement ---*/
-    grid_movement = new CVolumetricMovement(geometry_container[ZONE_0]);
+    grid_movement = new CVolumetricMovement(geometry_container[ZONE_0], config_container[ZONE_0]);
     
   }
 

--- a/SU2_DOT/src/SU2_DOT.cpp
+++ b/SU2_DOT/src/SU2_DOT.cpp
@@ -162,7 +162,7 @@ int main(int argc, char *argv[]) {
     if (rank == MASTER_NODE) cout << "Reading surface sensitivities at each node from file." << endl;
     geometry_container[ZONE_0]->SetBoundSensitivity(config_container[ZONE_0]);
   } else {
-    mesh_movement = new CVolumetricMovement(geometry_container[ZONE_0]);
+    mesh_movement = new CVolumetricMovement(geometry_container[ZONE_0], config_container[ZONE_0]);
     geometry_container[ZONE_0]->SetSensitivity(config_container[ZONE_0]);
 
     if (rank == MASTER_NODE) cout << "Setting mesh sensitivity." << endl;


### PR DESCRIPTION
Dear all,

I was having some memory issues when running FSI problems using the code in my branch. In particular, when running unsteady F-S simulations (which also subiterate internally on each time step) a big amount of memory was being used, and kept increasing as the simulation moved on. I found out that new spaces in memory were being allocated every time I was updating the mesh using the volumetric movement structure, this is, every subiteration. This lead to a very big amount of memory being used. In my particular case, this problem may be solved by initializing the LinSysSol, LinSysRes and StiffMatrix in the constructor of the CVolumetricMovement class, as opposed to doing so in the function SetVolume_Deformation(). 

I changed this into the branch feature_FSI_FEA, and then committed and pushed the changes. Nevertheless, I considered that these changes may affect some of your work, so instead of carrying the modification along with all the other changes in my branch, I think it is better to create a pull request now and make sure it doesn't affect negatively anybody else's work.

Cheers,

Ruben