### PR TITLE
Deprecating OPT_OBJECTIVE

### DIFF
--- a/Common/include/config_structure.hpp
+++ b/Common/include/config_structure.hpp
@@ -124,6 +124,7 @@ private:
   unsigned short SystemMeasurements; /*!< \brief System of measurements. */
   unsigned short Kind_Regime;  /*!< \brief Kind of adjoint function. */
   unsigned short Kind_ObjFunc;  /*!< \brief Kind of objective function. */
+  su2double Weight_ObjFunc;    /*!< \brief Weight applied to objective function. */
   unsigned short Kind_SensSmooth; /*!< \brief Kind of sensitivity smoothing technique. */
   unsigned short Continuous_Eqns; /*!< \brief Which equations to treat continuously (Hybrid adjoint)*/
   unsigned short Discrete_Eqns; /*!< \brief Which equations to treat discretely (Hybrid adjoint). */

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -750,6 +750,8 @@ void CConfig::SetConfig_Options(unsigned short val_iZone, unsigned short val_nZo
   /*!\brief OBJECTIVE_FUNCTION
    *  \n DESCRIPTION: Adjoint problem boundary condition \n OPTIONS: see \link Objective_Map \endlink \n DEFAULT: DRAG_COEFFICIENT \ingroup Config*/
   addEnumOption("OBJECTIVE_FUNCTION", Kind_ObjFunc, Objective_Map, DRAG_COEFFICIENT);
+  /*!\brief OBJECTIVE_WEIGHT  \n DESCRIPTION: Adjoint problem boundary condition weights. Applies scaling factor to objective(s) \ingroup Config*/
+  addDoubleOption("OBJECTIVE_WEIGHT", Weight_ObjFunc, 1.0);
 
   default_vec_5d[0]=0.0; default_vec_5d[1]=0.0; default_vec_5d[2]=0.0;
   default_vec_5d[3]=0.0;  default_vec_5d[4]=0.0;
@@ -1321,9 +1323,6 @@ void CConfig::SetConfig_Options(unsigned short val_iZone, unsigned short val_nZo
 
   /* DESCRIPTION: Number of partitions of the mesh */
   addPythonOption("NUMBER_PART");
-
-  /* DESCRIPTION: Optimization objective function with optional scaling factor*/
-  addPythonOption("OPT_OBJECTIVE");
 
   /* DESCRIPTION: Optimization constraint functions with optional scaling factor */
   addPythonOption("OPT_CONSTRAINT");

--- a/SU2_PY/SU2/eval/design.py
+++ b/SU2_PY/SU2/eval/design.py
@@ -233,15 +233,12 @@ def obj_f(dvs,config,state=None):
     vals_out = []
     for i_obj,this_obj in enumerate(objectives):
         scale = def_objs[this_obj]['SCALE']
-        sign  = su2io.get_objectiveSign(this_obj)
         
         # Evaluate Objective Function
-#        sys.stdout.write('  %s... ' % this_obj.title())
         func = su2func(this_obj,config,state)
-#        sys.stdout.write('done: %.6f\n' % func)
         
         # scaling and sign
-        func = func * sign * scale
+        func = func * scale
         
         vals_out.append(func)
     
@@ -282,16 +279,13 @@ def obj_df(dvs,config,state=None):
     vals_out = []
     for i_obj,this_obj in enumerate(objectives):
         scale = def_objs[this_obj]['SCALE']
-        sign  = su2io.get_objectiveSign(this_obj)
         
         # Evaluate Objective Gradient
-#        sys.stdout.write('  %s... ' % this_obj.title())
         grad = su2grad(this_obj,grad_method,config,state)
-#        sys.stdout.write('done\n')
         
         # scaling and sign
         for i_grd,dv_scl in enumerate(dv_scales):
-            grad[i_grd] = grad[i_grd] * sign * scale / dv_scl
+            grad[i_grd] = grad[i_grd] * scale / dv_scl
         
         vals_out.append(grad)
     

--- a/SU2_PY/SU2/eval/design.py
+++ b/SU2_PY/SU2/eval/design.py
@@ -222,7 +222,7 @@ def obj_f(dvs,config,state=None):
     config.unpack_dvs(dvs)
     state = su2io.State(state)
     
-    def_objs = config['OPT_OBJECTIVE']
+    def_objs = config['OBJECTIVE_FUNCTION']
     objectives = def_objs.keys()
     n_obj = len( objectives )
     assert n_obj == 1 , 'SU2 currently only supports one objective'
@@ -269,7 +269,7 @@ def obj_df(dvs,config,state=None):
     state = su2io.State(state)
     grad_method = config.get('GRADIENT_METHOD','CONTINUOUS_ADJOINT')
     
-    def_objs = config['OPT_OBJECTIVE']
+    def_objs = config['OBJECTIVE_FUNCTION']
     objectives = def_objs.keys()
     n_obj = len( objectives )
     assert n_obj == 1 , 'SU2 currently only supports one objective'

--- a/SU2_PY/SU2/eval/functions.py
+++ b/SU2_PY/SU2/eval/functions.py
@@ -249,7 +249,7 @@ def aerodynamics( config, state=None ):
         if state['FUNCTIONS'].has_key(key):
             funcs[key] = state['FUNCTIONS'][key]
             
-    if config.OBJECTIVE_FUNCTION == 'OUTFLOW_GENERALIZED':    
+    if 'OUTFLOW_GENERALIZED' in config.OBJECTIVE_FUNCTION.keys():    
         import downstream_function
         state['FUNCTIONS']['OUTFLOW_GENERALIZED']=downstream_function.downstream_function(config,state)
 

--- a/SU2_PY/SU2/eval/gradients.py
+++ b/SU2_PY/SU2/eval/gradients.py
@@ -86,7 +86,7 @@ def gradient( func_name, method, config, state=None ):
         if any([method == 'CONTINUOUS_ADJOINT', method == 'DISCRETE_ADJOINT']):
 
             # If using chain rule
-            if config.OBJECTIVE_FUNCTION == 'OUTFLOW_GENERALIZED':
+            if 'OUTFLOW_GENERALIZED' in config.OBJECTIVE_FUNCTION.keys():
                 import downstream_function
                 chaingrad = downstream_function.downstream_gradient(config,state)
                 # Set coefficients for gradients
@@ -256,7 +256,7 @@ def adjoint( func_name, config, state=None ):
         with redirect_output(log_adjoint):        
 
             # setup config
-            config['OBJECTIVE_FUNCTION'] = func_name
+            config['OBJECTIVE_FUNCTION'] = {func_name : {'SCALE': 1.0 }}
 
             # # RUN ADJOINT SOLUTION # #
             info = su2run.adjoint(config)

--- a/SU2_PY/SU2/io/config.py
+++ b/SU2_PY/SU2/io/config.py
@@ -445,19 +445,51 @@ def read_config(filename):
             
             # unitary objective definition
             if case('OPT_OBJECTIVE'):
+                print "OPT_OBJECTIVE is being deprecated - please replace with:"
+                print "OBJECTIVE_FUNCTION = DRAG"
+                print "OBJECTIVE_WEIGHT = 1.0"
+                print "Note that you may need to either move or delete these options if they already exist in your config file."
+                print "For objectives such as lift which are traditionally maximized, use a negative sign on the weight."
                 # remove white space
-                this_value = ''.join(this_value.split())                
+                #this_value = ''.join(this_value.split())                
                 # split by scale
-                this_value = this_value.split("*")
-                this_name  = this_value[0]
-                this_scale = 1.0
-                if len(this_value) > 1:
-                    this_scale = float( this_value[1] )
-                this_def = { this_name : {'SCALE':this_scale} }
+                #this_value = this_value.split("*")
+                #this_name  = this_value[0]
+                #this_scale = 1.0
+                #if len(this_value) > 1:
+                #    this_scale = float( this_value[1] )
+                #this_def = { this_name : {'SCALE':this_scale} }
+                # save to output dictionary
+                #data_dict[this_param] = this_def
+                break
+            
+            if case('OBJECTIVE_FUNCTION'):
+                this_value = this_value.split(',')
+                #split by ,
+                this_def={}
+                for  this_obj in this_value:       
+                    # split by scale
+                    this_name  = this_obj
+                    this_scale = 1.0
+                    this_def.update({ this_name : {'SCALE':this_scale} })
+
                 # save to output dictionary
                 data_dict[this_param] = this_def
                 break
-            
+                
+            if case('OBJECTIVE_WEIGHT'):
+                this_value = this_value.split(',')
+                if (not data_dict.has_key('OBJECTIVE_FUNCTION')):
+                    print "OBJECTIVE_FUNCTION must be defined prior to OBJECTIVE_WEIGHT."
+                    break
+                this_def = data_dict['OBJECTIVE_FUNCTION']
+                for this, this_name in enumerate(this_def):
+                    this_scale = this_value[this].strip('()')
+                    this_def[this_name] = {'SCALE':float(this_scale)} 
+                data_dict['OBJECTIVE_FUNCTION'] = this_def
+                data_dict[this_param] = (',').join(this_value)
+                break
+                
             # unitary constraint definition
             if case('OPT_CONSTRAINT'):
                 # remove white space
@@ -702,12 +734,11 @@ def write_config(filename,param_dict):
                 #: for each dv
                 break
             
-            if case("OPT_OBJECTIVE"):
-                assert len(new_value.keys())==1 , 'only one OPT_OBJECTIVE is currently supported'
+            if case('OBJECTIVE_FUNCTION'):
                 i_name = 0
                 for name,value in new_value.iteritems():
-                    if i_name>0: output_file.write("; ")
-                    output_file.write( "%s * %s" % (name,value['SCALE']) )
+                    if i_name>0: output_file.write(", ")
+                    output_file.write( "%s" % (name) )
                     i_name += 1
                 break
             

--- a/SU2_PY/SU2/io/config.py
+++ b/SU2_PY/SU2/io/config.py
@@ -445,11 +445,12 @@ def read_config(filename):
             
             # unitary objective definition
             if case('OPT_OBJECTIVE'):
-                print "OPT_OBJECTIVE is being deprecated - please replace with:"
+                print "OPT_OBJECTIVE is being deprecated, and replaced with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT:"
+                print "ex: "
                 print "OBJECTIVE_FUNCTION = DRAG"
                 print "OBJECTIVE_WEIGHT = 1.0"
                 print "Note that you may need to either move or delete these options if they already exist in your config file."
-                print "For objectives such as lift which are traditionally maximized, use a negative sign on the weight."
+                print "In order to maximize a function (ex: LIFT), use a negative sign on the weight."
                 # remove white space
                 #this_value = ''.join(this_value.split())                
                 # split by scale

--- a/SU2_PY/SU2/io/tools.py
+++ b/SU2_PY/SU2/io/tools.py
@@ -394,38 +394,6 @@ def read_aerodynamics( History_filename , special_cases=[], final_avg=0 ):
 #: def read_aerodynamics()
 
 
-
-# -------------------------------------------------------------------
-#  Get Objective Function Sign
-# -------------------------------------------------------------------
-
-def get_objectiveSign( ObjFun_name ):
-    """ returns -1 for maximization problems:
-            LIFT
-            EFFICIENCY
-            THRUST
-            FIGURE_OF_MERIT
-            MASS_FLOW_RATE
-            AVG_OUTLET_PRESSURE
-            AVG_TOTAL_PRESSURE
-        returns +1 otherwise
-    """
-    
-    # flip sign for maximization problems
-    if ObjFun_name == "LIFT"            : return -1.0
-    if ObjFun_name == "EFFICIENCY"      : return -1.0
-    if ObjFun_name == "THRUST"          : return -1.0
-    if ObjFun_name == "FIGURE_OF_MERIT" : return -1.0
-    if ObjFun_name == "MASS_FLOW_RATE" : return -1.0
-    if ObjFun_name == "AVG_TOTAL_PRESSURE" : return -1.0
-    if ObjFun_name == "AVG_OUTLET_PRESSURE" : return -1.0
-    
-    # otherwise
-    return 1.0
-
-#: def get_objectiveSign()
-
-
 # -------------------------------------------------------------------
 #  Get Constraint Sign
 # -------------------------------------------------------------------

--- a/SU2_PY/SU2/io/tools.py
+++ b/SU2_PY/SU2/io/tools.py
@@ -962,7 +962,7 @@ def restart2solution(config,state={}):
         restart  = config.RESTART_ADJ_FILENAME
         solution = config.SOLUTION_ADJ_FILENAME           
         # add suffix
-        func_name = config.OBJECTIVE_FUNCTION
+        func_name = config.OBJECTIVE_FUNCTION.keys()[0]
         suffix    = get_adjointSuffix(func_name)
         restart   = add_suffix(restart,suffix)
         solution  = add_suffix(solution,suffix)

--- a/SU2_PY/SU2/opt/scipy_tools.py
+++ b/SU2_PY/SU2/opt/scipy_tools.py
@@ -95,8 +95,9 @@ def scipy_slsqp(project,x0=None,xb=None,its=100,accu=1e-10,grads=True):
     x0 = [ x0[i]/dv_scl for i,dv_scl in enumerate(dv_scales) ]    
     
     # scale accuracy
-    obj = project.config['OPT_OBJECTIVE']
+    obj = project.config['OBJECTIVE_FUNCTION']
     obj_scale = obj[obj.keys()[0]]['SCALE']
+    print obj, obj_scale, accu
     accu = accu*obj_scale
 
     # scale accuracy

--- a/SU2_PY/SU2/run/adjoint.py
+++ b/SU2_PY/SU2/run/adjoint.py
@@ -100,7 +100,7 @@ def adjoint( config ):
                     'OBJECTIVE_FUNCTION'  : konfig['OBJECTIVE_FUNCTION']   })
     
     # files out
-    objective    = konfig['OBJECTIVE_FUNCTION']
+    objective    = konfig['OBJECTIVE_FUNCTION'].keys()[0]
     adj_title    = 'ADJOINT_' + objective
     suffix       = su2io.get_adjointSuffix(objective)
     restart_name = konfig['RESTART_FLOW_FILENAME']

--- a/SU2_PY/SU2/run/projection.py
+++ b/SU2_PY/SU2/run/projection.py
@@ -86,7 +86,7 @@ def projection( config, state={}, step = 1e-3 ):
     konfig.unpack_dvs(dv_new,dv_old)
 
     # filenames
-    objective      = konfig['OBJECTIVE_FUNCTION']
+    objective      = konfig['OBJECTIVE_FUNCTION'].keys()[0]
     grad_filename  = konfig['GRAD_OBJFUNC_FILENAME']
     output_format  = konfig['OUTPUT_FORMAT']
     plot_extension = su2io.get_extension(output_format)

--- a/SU2_PY/SU2/util/filter_adjoint.py
+++ b/SU2_PY/SU2/util/filter_adjoint.py
@@ -97,7 +97,7 @@ def process_surface_adjoint( config_filename       ,
     surface_filename = config_data['SURFACE_ADJ_FILENAME'] + '.csv'
     print surface_filename
     mesh_filename    = config_data['MESH_FILENAME']
-    gradient         = config_data['OBJECTIVE_FUNCTION']
+    gradient         = config_data['OBJECTIVE_FUNCTION'].keys()
     
     print('Config filename = %s' % config_filename)
     print('Surface filename = %s' % surface_filename)

--- a/SU2_PY/discrete_adjoint.py
+++ b/SU2_PY/discrete_adjoint.py
@@ -135,7 +135,7 @@ def discrete_design( filename           ,
 
     config['GRADIENT_METHOD'] = 'DISCRETE_ADJOINT'
 
-    ADJ_NAME = config.OBJECTIVE_FUNCTION
+    ADJ_NAME = config.OBJECTIVE_FUNCTION.keys()
     
     # State
     state = SU2.io.State()

--- a/TestCases/actuator_disk/ActDisk_Euler.cfg
+++ b/TestCases/actuator_disk/ActDisk_Euler.cfg
@@ -372,9 +372,9 @@ WRT_CON_FREQ= 1
 %    FFD_CAMBER_2D 	( 16, Scale | Mark. List | FFD_Box_ID, i_Ind )
 %    FFD_THICKNESS_2D 	( 17, Scale | Mark. List | FFD_Box_ID, i_Ind )
 %
-% Optimization objective function with scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= INVERSE_DESIGN_PRESSURE * 0.01
+% Optimization objective function defined with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT options
+%
+%= INVERSE_DESIGN_PRESSURE * 0.01
 %
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='

--- a/TestCases/cont_adj_euler/naca0012/inv_NACA0012.cfg
+++ b/TestCases/cont_adj_euler/naca0012/inv_NACA0012.cfg
@@ -77,6 +77,9 @@ NUM_METHOD_GRAD= GREEN_GAUSS
 %                                     INVERSE_DESIGN_HEATFLUX)
 OBJECTIVE_FUNCTION= DRAG
 %
+% Objective scaling factor
+OBJECTIVE_WEIGHT= 1.0
+%
 % Courant-Friedrichs-Lewy condition of the finest grid
 CFL_NUMBER= 5.0
 %
@@ -293,9 +296,7 @@ WRT_CON_FREQ= 1
 %    FFD_VOLUME 	( 13, Scale | Mark. List | FFD_BoxTag, i_Ind, j_Ind )
 %    FOURIER 		( 14, Scale | Mark. List | Lower(0)/Upper(1) side, index, cos(0)/sin(1) )
 %
-% Optimization objective function with scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 0.001
+% Optimization objective function defined with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT options
 %
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='

--- a/TestCases/cont_adj_euler/naca0012/inv_NACA0012_discadj.cfg
+++ b/TestCases/cont_adj_euler/naca0012/inv_NACA0012_discadj.cfg
@@ -78,6 +78,9 @@ NUM_METHOD_GRAD= GREEN_GAUSS
 %                                     INVERSE_DESIGN_HEATFLUX)
 OBJECTIVE_FUNCTION= DRAG
 %
+% Objective scaling factor
+OBJECTIVE_WEIGHT= 1.0
+%
 % Courant-Friedrichs-Lewy condition of the finest grid
 CFL_NUMBER= 5.0
 %
@@ -294,9 +297,7 @@ WRT_CON_FREQ= 1
 %    FFD_VOLUME 	( 13, Scale | Mark. List | FFD_BoxTag, i_Ind, j_Ind )
 %    FOURIER 		( 14, Scale | Mark. List | Lower(0)/Upper(1) side, index, cos(0)/sin(1) )
 %
-% Optimization objective function with scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 0.001
+% Optimization objective function defined with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT options
 %
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='

--- a/TestCases/cont_adj_euler/oneram6/inv_ONERAM6.cfg
+++ b/TestCases/cont_adj_euler/oneram6/inv_ONERAM6.cfg
@@ -90,6 +90,9 @@ NUM_METHOD_GRAD= WEIGHTED_LEAST_SQUARES
 %                                             INVERSE_DESIGN_HEATFLUX)
 OBJECTIVE_FUNCTION= DRAG
 %
+% Objective scaling factor
+OBJECTIVE_WEIGHT= 1.0
+%
 % Courant-Friedrichs-Lewy condition of the finest grid
 CFL_NUMBER= 5.0
 %
@@ -392,12 +395,10 @@ FFD_CONTINUITY= 2ND_DERIVATIVE
 %    FFD_THICKNESS_2D 	( 17, Scale | Mark. List | FFD_BoxTag, i_Ind )
 %    FFD_CONTROL_SURFACE 	( 18, Scale | Mark. List | FFD_BoxTag, x_Orig, y_Orig, z_Orig, x_End, y_End, z_End )
 %
-% Optimization objective function with scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 1.0
+% Optimization objective function defined with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT options
 %
-% Optimization constraint functions with scaling factors, separated by semicolons
-% ex= (Objective = Value ) * Scale, use '>','<','='
+% Optimization objective function defined with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT options
+% 
 OPT_CONSTRAINT= ( LIFT > 0.282557 ) * 1.0
 %
 % Maximum number of iterations

--- a/TestCases/cont_adj_euler/wedge/inv_wedge_ROE.cfg
+++ b/TestCases/cont_adj_euler/wedge/inv_wedge_ROE.cfg
@@ -190,6 +190,10 @@ MG_ADJFLOW= NO
 %                                             INVERSE_DESIGN_HEATFLUX, AVG_TOTAL_PRESSURE, 
 %                                             MASS_FLOW_RATE)
 OBJECTIVE_FUNCTION= OUTFLOW_GENERALIZED
+%
+% Objective scaling factor
+OBJECTIVE_WEIGHT= 1.0
+%
 % --------------------------- CONVERGENCE PARAMETERS --------------------------%
 %
 % Convergence criteria (CAUCHY, RESIDUAL)
@@ -356,9 +360,7 @@ VISUALIZE_DEFORMATION= YES
 %    FFD_THICKNESS_2D 	( 17, Scale | Mark. List | FFD_BoxTag, i_Ind )
 %    FFD_CONTROL_SURFACE 	( 18, Scale | Mark. List | FFD_BoxTag, x_Orig, y_Orig, z_Orig, x_End, y_End, z_End )
 %
-% Optimization objective function with scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE=OUTFLOW_GENERALIZED
+% Optimization objective function defined with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT options
 %
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='

--- a/TestCases/cont_adj_incomp_euler/naca0012/incomp_NACA0012.cfg
+++ b/TestCases/cont_adj_incomp_euler/naca0012/incomp_NACA0012.cfg
@@ -139,6 +139,9 @@ TIME_DISCRE_FLOW= EULER_IMPLICIT
 %                                     INVERSE_DESIGN_HEATFLUX)
 OBJECTIVE_FUNCTION= LIFT
 %
+% Objective scaling factor
+OBJECTIVE_WEIGHT= -1.0
+%
 % Convective numerical method (JST, LAX-FRIEDRICH, ROE)
 CONV_NUM_METHOD_ADJFLOW= ROE
 %

--- a/TestCases/cont_adj_incomp_navierstokes/cylinder/lam_incomp_cylinder.cfg
+++ b/TestCases/cont_adj_incomp_navierstokes/cylinder/lam_incomp_cylinder.cfg
@@ -159,6 +159,9 @@ TIME_DISCRE_FLOW= EULER_IMPLICIT
 %                                     INVERSE_DESIGN_HEATFLUX)
 OBJECTIVE_FUNCTION= DRAG
 %
+% Objective scaling factor
+OBJECTIVE_WEIGHT= 1.0
+%
 % Convective numerical method (JST, LAX-FRIEDRICH, ROE)
 CONV_NUM_METHOD_ADJFLOW= ROE
 %

--- a/TestCases/cont_adj_navierstokes/cylinder/lam_cylinder.cfg
+++ b/TestCases/cont_adj_navierstokes/cylinder/lam_cylinder.cfg
@@ -86,6 +86,9 @@ NUM_METHOD_GRAD= WEIGHTED_LEAST_SQUARES
 %                                     INVERSE_DESIGN_HEATFLUX)
 OBJECTIVE_FUNCTION= DRAG
 %
+% Objective scaling factor
+OBJECTIVE_WEIGHT= 1.0
+%
 % Courant-Friedrichs-Lewy condition of the finest grid
 CFL_NUMBER= 5.0
 %

--- a/TestCases/cont_adj_navierstokes/naca0012_sub/lam_NACA0012.cfg
+++ b/TestCases/cont_adj_navierstokes/naca0012_sub/lam_NACA0012.cfg
@@ -85,6 +85,9 @@ NUM_METHOD_GRAD= WEIGHTED_LEAST_SQUARES
 %                                             INVERSE_DESIGN_HEATFLUX)
 OBJECTIVE_FUNCTION= DRAG
 %
+% Objective scaling factor
+OBJECTIVE_WEIGHT= 0.01
+%
 % Courant-Friedrichs-Lewy condition of the finest grid
 CFL_NUMBER= 5.0
 %
@@ -294,9 +297,7 @@ WRT_CON_FREQ= 1
 %    FFD_VOLUME 	( 13, Scale | Mark. List | FFD_BoxTag, i_Ind, j_Ind )
 %    FOURIER 		( 14, Scale | Mark. List | Lower(0)/Upper(1) side, index, cos(0)/sin(1) )
 %
-% Optimization objective function with scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 0.01
+% Optimization objective function defined with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT options
 %
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='

--- a/TestCases/cont_adj_navierstokes/naca0012_trans/lam_NACA0012.cfg
+++ b/TestCases/cont_adj_navierstokes/naca0012_trans/lam_NACA0012.cfg
@@ -85,6 +85,9 @@ NUM_METHOD_GRAD= GREEN_GAUSS
 %                                             INVERSE_DESIGN_HEATFLUX)
 OBJECTIVE_FUNCTION= DRAG
 %
+% Objective scaling factor
+OBJECTIVE_WEIGHT= 0.01
+%
 % Courant-Friedrichs-Lewy condition of the finest grid
 CFL_NUMBER= 25.0
 %
@@ -303,9 +306,7 @@ WRT_CON_FREQ= 5
 %    FFD_VOLUME 	( 13, Scale | Mark. List | FFD_BoxTag, i_Ind, j_Ind )
 %    FOURIER 		( 14, Scale | Mark. List | Lower(0)/Upper(1) side, index, cos(0)/sin(1) )
 %
-% Optimization objective function with scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 0.01
+% Optimization objective function defined with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT options
 %
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='

--- a/TestCases/cont_adj_rans/oneram6/turb_ONERAM6.cfg
+++ b/TestCases/cont_adj_rans/oneram6/turb_ONERAM6.cfg
@@ -184,6 +184,9 @@ TIME_DISCRE_TURB= EULER_IMPLICIT
 %                                     TORQUE, FREE_SURFACE)
 OBJECTIVE_FUNCTION= DRAG
 %
+% Objective scaling factor
+OBJECTIVE_WEIGHT= 0.02
+%
 % Convective numerical method (JST, LAX-FRIEDRICH, ROE)
 CONV_NUM_METHOD_ADJFLOW= JST
 %
@@ -351,9 +354,7 @@ WRT_CON_FREQ_DUALTIME= 25
 %                     FORCE_X, FORCE_Y, FORCE_Z, THRUST, TORQUE, FIGURE_OF_MERIT
 %                     FREESURFACE)
 
-% Optimization objective function with optional scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 0.02
+% Optimization objective function defined with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT options
 
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='  (LIFT > 0.267) * 0.02

--- a/TestCases/cont_adj_rans/rae2822/turb_SA_RAE2822.cfg
+++ b/TestCases/cont_adj_rans/rae2822/turb_SA_RAE2822.cfg
@@ -155,6 +155,9 @@ TIME_DISCRE_TURB= EULER_IMPLICIT
 %                                     INVERSE_DESIGN_HEATFLUX)
 OBJECTIVE_FUNCTION= DRAG
 %
+% Objective scaling factor
+OBJECTIVE_WEIGHT= 0.001
+%
 % Convective numerical method (JST, LAX-FRIEDRICH, ROE)
 CONV_NUM_METHOD_ADJFLOW= ROE
 %
@@ -279,9 +282,7 @@ DV_PARAM= ( 1, 0.5 )
 %    FORCE_Z, MOMENT_X, MOMENT_Y, MOMENT_Z, EFFICIENCY, 
 %    EQUIVALENT_AREA, THRUST, TORQUE, FREESURFACE
 
-% Optimization objective function with optional scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 0.001
+% Optimization objective function defined with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT options
 
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='

--- a/TestCases/control_surface/inv_ONERAM6_moving.cfg
+++ b/TestCases/control_surface/inv_ONERAM6_moving.cfg
@@ -322,8 +322,8 @@ FFD_ITERATIONS= 1000
 %		      FREESURFACE)
 
 % Optimization objective function with optional scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 100.0
+%
+%= DRAG * 100.0
 
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='

--- a/TestCases/control_surface/inv_ONERAM6_setting.cfg
+++ b/TestCases/control_surface/inv_ONERAM6_setting.cfg
@@ -322,8 +322,8 @@ FFD_ITERATIONS= 1000
 %		      FREESURFACE)
 
 % Optimization objective function with optional scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 100.0
+%
+%= DRAG * 100.0
 
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='

--- a/TestCases/euler/naca0012/inv_NACA0012.cfg
+++ b/TestCases/euler/naca0012/inv_NACA0012.cfg
@@ -336,9 +336,9 @@ WRT_CON_FREQ= 1
 %    FFD_CAMBER_2D 	( 16, Scale | Mark. List | FFD_Box_ID, i_Ind )
 %    FFD_THICKNESS_2D 	( 17, Scale | Mark. List | FFD_Box_ID, i_Ind )
 %
-% Optimization objective function with scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 0.001
+% Optimization objective function defined with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT options
+%
+%= DRAG * 0.001
 %
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='

--- a/TestCases/euler/oneram6/inv_ONERAM6.cfg
+++ b/TestCases/euler/oneram6/inv_ONERAM6.cfg
@@ -392,9 +392,9 @@ FFD_CONTINUITY= 2ND_DERIVATIVE
 %    FFD_THICKNESS_2D 	( 17, Scale | Mark. List | FFD_BoxTag, i_Ind )
 %    FFD_CONTROL_SURFACE 	( 18, Scale | Mark. List | FFD_BoxTag, x_Orig, y_Orig, z_Orig, x_End, y_End, z_End )
 %
-% Optimization objective function with scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 1.0
+% Optimization objective function defined with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT options
+%
+%= DRAG * 1.0
 %
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='

--- a/TestCases/fixed_cl/naca0012/inv_NACA0012.cfg
+++ b/TestCases/fixed_cl/naca0012/inv_NACA0012.cfg
@@ -344,9 +344,9 @@ WRT_CON_FREQ= 1
 %    FFD_CAMBER_2D 	( 16, Scale | Mark. List | FFD_Box_ID, i_Ind )
 %    FFD_THICKNESS_2D 	( 17, Scale | Mark. List | FFD_Box_ID, i_Ind )
 %
-% Optimization objective function with scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 0.001
+% Optimization objective function defined with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT options
+%
+%= DRAG * 0.001
 %
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='

--- a/TestCases/optimization_euler/pitching_naca64a010/pitching_NACA64A010.cfg
+++ b/TestCases/optimization_euler/pitching_naca64a010/pitching_NACA64A010.cfg
@@ -207,6 +207,9 @@ TIME_DISCRE_FLOW= EULER_IMPLICIT
 %                                     FORCE_X, FORCE_Y, FORCE_Z, THRUST, TORQUE)
 OBJECTIVE_FUNCTION= DRAG
 %
+% Objective scaling factor
+OBJECTIVE_WEIGHT= 0.001
+%
 % Convective numerical method (JST, LAX-FRIEDRICH, ROE)
 CONV_NUM_METHOD_ADJFLOW= JST
 %
@@ -342,9 +345,7 @@ WRT_CON_FREQ= 1
 %    FORCE_Z, MOMENT_X, MOMENT_Y, MOMENT_Z, EFFICIENCY,
 %    EQUIVALENT_AREA, THRUST, TORQUE, FREE_SURFACE
 
-% Optimization objective function with optional scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 0.001
+% Optimization objective function defined with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT options
 
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='

--- a/TestCases/optimization_euler/pitching_oneram6/pitching_ONERAM6.cfg
+++ b/TestCases/optimization_euler/pitching_oneram6/pitching_ONERAM6.cfg
@@ -358,10 +358,12 @@ VISUALIZE_DEFORMATION= NO
 %                     FORCE_X, FORCE_Y, FORCE_Z, THRUST, TORQUE, FIGURE_OF_MERIT
 %		      FREESURFACE)
 
-% Optimization objective function with optional scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 0.1
-
+% Optimization objective function defined with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT options
+OBJECTIVE_FUNCTION= DRAG
+%
+% Objective scaling factor
+OBJECTIVE_WEIGHT= 0.1
+%
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='
 OPT_CONSTRAINT= (LIFT > 0.2864) * 0.1; (MAX_THICKNESS_SEC1 > 0.0570) * 0.1; (MAX_THICKNESS_SEC2 > 0.0513) * 0.1; (MAX_THICKNESS_SEC3 > 0.0457) * 0.1; (MAX_THICKNESS_SEC4 > 0.0399) * 0.1; (MAX_THICKNESS_SEC5 > 0.0343) * 0.1

--- a/TestCases/optimization_euler/rotating_naca0012/rotating_NACA0012.cfg
+++ b/TestCases/optimization_euler/rotating_naca0012/rotating_NACA0012.cfg
@@ -173,6 +173,9 @@ TIME_DISCRE_FLOW= EULER_IMPLICIT
 %                                     TORQUE, FREE_SURFACE)
 OBJECTIVE_FUNCTION= DRAG
 %
+% Objective scaling factor
+OBJECTIVE_WEIGHT= 0.001
+%
 % Convective numerical method (JST, LAX-FRIEDRICH, ROE)
 CONV_NUM_METHOD_ADJFLOW= JST
 %
@@ -315,9 +318,7 @@ WRT_CON_FREQ= 1
 %    FORCE_Z, MOMENT_X, MOMENT_Y, MOMENT_Z, EFFICIENCY, 
 %    EQUIVALENT_AREA, THRUST, TORQUE, FREE_SURFACE
 
-% Optimization objective function with optional scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 0.001
+% Optimization objective function defined with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT options
 
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='

--- a/TestCases/optimization_euler/steady_inverse_design/inv_NACA0012.cfg
+++ b/TestCases/optimization_euler/steady_inverse_design/inv_NACA0012.cfg
@@ -91,6 +91,9 @@ NUM_METHOD_GRAD= WEIGHTED_LEAST_SQUARES
 %                                             INVERSE_DESIGN_HEATFLUX)
 OBJECTIVE_FUNCTION= INVERSE_DESIGN_PRESSURE
 %
+% Objective scaling factor
+OBJECTIVE_WEIGHT= 0.001
+%
 % Courant-Friedrichs-Lewy condition of the finest grid
 CFL_NUMBER= 2.0
 %
@@ -334,9 +337,7 @@ WRT_CON_FREQ= 1
 %    FFD_CAMBER_2D 	( 16, Scale | Mark. List | FFD_Box_ID, i_Ind )
 %    FFD_THICKNESS_2D 	( 17, Scale | Mark. List | FFD_Box_ID, i_Ind )
 %
-% Optimization objective function with scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= INVERSE_DESIGN_PRESSURE * 0.001
+% Optimization objective function defined with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT options
 %
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='

--- a/TestCases/optimization_euler/steady_naca0012/inv_NACA0012_adv.cfg
+++ b/TestCases/optimization_euler/steady_naca0012/inv_NACA0012_adv.cfg
@@ -150,6 +150,9 @@ TIME_DISCRE_FLOW= EULER_IMPLICIT
 %                                     TORQUE, FREE_SURFACE)
 OBJECTIVE_FUNCTION= DRAG
 %
+% Objective scaling factor
+OBJECTIVE_WEIGHT= 0.001
+%
 % Convective numerical method (JST, LAX-FRIEDRICH, ROE-1ST_ORDER, 
 %                              ROE-2ND_ORDER)
 CONV_NUM_METHOD_ADJFLOW= JST
@@ -346,9 +349,7 @@ WRT_HALO= NO
 %    FFD_VOLUME 	( 13, Scale | Mark. List | FFD_BoxTag, i_Ind, j_Ind )
 %    FOURIER 		( 14, Scale | Mark. List | Lower(0)/Upper(1) side, index, cos(0)/sin(1) )
 %
-% Optimization objective function with scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 0.001
+% Optimization objective function defined with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT options
 %
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='

--- a/TestCases/optimization_euler/steady_naca0012/inv_NACA0012_basic.cfg
+++ b/TestCases/optimization_euler/steady_naca0012/inv_NACA0012_basic.cfg
@@ -150,6 +150,9 @@ TIME_DISCRE_FLOW= EULER_IMPLICIT
 %                                     TORQUE, FREE_SURFACE)
 OBJECTIVE_FUNCTION= DRAG
 %
+% Objective scaling factor
+OBJECTIVE_WEIGHT= 0.001
+%
 % Convective numerical method (JST, LAX-FRIEDRICH, ROE-1ST_ORDER, 
 %                              ROE-2ND_ORDER)
 CONV_NUM_METHOD_ADJFLOW= JST
@@ -337,9 +340,7 @@ WRT_HALO= NO
 %    FFD_VOLUME 	( 13, Scale | Mark. List | FFD_BoxTag, i_Ind, j_Ind )
 %    FOURIER 		( 14, Scale | Mark. List | Lower(0)/Upper(1) side, index, cos(0)/sin(1) )
 %
-% Optimization objective function with scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 0.001
+% Optimization objective function defined with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT options
 %
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='

--- a/TestCases/optimization_euler/steady_oneram6/inv_ONERAM6_adv.cfg
+++ b/TestCases/optimization_euler/steady_oneram6/inv_ONERAM6_adv.cfg
@@ -84,6 +84,9 @@ NUM_METHOD_GRAD= WEIGHTED_LEAST_SQUARES
 %                                             INVERSE_DESIGN_HEATFLUX)
 OBJECTIVE_FUNCTION= DRAG
 %
+% Objective scaling factor
+OBJECTIVE_WEIGHT= 0.1
+%
 % Courant-Friedrichs-Lewy condition of the finest grid
 CFL_NUMBER= 5.0
 %
@@ -393,9 +396,7 @@ VISUALIZE_DEFORMATION= NO
 %    FFD_VOLUME 	( 13, Scale | Mark. List | FFD_BoxTag, i_Ind, j_Ind )
 %    FOURIER 		( 14, Scale | Mark. List | Lower(0)/Upper(1) side, index, cos(0)/sin(1) )
 %
-% Optimization objective function with scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 0.1
+% Optimization objective function defined with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT options
 %
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='

--- a/TestCases/optimization_euler/steady_oneram6/inv_ONERAM6_basic.cfg
+++ b/TestCases/optimization_euler/steady_oneram6/inv_ONERAM6_basic.cfg
@@ -86,6 +86,9 @@ NUM_METHOD_GRAD= WEIGHTED_LEAST_SQUARES
 %                                             INVERSE_DESIGN_HEATFLUX)
 OBJECTIVE_FUNCTION= DRAG
 %
+% Objective scaling factor
+OBJECTIVE_WEIGHT= 0.1
+%
 % Courant-Friedrichs-Lewy condition of the finest grid
 CFL_NUMBER= 10.0
 %
@@ -379,9 +382,7 @@ VISUALIZE_DEFORMATION= NO
 %    FFD_VOLUME 	( 13, Scale | Mark. List | FFD_BoxTag, i_Ind, j_Ind )
 %    FOURIER 		( 14, Scale | Mark. List | Lower(0)/Upper(1) side, index, cos(0)/sin(1) )
 %
-% Optimization objective function with scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 0.1
+% Optimization objective function defined with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT options
 %
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='

--- a/TestCases/optimization_rans/pitching_naca64a010/turb_NACA64A010.cfg
+++ b/TestCases/optimization_rans/pitching_naca64a010/turb_NACA64A010.cfg
@@ -223,6 +223,9 @@ TIME_DISCRE_TURB= EULER_IMPLICIT
 %                                     FORCE_X, FORCE_Y, FORCE_Z, THRUST, TORQUE)
 OBJECTIVE_FUNCTION= DRAG
 %
+% Objective scaling factor
+OBJECTIVE_WEIGHT= 0.001
+%
 % Convective numerical method (JST, LAX-FRIEDRICH, ROE)
 CONV_NUM_METHOD_ADJFLOW= JST
 %
@@ -373,9 +376,7 @@ WRT_CON_FREQ_DUALTIME= 100
 %    FORCE_Z, MOMENT_X, MOMENT_Y, MOMENT_Z, EFFICIENCY,
 %    EQUIVALENT_AREA, THRUST, TORQUE, FREE_SURFACE
 
-% Optimization objective function with optional scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 0.001
+% Optimization objective function defined with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT options
 
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='

--- a/TestCases/optimization_rans/pitching_oneram6/turb_ONERAM6.cfg
+++ b/TestCases/optimization_rans/pitching_oneram6/turb_ONERAM6.cfg
@@ -230,6 +230,9 @@ TIME_DISCRE_TURB= EULER_IMPLICIT
 %                                     TORQUE, FREE_SURFACE)
 OBJECTIVE_FUNCTION= DRAG
 %
+% Objective scaling factor
+OBJECTIVE_WEIGHT= 0.0Z2
+%
 % Convective numerical method (JST, LAX-FRIEDRICH, ROE)
 CONV_NUM_METHOD_ADJFLOW= JST
 %
@@ -412,9 +415,7 @@ WRT_CON_FREQ_DUALTIME= 25
 %                     FORCE_X, FORCE_Y, FORCE_Z, THRUST, TORQUE, FIGURE_OF_MERIT
 %                     FREESURFACE)
 
-% Optimization objective function with optional scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 0.02
+% Optimization objective function defined with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT options
 
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='  (LIFT > 0.267) * 0.02

--- a/TestCases/optimization_rans/steady_oneram6/turb_ONERAM6.cfg
+++ b/TestCases/optimization_rans/steady_oneram6/turb_ONERAM6.cfg
@@ -181,6 +181,10 @@ TIME_DISCRE_TURB= EULER_IMPLICIT
 %                                     TORQUE, FREE_SURFACE)
 OBJECTIVE_FUNCTION= DRAG
 %
+% Objective scaling factor
+OBJECTIVE_WEIGHT= 0.001
+%
+%
 % Convective numerical method (JST, LAX-FRIEDRICH, ROE)
 CONV_NUM_METHOD_ADJFLOW= JST
 %
@@ -342,9 +346,7 @@ WRT_CON_FREQ_DUALTIME= 25
 %                     FORCE_X, FORCE_Y, FORCE_Z, THRUST, TORQUE, FIGURE_OF_MERIT
 %                     FREESURFACE)
 
-% Optimization objective function with optional scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 0.001
+% Optimization objective function defined with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT options
 
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='

--- a/TestCases/optimization_rans/steady_rae2822/turb_SA_RAE2822.cfg
+++ b/TestCases/optimization_rans/steady_rae2822/turb_SA_RAE2822.cfg
@@ -162,6 +162,9 @@ TIME_DISCRE_TURB= EULER_IMPLICIT
 %                                     TORQUE, FREESURFACE)
 OBJECTIVE_FUNCTION= DRAG
 %
+% Objective scaling factor
+OBJECTIVE_WEIGHT= 0.001
+%
 % Convective numerical method (JST, LAX-FRIEDRICH, ROE-1ST_ORDER, 
 %                              ROE-2ND_ORDER)
 CONV_NUM_METHOD_ADJFLOW= JST
@@ -314,9 +317,7 @@ VISUALIZE_DEFORMATION= NO
 %    FORCE_Z, MOMENT_X, MOMENT_Y, MOMENT_Z, EFFICIENCY, 
 %    EQUIVALENT_AREA, THRUST, TORQUE, FREESURFACE
 
-% Optimization objective function with optional scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 0.001
+% Optimization objective function defined with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT options
 
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='

--- a/TestCases/rans/rae2822/turb_SA_RAE2822.cfg
+++ b/TestCases/rans/rae2822/turb_SA_RAE2822.cfg
@@ -317,8 +317,8 @@ MOTION_FILENAME= mesh_motion.dat
 %    EQUIVALENT_AREA, THRUST, TORQUE, FREESURFACE
 
 % Optimization objective function with optional scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 0.001
+%
+%= DRAG * 0.001
 
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='

--- a/TestCases/rotating/naca0012/rot_NACA0012.cfg
+++ b/TestCases/rotating/naca0012/rot_NACA0012.cfg
@@ -375,9 +375,9 @@ WRT_CON_FREQ= 1
 %    FFD_VOLUME 	( 13, Scale | Mark. List | FFD_BoxTag, i_Ind, j_Ind )
 %    FOURIER 		( 14, Scale | Mark. List | Lower(0)/Upper(1) side, index, cos(0)/sin(1) )
 %
-% Optimization objective function with scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 0.01
+% Optimization objective function defined with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT options
+%
+%= DRAG * 0.01
 %
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='

--- a/TestCases/unsteady/pitching_naca64a010_euler/pitching_NACA64A010.cfg
+++ b/TestCases/unsteady/pitching_naca64a010_euler/pitching_NACA64A010.cfg
@@ -343,8 +343,8 @@ WRT_CON_FREQ= 1
 %    EQUIVALENT_AREA, THRUST, TORQUE, FREE_SURFACE
 
 % Optimization objective function with optional scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 0.001
+%
+%= DRAG * 0.001
 
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='

--- a/TestCases/unsteady/pitching_naca64a010_rans/turb_NACA64A010.cfg
+++ b/TestCases/unsteady/pitching_naca64a010_rans/turb_NACA64A010.cfg
@@ -374,8 +374,8 @@ WRT_CON_FREQ_DUALTIME= 100
 %    EQUIVALENT_AREA, THRUST, TORQUE, FREE_SURFACE
 
 % Optimization objective function with optional scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 0.001
+%
+%= DRAG * 0.001
 
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -921,9 +921,9 @@ CONSOLE_OUTPUT_VERBOSITY= HIGH
 %    FFD_THICKNESS_2D 	( 17, Scale | Mark. List | FFD_BoxTag, i_Ind )
 %    FFD_CONTROL_SURFACE 	( 18, Scale | Mark. List | FFD_BoxTag, x_Orig, y_Orig, z_Orig, x_End, y_End, z_End )
 %
-% Optimization objective function with scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 0.001
+% Optimization objective function defined with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT options
+%
+%
 %
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='

--- a/config_template_basic.cfg
+++ b/config_template_basic.cfg
@@ -621,9 +621,8 @@ CONSOLE_OUTPUT_VERBOSITY= HIGH
 %    FFD_THICKNESS_2D 	( 17, Scale | Mark. List | FFD_BoxTag, i_Ind )
 %    FFD_CONTROL_SURFACE 	( 18, Scale | Mark. List | FFD_BoxTag, x_Orig, y_Orig, z_Orig, x_End, y_End, z_End )
 %
-% Optimization objective function with scaling factor
-% ex= Objective * Scale
-OPT_OBJECTIVE= DRAG * 0.001
+% Optimization objective function defined with OBJECTIVE_FUNCTION and OBJECTIVE_WEIGHT options
+%
 %
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='


### PR DESCRIPTION
This is a relatively small code change, but the change in options will effect the config files for everyone currently using optimization, and for anyone who has an OPT_OBJECTIVE defined in their config file. 

The reasoning behind deprecating this option:
-Compressing the OPT_OBJECTIVE and OBJECTIVE_FUNCTION options into a single specification will reduce potential confusion about the behavior of these options. 
-Using the new OBJECTIVE_WEIGHT option to specify not only the scaling but also the sign clarifies the behavior of the optimizer - previously, the sign of the objective function was automatically flipped behind the scenes, now this is controlled by the user.
- This change facilitates planned further modifications to allow multiple objectives. 

Please feel free to comment both on the code changes themselves as well as on the new config option format