### PR TITLE
Feature general hllc

### DIFF
--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -1654,7 +1654,19 @@ void CConfig::SetPostprocessing(unsigned short val_software, unsigned short val_
   }
 
   
-  
+  /*--- Check for Fluid model consistency ---*/
+
+  if (standard_air){
+	if (Gamma != 1.4 || Gas_Constant != 287.058){
+		//cout << "Warning! Trying to specify non-coherent ratio of specific heats or specific gas constant!" << endl;
+		//cout << "Re-setting to default values!";
+		//cout << "Specific heats ratio: 1.4" << endl;
+		//cout << "Specific gas constant: 287.058" << endl;
+
+		Gamma = 1.4;
+		Gas_Constant = 287.058;
+        }
+  }
   /*--- Check for Measurement System ---*/
   
   if (SystemMeasurements == US && !standard_air) {
@@ -1666,12 +1678,12 @@ void CConfig::SetPostprocessing(unsigned short val_software, unsigned short val_
   
   if (!ideal_gas) {
     if (Kind_ConvNumScheme_Flow != SPACE_UPWIND) {
-      cout << "Only ROE Upwind scheme can be used for Not Ideal Compressible Fluids" << endl;
+      cout << "Only ROE Upwind and HLLC Upwind scheme can be used for Non-Ideal Compressible Fluids" << endl;
       exit(EXIT_FAILURE);
     }
     else {
-      if (Kind_Upwind_Flow != ROE) {
-        cout << "Only ROE Upwind scheme can be used for Not Ideal Compressible Fluids" << endl;
+      if (Kind_Upwind_Flow != ROE && Kind_Upwind_Flow != HLLC) {
+        cout << "Only ROE Upwind and HLLC Upwind scheme can be used for Non-Ideal Compressible Fluids" << endl;
         exit(EXIT_FAILURE);
       }
     }
@@ -1681,11 +1693,11 @@ void CConfig::SetPostprocessing(unsigned short val_software, unsigned short val_
   
   if (!ideal_gas) {
     if (nMarker_Inlet != 0) {
-      cout << "Riemann Boundary conditions must be used for inlet and outlet with Not Ideal Compressible Fluids " << endl;
+      cout << "Riemann Boundary conditions must be used for inlet and outlet with Non-ideal Compressible Fluids " << endl;
       exit(EXIT_FAILURE);
     }
     if (nMarker_Outlet != 0) {
-      cout << "Riemann Boundary conditions must be used outlet with Not Ideal Compressible Fluids " << endl;
+      cout << "Riemann Boundary conditions must be used outlet with Non-Ideal Compressible Fluids " << endl;
       exit(EXIT_FAILURE);
     }
     

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -125,7 +125,7 @@ void CConfig::SetPointersNull(void) {
   Marker_FlowLoad=NULL;       Marker_Neumann=NULL;          Marker_Neumann_Elec=NULL;
   Marker_All_TagBound=NULL;        Marker_CfgFile_TagBound=NULL;       Marker_All_KindBC=NULL;
   Marker_CfgFile_KindBC=NULL;    Marker_All_SendRecv=NULL; Marker_All_PerBound=NULL;
-  Marker_FSIinterface=NULL;
+  Marker_FSIinterface=NULL;	Marker_Riemann=NULL;
 
   /*--- Boundary Condition settings ---*/
 
@@ -1662,7 +1662,7 @@ void CConfig::SetPostprocessing(unsigned short val_software, unsigned short val_
     exit(EXIT_FAILURE);
   }
   
-  /*--- Check for Convective scheme available for NICF ---*/
+  /*--- Check for Convective scheme available for NICFD ---*/
   
   if (!ideal_gas) {
     if (Kind_ConvNumScheme_Flow != SPACE_UPWIND) {
@@ -1677,7 +1677,7 @@ void CConfig::SetPostprocessing(unsigned short val_software, unsigned short val_
     }
   }
   
-  /*--- Check for Boundary condition available for NICF ---*/
+  /*--- Check for Boundary condition available for NICFD ---*/
   
   if (!ideal_gas) {
     if (nMarker_Inlet != 0) {

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -1658,11 +1658,6 @@ void CConfig::SetPostprocessing(unsigned short val_software, unsigned short val_
 
   if (standard_air){
 	if (Gamma != 1.4 || Gas_Constant != 287.058){
-		//cout << "Warning! Trying to specify non-coherent ratio of specific heats or specific gas constant!" << endl;
-		//cout << "Re-setting to default values!";
-		//cout << "Specific heats ratio: 1.4" << endl;
-		//cout << "Specific gas constant: 287.058" << endl;
-
 		Gamma = 1.4;
 		Gas_Constant = 287.058;
         }

--- a/SU2_CFD/include/numerics_structure.hpp
+++ b/SU2_CFD/include/numerics_structure.hpp
@@ -2158,22 +2158,23 @@ public:
 class CUpwGeneralHLLC_Flow : public CNumerics {
 private:
   bool implicit;
+  unsigned short iDim, iVar, jVar, kVar;
+  
   su2double *Diff_U;
   su2double *Velocity_i, *Velocity_j, *RoeVelocity;
   su2double *ProjFlux_i, *ProjFlux_j;
   su2double *delta_wave, *delta_vel;
   su2double *Lambda, *Epsilon;
   su2double **P_Tensor, **invP_Tensor;
-  su2double sq_vel, sq_vel_i, sq_vel_j, Proj_ModJac_Tensor_ij, Density_i, Energy_i, SoundSpeed_i, Pressure_i, Enthalpy_i,
-  Density_j, Energy_j, SoundSpeed_j, Pressure_j, Enthalpy_j, R, RoeDensity, RoeEnthalpy, RoeSoundSpeed, RoeSoundSpeed2,
-  ProjVelocity, ProjVelocity_i, ProjVelocity_j;
-  unsigned short iDim, iVar, jVar, kVar;
-  su2double tmp, velRoe[3], uRoe, gamPdivRho, sq_velRoe, cRoe, sL, sR, sM, pStar, invSLmSs, sLmuL, rhoSL, rhouSL[3],
-  eSL, invSRmSs, sRmuR, rhoSR, rhouSR[3], eSR, kappa;
-su2double Rrho, sq_velRoe_2;
+  
+  su2double sq_vel_i, Density_i, Energy_i, SoundSpeed_i, Pressure_i, Enthalpy_i, ProjVelocity_i, StaticEnthalpy_i, StaticEnergy_i;
+  su2double sq_vel_j, Density_j, Energy_j, SoundSpeed_j, Pressure_j, Enthalpy_j, ProjVelocity_j, StaticEnthalpy_j, StaticEnergy_j;
+  
+  su2double sq_velRoe, Proj_ModJac_Tensor_ij, RoeDensity, RoeEnthalpy, RoeSoundSpeed, RoeSoundSpeed2, RoeProjVelocity;
+  su2double Kappa_i, Kappa_j, Chi_i, Chi_j, RoeKappa, RoeChi, RoeKappaStaticEnthalpy;
 
-  su2double StaticEnthalpy_i, StaticEnergy_i, StaticEnthalpy_j, StaticEnergy_j, Kappa_i, Kappa_j, Chi_i, Chi_j, Velocity2_i, Velocity2_j;
-  su2double RoeKappa, RoeChi, RoeKappaStaticEnthalpy;
+  su2double sL, sR, sM, pStar, invSLmSs, sLmuL, rhoSL, rhouSL[3], Rrho, eSL, invSRmSs, sRmuR, rhoSR, rhouSR[3], eSR, kappa;
+
   
 public:
   
@@ -2205,13 +2206,13 @@ public:
 
    /*!
 
-   * \brief Compute the Average for a general fluid flux between two nodes i and j.
+   * \brief Compute the Average quantities for a general fluid flux between two nodes i and j.
 
    * Using the approach of Vinokur and Montagne'
 
    */
   
-  void ComputeRoeAverage();
+  void VinokurMontagne();
 
 };
 

--- a/SU2_CFD/include/numerics_structure.hpp
+++ b/SU2_CFD/include/numerics_structure.hpp
@@ -2147,6 +2147,72 @@ public:
 };
 
 /*!
+ * \class CUpwGeneralHLLC_Flow
+ * \brief Class for solving an approximate Riemann AUSM.
+ * \ingroup ConvDiscr
+ * \author F. Palacios, based on the Joe code implementation
+ * \version 4.0.1 "Cardinal"
+ */
+class CUpwGeneralHLLC_Flow : public CNumerics {
+private:
+  bool implicit;
+  su2double *Diff_U;
+  su2double *Velocity_i, *Velocity_j, *RoeVelocity;
+  su2double *ProjFlux_i, *ProjFlux_j;
+  su2double *delta_wave, *delta_vel;
+  su2double *Lambda, *Epsilon;
+  su2double **P_Tensor, **invP_Tensor;
+  su2double sq_vel, sq_vel_i, sq_vel_j, Proj_ModJac_Tensor_ij, Density_i, Energy_i, SoundSpeed_i, Pressure_i, Enthalpy_i,
+  Density_j, Energy_j, SoundSpeed_j, Pressure_j, Enthalpy_j, R, RoeDensity, RoeEnthalpy, RoeSoundSpeed, RoeSoundSpeed2,
+  ProjVelocity, ProjVelocity_i, ProjVelocity_j;
+  unsigned short iDim, iVar, jVar, kVar;
+  su2double tmp, velRoe[3], uRoe, gamPdivRho, sq_velRoe, cRoe, sL, sR, sM, pStar, invSLmSs, sLmuL, rhoSL, rhouSL[3],
+  eSL, invSRmSs, sRmuR, rhoSR, rhouSR[3], eSR, kappa;
+
+  su2double StaticEnthalpy_i, StaticEnergy_i, StaticEnthalpy_j, StaticEnergy_j, Kappa_i, Kappa_j, Chi_i, Chi_j, Velocity2_i, Velocity2_j;
+  su2double RoeKappa, RoeChi, RoeKappaStaticEnthalpy;
+  
+public:
+  
+  /*!
+   * \brief Constructor of the class.
+   * \param[in] val_nDim - Number of dimensions of the problem.
+
+   * \param[in] val_nVar - Number of variables of the problem.
+   * \param[in] config - Definition of the particular problem.
+   */
+  CUpwGeneralHLLC_Flow(unsigned short val_nDim, unsigned short val_nVar, CConfig *config);
+  
+  /*!
+
+   * \brief Destructor of the class.
+   */
+  ~CUpwGeneralHLLC_Flow(void);
+  
+  /*!
+
+   * \brief Compute the Roe's flux between two nodes i and j.
+   * \param[out] val_residual - Pointer to the total residual.
+   * \param[out] val_Jacobian_i - Jacobian of the numerical method at node i (implicit computation).
+   * \param[out] val_Jacobian_j - Jacobian of the numerical method at node j (implicit computation).
+   * \param[in] config - Definition of the particular problem.
+
+   */
+  void ComputeResidual(su2double *val_residual, su2double **val_Jacobian_i, su2double **val_Jacobian_j, CConfig *config);
+
+   /*!
+
+   * \brief Compute the Average for a general fluid flux between two nodes i and j.
+
+   * Using the approach of Vinokur and Montagne'
+
+   */
+  
+  void ComputeRoeAverage();
+
+};
+
+/*!
  * \class CUpwLin_TransLM
  * \brief Class for performing a linear upwind solver for the Spalart-Allmaras turbulence model equations with transition
  * \ingroup ConvDiscr

--- a/SU2_CFD/include/numerics_structure.hpp
+++ b/SU2_CFD/include/numerics_structure.hpp
@@ -2116,11 +2116,11 @@ private:
   su2double *delta_wave, *delta_vel;
   su2double *Lambda, *Epsilon;
   su2double **P_Tensor, **invP_Tensor;
-  su2double sq_vel, sq_vel_i, sq_vel_j, Proj_ModJac_Tensor_ij, Density_i, Energy_i, SoundSpeed_i, Pressure_i, Enthalpy_i,
-  Density_j, Energy_j, SoundSpeed_j, Pressure_j, Enthalpy_j, R, RoeDensity, RoeEnthalpy, RoeSoundSpeed,
-  ProjVelocity, ProjVelocity_i, ProjVelocity_j;
+  su2double sq_vel_i, sq_vel_j, Proj_ModJac_Tensor_ij, Density_i, Energy_i, SoundSpeed_i, Pressure_i, Enthalpy_i,
+  Density_j, Energy_j, SoundSpeed_j, Pressure_j, Enthalpy_j, RoeDensity, RoeEnthalpy, RoeSoundSpeed,
+  RoeProjVelocity, ProjVelocity_i, ProjVelocity_j;
   unsigned short iDim, iVar, jVar, kVar;
-  su2double Rrho, tmp, velRoe[3], uRoe, gamPdivRho, sq_velRoe, cRoe, sL, sR, sM, pStar, invSLmSs, sLmuL, rhoSL, rhouSL[3],
+  su2double Rrho, tmp, velRoe[3], sq_velRoe, sL, sR, sM, pStar, invSLmSs, sLmuL, rhoSL, rhouSL[3],
   eSL, invSRmSs, sRmuR, rhoSR, rhouSR[3], eSR;
   
 public:

--- a/SU2_CFD/include/numerics_structure.hpp
+++ b/SU2_CFD/include/numerics_structure.hpp
@@ -2168,6 +2168,7 @@ private:
   unsigned short iDim, iVar, jVar, kVar;
   su2double tmp, velRoe[3], uRoe, gamPdivRho, sq_velRoe, cRoe, sL, sR, sM, pStar, invSLmSs, sLmuL, rhoSL, rhouSL[3],
   eSL, invSRmSs, sRmuR, rhoSR, rhouSR[3], eSR, kappa;
+su2double Rrho, sq_velRoe_2;
 
   su2double StaticEnthalpy_i, StaticEnergy_i, StaticEnthalpy_j, StaticEnergy_j, Kappa_i, Kappa_j, Chi_i, Chi_j, Velocity2_i, Velocity2_j;
   su2double RoeKappa, RoeChi, RoeKappaStaticEnthalpy;

--- a/SU2_CFD/src/driver_structure.cpp
+++ b/SU2_CFD/src/driver_structure.cpp
@@ -606,11 +606,19 @@ void CDriver::Numerics_Preprocessing(CNumerics ****numerics_container,
               break;
               
             case HLLC:
-              for (iMGlevel = 0; iMGlevel <= config->GetnMGLevels(); iMGlevel++) {
-                numerics_container[iMGlevel][FLOW_SOL][CONV_TERM] = new CUpwHLLC_Flow(nDim, nVar_Flow, config);
-                numerics_container[iMGlevel][FLOW_SOL][CONV_BOUND_TERM] = new CUpwHLLC_Flow(nDim, nVar_Flow, config);
-              }
-              break;
+		if (!ideal_gas) {
+		      for (iMGlevel = 0; iMGlevel <= config->GetnMGLevels(); iMGlevel++) {
+		        numerics_container[iMGlevel][FLOW_SOL][CONV_TERM] = new CUpwHLLC_Flow(nDim, nVar_Flow, config);
+		        numerics_container[iMGlevel][FLOW_SOL][CONV_BOUND_TERM] = new CUpwHLLC_Flow(nDim, nVar_Flow, config);
+		      }
+		}
+		else {cout << "!!!!!!!!!!!!!!!!! GENERAL HLLC" << endl;
+		      for (iMGlevel = 0; iMGlevel <= config->GetnMGLevels(); iMGlevel++) {
+		        numerics_container[iMGlevel][FLOW_SOL][CONV_TERM] = new CUpwGeneralHLLC_Flow(nDim, nVar_Flow, config);
+		        numerics_container[iMGlevel][FLOW_SOL][CONV_BOUND_TERM] = new CUpwGeneralHLLC_Flow(nDim, nVar_Flow, config);
+		      }
+		}
+             	break;
               
             case MSW:
               for (iMGlevel = 0; iMGlevel <= config->GetnMGLevels(); iMGlevel++) {

--- a/SU2_CFD/src/driver_structure.cpp
+++ b/SU2_CFD/src/driver_structure.cpp
@@ -606,13 +606,13 @@ void CDriver::Numerics_Preprocessing(CNumerics ****numerics_container,
               break;
               
             case HLLC:
-		if (!ideal_gas) {
+		if (ideal_gas) {
 		      for (iMGlevel = 0; iMGlevel <= config->GetnMGLevels(); iMGlevel++) {
 		        numerics_container[iMGlevel][FLOW_SOL][CONV_TERM] = new CUpwHLLC_Flow(nDim, nVar_Flow, config);
 		        numerics_container[iMGlevel][FLOW_SOL][CONV_BOUND_TERM] = new CUpwHLLC_Flow(nDim, nVar_Flow, config);
 		      }
 		}
-		else {cout << "!!!!!!!!!!!!!!!!! GENERAL HLLC" << endl;
+		else {
 		      for (iMGlevel = 0; iMGlevel <= config->GetnMGLevels(); iMGlevel++) {
 		        numerics_container[iMGlevel][FLOW_SOL][CONV_TERM] = new CUpwGeneralHLLC_Flow(nDim, nVar_Flow, config);
 		        numerics_container[iMGlevel][FLOW_SOL][CONV_BOUND_TERM] = new CUpwGeneralHLLC_Flow(nDim, nVar_Flow, config);

--- a/SU2_CFD/src/numerics_direct_mean.cpp
+++ b/SU2_CFD/src/numerics_direct_mean.cpp
@@ -1233,8 +1233,8 @@ void CUpwGeneralHLLC_Flow::ComputeResidual(su2double *val_residual, su2double **
   StaticEnergy_i   = Energy_i - 0.5*sq_vel_i;
   StaticEnthalpy_i = Enthalpy_i - 0.5*sq_vel_i;
   
-  Kappa_i = Gamma-1;//S_i[1]/Density_i;
-  Chi_i = 0;//S_i[0] - Kappa_i*StaticEnergy_i;
+  Kappa_i = S_i[1]/Density_i;
+  Chi_i = S_i[0] - Kappa_i*StaticEnergy_i;
   SoundSpeed_i = sqrt(Chi_i + StaticEnthalpy_i*Kappa_i);
     
   /*--- Primitive variables at point j ---*/
@@ -1253,8 +1253,8 @@ void CUpwGeneralHLLC_Flow::ComputeResidual(su2double *val_residual, su2double **
   StaticEnergy_j   = Energy_j - 0.5*sq_vel_j;
   StaticEnthalpy_j = Enthalpy_j - 0.5*sq_vel_j;
 
-  Kappa_j = Gamma-1;//S_j[1]/Density_j;
-  Chi_j = 0;//S_j[0] - Kappa_j*StaticEnergy_j;
+  Kappa_j = S_j[1]/Density_j;
+  Chi_j = S_j[0] - Kappa_j*StaticEnergy_j;
   SoundSpeed_j = sqrt(Chi_j + StaticEnthalpy_j*Kappa_j);
    
   /*--- Projected velocities ---*/


### PR DESCRIPTION
In this branch the HLLC algorithm has been generalized to Non-Ideal flows so that now it can be used with more complex equations of state. Computation on nicfd LS89 test case with Van der Waals eos show quite similar Cd/Cl predicted values.

Furthermore I cleaned up a little bit the original CUpwHLLC_Flow::ComputeResidual: there were some redundancies (some variables were computed twice). I also made changes that in my opinion improve code readability. Regression tests (for the original HLLC) passed on my PC with a difference of 1E-6 on RhoE residual (slight differences were anyway expected).

A couple of bugs fixed.

Cheers 
Giulio