### PR TITLE
Fix heat flux continuous adj

### DIFF
--- a/SU2_CFD/src/solver_adjoint_mean.cpp
+++ b/SU2_CFD/src/solver_adjoint_mean.cpp
@@ -5220,8 +5220,6 @@ CAdjNSSolver::CAdjNSSolver(CGeometry *geometry, CConfig *config, unsigned short 
   
   /*--- Norm heat flux objective test ---*/
   pnorm = 1.0;
-  if (config->GetKind_ObjFunc()==TOTAL_HEATFLUX)
-    pnorm = 1.0;
   if (config->GetKind_ObjFunc()==MAXIMUM_HEATFLUX)
     pnorm = 8.0;
   

--- a/SU2_CFD/src/solver_adjoint_mean.cpp
+++ b/SU2_CFD/src/solver_adjoint_mean.cpp
@@ -5219,8 +5219,11 @@ CAdjNSSolver::CAdjNSSolver(CGeometry *geometry, CConfig *config, unsigned short 
 #endif
   
   /*--- Norm heat flux objective test ---*/
-  
-  pnorm = 10;
+  pnorm = 1.0;
+  if (config->GetKind_ObjFunc()==TOTAL_HEATFLUX)
+    pnorm = 1.0;
+  if (config->GetKind_ObjFunc()==MAXIMUM_HEATFLUX)
+    pnorm = 8.0;
   
   /*--- Set the gamma value ---*/
   
@@ -5359,7 +5362,7 @@ CAdjNSSolver::CAdjNSSolver(CGeometry *geometry, CConfig *config, unsigned short 
   if ((config->GetKind_ObjFunc() == TOTAL_HEATFLUX) ||
       (config->GetKind_ObjFunc() == MAXIMUM_HEATFLUX) ||
       (config->GetKind_ObjFunc() == INVERSE_DESIGN_HEATFLUX))
-    PsiE_Inf = -1.0;
+    PsiE_Inf = 1.0;
   else
     PsiE_Inf = 0.0;
   Phi_Inf = new su2double [nDim];
@@ -6801,7 +6804,7 @@ void CAdjNSSolver::BC_Isothermal_Wall(CGeometry *geometry, CSolver **solver_cont
   Sigma_xx, Sigma_yy, Sigma_zz, Sigma_xy, Sigma_xz, Sigma_yz,
   Sigma_xx5, Sigma_yy5, Sigma_zz5, Sigma_xy5, Sigma_xz5,
   Sigma_yz5, eta_xx, eta_yy, eta_zz, eta_xy, eta_xz, eta_yz;
-  su2double kGTdotn;
+  su2double kGTdotn=0.0, Area=0.0, Xi=0.0;
   
   su2double *Psi = new su2double[nVar];
   su2double **Tau = new su2double* [nDim];
@@ -6904,14 +6907,24 @@ void CAdjNSSolver::BC_Isothermal_Wall(CGeometry *geometry, CSolver **solver_cont
         q = 0.0;
       }
       else {
+
+        Area = 0.0;
+        for (iDim=0; iDim<nDim; iDim++)
+          Area+=Normal[iDim]*Normal[iDim];
+        Area = pow(Area, 0.5);
+
+        /* --- Temperature gradient term ---*/
         GradT = solver_container[FLOW_SOL]->node[iPoint]->GetGradient_Primitive()[0];
-        kGTdotn = 0;
-//        Xi = solver_container[FLOW_SOL]->GetTotal_MaxHeatFlux();
-//        Xi = 1.0;
+
+        kGTdotn = 0.0;
         for (iDim = 0; iDim < nDim; iDim++)
           kGTdotn += Thermal_Conductivity*GradT[iDim]*Normal[iDim];
-        //q = - Xi * pnorm * pow(kGTdotn, pnorm-1.0);
-        q = -1.0;
+
+        /*--- constant term to multiply max heat flux objective ---*/
+        Xi = solver_container[FLOW_SOL]->GetTotal_HeatFlux(); // versions for max heat flux
+        Xi = pow(Xi, 1.0/pnorm-1.0)/pnorm;
+        /*--- Boundary condition value ---*/
+        q = Xi * pnorm * pow(-kGTdotn, pnorm-1.0)*Area;
       }
       
       /*--- Strong BC enforcement of the energy equation ---*/


### PR DESCRIPTION
Some small changes to bring the continuous adjoint total heat flux gradient closer to finite difference result (mainly there was a missing area term in BC_isothermal). 
There may still be a problem with the continuous adjoint for maximum heat flux; modifications also include changing norm used on the max heat flux to be the same as the norm used in the output calculation for max heat flux. 