### PR TITLE
Support both Python 2.6+ and Python 3.4+

### DIFF
--- a/SU2_PY/SU2/__init__.py
+++ b/SU2_PY/SU2/__init__.py
@@ -5,14 +5,6 @@ class EvaluationFailure(RuntimeError):
 class DivergenceFailure(EvaluationFailure):
     pass
 
-
-import run
-import io
-import mesh
-import eval
-import opt
-import util
-
 try:
     import readline
     import rlcompleter

--- a/SU2_PY/SU2/eval/design.py
+++ b/SU2_PY/SU2/eval/design.py
@@ -33,7 +33,7 @@
 #  Imports
 # ----------------------------------------------------------------------
 
-import os, sys, shutil, copy, glob, re
+import os, copy
 from .. import io   as su2io
 from .  import func as su2func
 from .  import grad as su2grad

--- a/SU2_PY/SU2/eval/functions.py
+++ b/SU2_PY/SU2/eval/functions.py
@@ -93,7 +93,7 @@ def function( func_name, config, state=None ):
             geometry( func_name, config, state )
             
         else:
-            raise Exception, 'unknown function name, %s' % func_name
+            raise Exception('unknown function name, %s' % func_name)
         
     #: if not redundant
     

--- a/SU2_PY/SU2/eval/gradients.py
+++ b/SU2_PY/SU2/eval/gradients.py
@@ -77,7 +77,7 @@ def gradient( func_name, method, config, state=None ):
     grads = {}
     state = su2io.State(state)
     if func_name == 'ALL':
-        raise Exception , "func_name = 'ALL' not yet supported"
+        raise Exception("func_name = 'ALL' not yet supported")
 
     # redundancy check
     if not state['GRADIENTS'].has_key(func_name):
@@ -105,7 +105,7 @@ def gradient( func_name, method, config, state=None ):
                 grads = geometry( func_name, config, state )
 
             else:
-                raise Exception, 'unknown function name: %s' % func_name
+                raise Exception('unknown function name: %s' % func_name)
 
         # Finite Difference Gradients
         elif method == 'FINDIFF':
@@ -115,7 +115,7 @@ def gradient( func_name, method, config, state=None ):
             grad = directdiff (config , state )
 
         else:
-            raise Exception , 'unrecognized gradient method'
+            raise Exception('unrecognized gradient method')
         
         if ('CUSTOM' in config.DV_KIND and 'OUTFLOW_GENERALIZED' in config.OBJECTIVE_FUNCTION ):
             import downstream_function
@@ -304,7 +304,7 @@ def stability( func_name, config, state=None, step=1e-2 ):
 
     # find base func name
     matches = [ k for k in su2io.optnames_aero if k in func_name ]
-    if not len(matches) == 1: raise Exception, 'could not find stability function name'
+    if not len(matches) == 1: raise Exception('could not find stability function name')
     base_name = matches[0]    
 
     ADJ_NAME = 'ADJOINT_'+base_name

--- a/SU2_PY/SU2/io/__init__.py
+++ b/SU2_PY/SU2/io/__init__.py
@@ -1,14 +1,10 @@
 # SU2/io/__init__.py
 
-from tools    import *
-from redirect import output as redirect_output
-from redirect import folder as redirect_folder
-from data     import load_data, save_data
-from filelock import filelock
+from .tools    import *
+from .redirect import output as redirect_output
+from .redirect import folder as redirect_folder
+from .data     import load_data, save_data
+from .filelock import filelock
 
-from config   import Config
-from state    import State_Factory as State
-
-
-
-
+from .config   import Config
+from .state    import State_Factory as State

--- a/SU2_PY/SU2/io/config.py
+++ b/SU2_PY/SU2/io/config.py
@@ -37,12 +37,9 @@ import os, sys, shutil, copy
 import numpy as np
 from ..util import bunch, ordered_bunch, switch
 from .tools import *
-from config_options import *
+from .config_options import *
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ..util.ordered_dict import OrderedDict
+from ..util.ordered_dict import OrderedDict
 
 inf = 1.0e20
 
@@ -84,7 +81,7 @@ class Config(ordered_bunch):
         if args and isinstance(args[0],str):
             filename = args[0]
             args = args[1:]
-        elif kwarg.has_key('filename'):
+        elif 'filename' in kwarg:
             filename = kwarg['filename']
             del kwarg['filename']
         else:
@@ -98,10 +95,10 @@ class Config(ordered_bunch):
             try:
                 self.read(filename)
             except IOError:
-                print 'Could not find config file: %s' % filename
-	    except:
-		print 'Unexpected error: ',sys.exc_info()[0]
-		raise
+                print('Could not find config file: %s' % filename)
+            except:
+                print('Unexpected error: ', sys.exc_info()[0])
+                raise
         
         self._filename = filename
     
@@ -125,13 +122,13 @@ class Config(ordered_bunch):
         try:
             return super(Config,self).__getattr__(k)
         except AttributeError:
-            raise AttributeError , 'Config parameter not found'
+            raise AttributeError('Config parameter not found')
         
     def __getitem__(self,k):
         try:
             return super(Config,self).__getitem__(k)
         except KeyError:
-            raise KeyError , 'Config parameter not found: %s' % k
+            raise KeyError('Config parameter not found: %s' % k)
 
     def unpack_dvs(self,dv_new,dv_old=None):
         """ updates config with design variable vectors
@@ -250,7 +247,7 @@ class Config(ordered_bunch):
         distance = 0.0
         
         for key in keys_check:
-            if konfig_diff.has_key(key):
+            if key in konfig_diff:
                 
                 val1 = konfig_diff[key][0]
                 val2 = konfig_diff[key][1]
@@ -262,7 +259,7 @@ class Config(ordered_bunch):
                     this_diff = np.sqrt( np.sum( (val1-val2)**2 ) )
                 
                 else:
-                    print 'Warning, unexpected config difference'
+                    print('Warning, unexpected config difference')
                     this_diff = inf
                     
                 distance += this_diff
@@ -318,7 +315,7 @@ def read_config(filename):
         this_param = line[0].strip()
         this_value = line[1].strip()
         
-        assert not data_dict.has_key(this_param) , ('Config file has multiple specifications of %s' % this_param )
+        assert this_param not in data_dict, ('Config file has multiple specifications of %s' % this_param )
         for case in switch(this_param):
             
             # comma delimited lists of strings with or without paren's
@@ -554,17 +551,17 @@ def read_config(filename):
     #: for line
 
     #hack - twl
-    if not data_dict.has_key('DV_VALUE_NEW'):
+    if 'DV_VALUE_NEW' not in data_dict:
         data_dict['DV_VALUE_NEW'] = [0]
-    if not data_dict.has_key('DV_VALUE_OLD'):
+    if 'DV_VALUE_OLD' not in data_dict:
         data_dict['DV_VALUE_OLD'] = [0]
-    if not data_dict.has_key('OPT_ITERATIONS'):
+    if 'OPT_ITERATIONS' not in data_dict:
         data_dict['OPT_ITERATIONS'] = 100
-    if not data_dict.has_key('OPT_ACCURACY'):
+    if 'OPT_ACCURACY' not in data_dict:
         data_dict['OPT_ACCURACY'] = 1e-10
-    if not data_dict.has_key('OPT_BOUND_UPPER'):
+    if 'OPT_BOUND_UPPER' not in data_dict:
         data_dict['OPT_BOUND_UPPER'] = 1e10
-    if not data_dict.has_key('OPT_BOUND_LOWER'):
+    if 'OPT_BOUND_LOWER' not in data_dict:
         data_dict['OPT_BOUND_LOWER'] = -1e10
     if not data_dict.has_key('VALUE_OBJFUNC_FILENAME'):
       data_dict['VALUE_OBJFUNC_FILENAME'] = 'of_eval.dat'
@@ -606,7 +603,7 @@ def write_config(filename,param_dict):
         old_value  = line[1].strip()
         
         # skip if parameter unwanted
-        if not param_dict.has_key(this_param):
+        if this_param not in param_dict:
             output_file.write(raw_line)
             continue
         
@@ -795,7 +792,7 @@ def dump_config(filename,config):
     '''
     
     # HACK - twl
-    if config.has_key('DV_VALUE_NEW'):
+    if 'DV_VALUE_NEW' in config:
         config.DV_VALUE = config.DV_VALUE_NEW
         
     config_file = open(filename,'w')

--- a/SU2_PY/SU2/io/data.py
+++ b/SU2_PY/SU2/io/data.py
@@ -34,8 +34,15 @@
 # ----------------------------------------------------------------------
 
 import os, sys, shutil, copy
-import cPickle as pickle
-from filelock import filelock
+if sys.version_info.major > 2:
+    # Py3 pickle now manage both accelerated cPickle and pure python pickle
+    # See https://docs.python.org/3/whatsnew/3.0.html#library-changes, 4th item.
+    import pickle
+else:
+    import cPickle as pickle
+
+
+from .filelock import filelock
 
 # -------------------------------------------------------------------
 #  Load a Dictionary of Data
@@ -71,7 +78,7 @@ def load_data( file_name, var_names=None   ,
         scipy_loaded = False    
         
     if not os.path.exists(file_name):
-        raise Exception , 'File does not exist: %s' % file_name
+        raise Exception('File does not exist: %s' % file_name)
     
     # process file format
     if file_format == 'infer':
@@ -177,7 +184,7 @@ def save_data( file_name, data_dict, append=False ,
         if append == True and os.path.exists(file_name):
             # check file exists
             if not os.path.exists(file_name):
-                raise Exception , 'Cannot append, file does not exist: %s' % file_name  
+                raise Exception('Cannot append, file does not exist: %s' % file_name)
             # load old data
             data_dict_old = load( file_name   = file_name   ,
                                   var_names   = None        ,

--- a/SU2_PY/SU2/io/state.py
+++ b/SU2_PY/SU2/io/state.py
@@ -236,7 +236,7 @@ class State(ordered_bunch):
             if not files.has_key(label):
                 if os.path.exists(filename):
                     files[label] = filename
-                    print 'Found: %s' % filename
+                    print('Found: %s' % filename)
             else:
                 assert os.path.exists(files[label]) , 'state expected file: %s' % filename
         #: register_file()                

--- a/SU2_PY/SU2/io/tools.py
+++ b/SU2_PY/SU2/io/tools.py
@@ -33,7 +33,7 @@
 #  Imports
 # -------------------------------------------------------------------
 
-import os, time, sys, pickle, errno, copy
+import os
 import shutil, glob
 from SU2.util import ordered_bunch
 
@@ -126,7 +126,7 @@ def read_plot( filename ):
 
     # check for number of zones
     if len(zones) > 1:
-        raise IOError , 'multiple zones not supported'
+        raise IOError('multiple zones not supported')
     
     # done
     plot_file.close()              
@@ -977,5 +977,5 @@ def restart2solution(config,state={}):
         if state: state.FILES[ADJ_NAME] = solution
         
     else:
-        raise Exception, 'unknown math problem'
+        raise Exception('unknown math problem')
 

--- a/SU2_PY/SU2/mesh/__init__.py
+++ b/SU2_PY/SU2/mesh/__init__.py
@@ -2,6 +2,4 @@
 
 __all__ = ['adapt']
 
-import adapt
-
 from tools import *

--- a/SU2_PY/SU2/mesh/adapt.py
+++ b/SU2_PY/SU2/mesh/adapt.py
@@ -29,7 +29,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with SU2. If not, see <http://www.gnu.org/licenses/>.
 
-import os, sys, shutil, copy
+import copy
 
 from .. import io  as su2io
 from ..run import CFD as SU2_CFD

--- a/SU2_PY/SU2/mesh/tools.py
+++ b/SU2_PY/SU2/mesh/tools.py
@@ -29,6 +29,11 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with SU2. If not, see <http://www.gnu.org/licenses/>.
 
+import sys
+if sys.version_info.major > 2:
+    # In PY3, 'long' and 'int' are unified in 'int' type
+    long = int
+
 # -------------------------------------------------------------------
 #  Imports
 # -------------------------------------------------------------------

--- a/SU2_PY/SU2/opt/project.py
+++ b/SU2_PY/SU2/opt/project.py
@@ -29,6 +29,9 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with SU2. If not, see <http://www.gnu.org/licenses/>.
 
+# make print(*args) function available in PY2.6+, does'nt work on PY < 2.6
+from __future__ import print_function
+
 # -------------------------------------------------------------------
 #  Imports
 # -------------------------------------------------------------------
@@ -104,7 +107,7 @@ class Project(object):
         if '*' in folder: folder = su2io.next_folder(folder)        
         if designs is None: designs = []
         
-        print 'New Project: %s' % (folder)
+        print('New Project: %s' % (folder))
         
         # setup config
         config = copy.deepcopy(config)
@@ -119,7 +122,7 @@ class Project(object):
         if config.OBJECTIVE_FUNCTION == 'OUTFLOW_GENERALIZED':
             state.FILES['DownstreamFunction'] = 'downstream_function.py'
         if 'MESH' not in state.FILES:
-            raise Exception , 'Could not find mesh file: %s' % config.MESH_FILENAME
+            raise Exception('Could not find mesh file: %s' % config.MESH_FILENAME)
         
         self.config  = config      # base config
         self.state   = state       # base state
@@ -175,7 +178,7 @@ class Project(object):
             design = self.new_design(konfig)
             
             if config.get('CONSOLE','VERBOSE') == 'VERBOSE':
-                print os.path.join(self.folder,design.folder)
+                print(os.path.join(self.folder,design.folder))
             timestamp = design.state.tic()
             
             # run design+
@@ -283,7 +286,7 @@ class Project(object):
         if delta == 0.0 and closest:
             design = closest
         else:
-            raise Exception, 'design not found for this config'
+            raise Exception('design not found for this config')
         return design
         
     def closest_design(self,config):

--- a/SU2_PY/SU2/opt/scipy_tools.py
+++ b/SU2_PY/SU2/opt/scipy_tools.py
@@ -33,11 +33,10 @@
 #  Imports
 # -------------------------------------------------------------------
 
-import os, sys, shutil, copy
+import sys
 
 from .. import eval as su2eval
 from numpy import array, zeros
-from numpy.linalg import norm
 
 
 # -------------------------------------------------------------------

--- a/SU2_PY/SU2/run/__init__.py
+++ b/SU2_PY/SU2/run/__init__.py
@@ -1,19 +1,19 @@
 # SU2/run/__init__.py
 
-from interface import  \
-    build_command     ,\
-    run_command       ,\
-    CFD               ,\
-    MSH               ,\
-    DEF               ,\
-    DOT               ,\
-    SOL               ,\
-    SOL_FSI           ;
+from .interface import (
+    build_command     ,
+    run_command       ,
+    CFD               ,
+    MSH               ,
+    DEF               ,
+    DOT               ,
+    SOL               ,
+    SOL_FSI)
 
-from direct     import direct
-from adjoint    import adjoint
-from projection import projection
-from deform     import deform
-from geometry   import geometry
-from adaptation import adaptation
-from merge      import merge 
+from .direct     import direct
+from .adjoint    import adjoint
+from .projection import projection
+from .deform     import deform
+from .geometry   import geometry
+from .adaptation import adaptation
+from .merge      import merge

--- a/SU2_PY/SU2/run/adaptation.py
+++ b/SU2_PY/SU2/run/adaptation.py
@@ -29,9 +29,10 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with SU2. If not, see <http://www.gnu.org/licenses/>.
 
-import os, sys, shutil, copy
+import copy
 
 from .. import io   as su2io
+from ..io.data import append_nestdict
 from .. import mesh as su2mesh
 
 def adaptation ( config , kind='' ):

--- a/SU2_PY/SU2/run/adjoint.py
+++ b/SU2_PY/SU2/run/adjoint.py
@@ -33,11 +33,11 @@
 #  Imports
 # ----------------------------------------------------------------------
 
-import os, sys, shutil, copy
+import copy
 
 from .. import io  as su2io
-from merge     import merge     as su2merge
-from interface import CFD       as SU2_CFD
+from .merge     import merge     as su2merge
+from .interface import CFD       as SU2_CFD
 
 # ----------------------------------------------------------------------
 #  Adjoint Simulation

--- a/SU2_PY/SU2/run/deform.py
+++ b/SU2_PY/SU2/run/deform.py
@@ -33,10 +33,10 @@
 #  Imports
 # ----------------------------------------------------------------------
 
-import os, sys, shutil, copy
+import copy
 
 from .. import io  as su2io
-from interface import DEF as SU2_DEF
+from .interface import DEF as SU2_DEF
 
 
 # ----------------------------------------------------------------------
@@ -72,7 +72,7 @@ def deform ( config, dv_new=None, dv_old=None ):
     if dv_old is None: dv_old = []
     
     # error check
-    if dv_old and not dv_new: raise Exception, 'must provide dv_old with dv_new'
+    if dv_old and not dv_new: raise Exception('must provide dv_old with dv_new')
     
     # local copy
     konfig = copy.deepcopy(config)

--- a/SU2_PY/SU2/run/direct.py
+++ b/SU2_PY/SU2/run/direct.py
@@ -33,11 +33,11 @@
 #  Imports
 # ----------------------------------------------------------------------
 
-import os, sys, shutil, copy
+import copy
 
 from .. import io  as su2io
-from merge     import merge     as su2merge
-from interface import CFD       as SU2_CFD
+from .merge     import merge     as su2merge
+from .interface import CFD       as SU2_CFD
 
 # ----------------------------------------------------------------------
 #  Direct Simulation

--- a/SU2_PY/SU2/run/geometry.py
+++ b/SU2_PY/SU2/run/geometry.py
@@ -33,10 +33,10 @@
 #  Imports
 # ----------------------------------------------------------------------
 
-import os, sys, shutil, copy
+import copy
 
 from .. import io  as su2io
-from interface import GEO       as SU2_GEO
+from .interface import GEO       as SU2_GEO
 from ..util import ordered_bunch
 
 # ----------------------------------------------------------------------

--- a/SU2_PY/SU2/run/interface.py
+++ b/SU2_PY/SU2/run/interface.py
@@ -266,7 +266,7 @@ def build_command( the_Command , processes=0 ):
     the_Command = base_Command % the_Command
     if processes > 1:
         if not mpi_Command:
-            raise RuntimeError , 'could not find an mpi interface'
+            raise RuntimeError('could not find an mpi interface')
         the_Command = mpi_Command % (processes,the_Command)
     return the_Command
 
@@ -285,14 +285,14 @@ def run_command( Command ):
     
     if return_code < 0:
         message = "SU2 process was terminated by signal '%s'\n%s" % (-return_code,message)
-        raise SystemExit , message
+        raise SystemExit(message)
     elif return_code > 0:
         message = "Path = %s\nCommand = %s\nSU2 process returned error '%s'\n%s" % (os.path.abspath(','),Command,return_code,message)
         if return_code in return_code_map.keys():
             exception = return_code_map[return_code]
         else:
             exception = RuntimeError
-        raise exception , message
+        raise exception(message)
     else:
         sys.stdout.write(message)
             

--- a/SU2_PY/SU2/run/merge.py
+++ b/SU2_PY/SU2/run/merge.py
@@ -24,8 +24,8 @@
 
 import os, sys, shutil, copy
 from .. import io  as su2io
-from interface import SOL as SU2_SOL
-from interface import SOL_FSI as SU2_SOL_FSI
+from .interface import SOL as SU2_SOL
+from .interface import SOL_FSI as SU2_SOL_FSI
 
 # ----------------------------------------------------------------------
 #  Merge Mesh

--- a/SU2_PY/SU2/run/projection.py
+++ b/SU2_PY/SU2/run/projection.py
@@ -37,7 +37,7 @@ import os, sys, shutil, copy
 
 from .. import io   as su2io
 from .. import util as su2util
-from interface import DOT as SU2_DOT
+from .interface import DOT as SU2_DOT
 
 
 # ----------------------------------------------------------------------

--- a/SU2_PY/SU2/util/__init__.py
+++ b/SU2_PY/SU2/util/__init__.py
@@ -1,8 +1,8 @@
-from switch        import switch
-from bunch         import Bunch        as bunch
-from ordered_dict  import OrderedDict  as ordered_dict
-from ordered_bunch import OrderedBunch as ordered_bunch
-from plot          import write_plot, tecplot, paraview
-from lhc_unif      import lhc_unif
-from mp_eval       import mp_eval
-from which         import which
+from .switch        import switch
+from .bunch         import Bunch        as bunch
+from .ordered_dict  import OrderedDict  as ordered_dict
+from .ordered_bunch import OrderedBunch as ordered_bunch
+from .plot          import write_plot, tecplot, paraview
+from .lhc_unif      import lhc_unif
+from .mp_eval       import mp_eval
+from .which         import which

--- a/SU2_PY/SU2/util/misc.py
+++ b/SU2_PY/SU2/util/misc.py
@@ -1,4 +1,6 @@
 
+import numpy as np
+
 def check_array(A,oned_as='row'):
     ''' ensures A is an array and at least of rank 2
     '''
@@ -11,6 +13,6 @@ def check_array(A,oned_as='row'):
         elif oned_as == 'col':
             A = A.T
         else:
-            raise Exception , "oned_as must be 'row' or 'col' "
+            raise Exception("oned_as must be 'row' or 'col' ")
             
     return A

--- a/SU2_PY/SU2/util/mp_eval.py
+++ b/SU2_PY/SU2/util/mp_eval.py
@@ -1,7 +1,11 @@
 import os
 import multiprocessing as mp
 import numpy as np
-from misc import check_array
+import sys
+
+if sys.version_info.major > 2:
+    # In Py3, range corresponds to Py2 xrange
+    xrange = range
 
 class mp_eval(object):
     
@@ -36,7 +40,7 @@ class mp_eval(object):
         elif isinstance(inputs,list):
             n_inputs = len(inputs)
         else:
-            raise Exception, 'unsupported input'
+            raise Exception('unsupported input')
         
         for i_input,this_input in enumerate(inputs):
             this_job = { 'index'  : i_input    ,

--- a/SU2_PY/SU2/util/ordered_bunch.py
+++ b/SU2_PY/SU2/util/ordered_bunch.py
@@ -26,7 +26,7 @@
     https://pypi.python.org/pypi/bunch
 """
 
-from ordered_dict import OrderedDict
+from ..util.ordered_dict import OrderedDict
 
 ## Compatability Issues...
 #try:

--- a/SU2_PY/SU2/util/ordered_dict.py
+++ b/SU2_PY/SU2/util/ordered_dict.py
@@ -7,7 +7,11 @@
 try:
     from thread import get_ident as _get_ident
 except ImportError:
-    from dummy_thread import get_ident as _get_ident
+    try:
+        from dummy_thread import get_ident as _get_ident
+    except ImportError:
+        # Python 3+
+        from _thread import get_ident as _get_ident
 
 try:
     from _abcoll import KeysView, ValuesView, ItemsView

--- a/SU2_PY/change_version_number.py
+++ b/SU2_PY/change_version_number.py
@@ -29,13 +29,22 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with SU2. If not, see <http://www.gnu.org/licenses/>.
 
+# make print(*args) function available in PY2.6+, does'nt work on PY < 2.6
+from __future__ import print_function
+
 # Run the script from the base directory (ie $SU2HOME). Grep will search directories recursively for matches in version number
 import os,sys
+
+if sys.version_info.major > 2:
+  # In PY3, raw_input is replaced with input.
+  # For original input behaviour, just write eval(input())
+  raw_input = input
 
 oldvers = '4.1.0 "Cardinal"'
 newvers = '4.1.1 "Cardinal"'
 
-os.system('rm -rf version.txt')
+if os.path.exists('version.txt'):
+  os.remove('version.txt')
 
 # Grep flag cheatsheet:
 # -I : Ignore binary files
@@ -43,6 +52,8 @@ os.system('rm -rf version.txt')
 # -w : Match whole word
 # -r : search directory recursively
 # -v : Omit search string (.svn omitted, line containing ISC is CGNS related)
+
+#TODO: replace with portable instructions. This works only on unix systems
 os.system("grep -IFwr '%s' *|grep -vF '.svn' |grep -v ISC > version.txt"%oldvers)
 
 # Create a list of files to adjust
@@ -53,14 +64,14 @@ for line in f.readlines():
   if not candidate in filelist and candidate.find(sys.argv[0])<0:
     filelist.append(candidate)
 f.close()
-print filelist
+print(filelist)
 
 # Prompt user before continuing 
 yorn = ''
 while(not yorn.lower()=='y'):
   yorn = raw_input('Replace %s with %s in the listed files? [Y/N]: '%(oldvers,newvers))
   if yorn.lower()=='n':
-    print 'The file version.txt contains matches of oldvers'
+    print('The file version.txt contains matches of oldvers')
     sys.exit()
 
 # Loop through and correct all files

--- a/SU2_PY/compute_polar.py
+++ b/SU2_PY/compute_polar.py
@@ -29,6 +29,9 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with SU2. If not, see <http://www.gnu.org/licenses/>.
 
+# make print(*args) function available in PY2.6+, does'nt work on PY < 2.6
+from __future__ import print_function
+
 # imports
 import numpy as np
 from optparse import OptionParser
@@ -90,7 +93,7 @@ for MachNumber in mach:
     # set angle of attack
     konfig.AoA = AngleAttack
     konfig.MACH_NUMBER = MachNumber
-    print 'Mach = ' , konfig.MACH_NUMBER , 'AoA = ' , konfig.AoA
+    print('Mach = ', konfig.MACH_NUMBER, 'AoA = ', konfig.AoA)
     
     # run su2
     drag = SU2.eval.func('DRAG',konfig,ztate)

--- a/SU2_PY/compute_stability.py
+++ b/SU2_PY/compute_stability.py
@@ -29,10 +29,11 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with SU2. If not, see <http://www.gnu.org/licenses/>.
 
+# make print(*args) function available in PY2.6+, does'nt work on PY < 2.6
+from __future__ import print_function
+
 # imports
-import numpy as np
 from optparse import OptionParser
-import os, sys, shutil, copy
 import SU2
 
 # Command Line Options
@@ -65,7 +66,7 @@ moment_y_alpha= SU2.eval.func('D_MOMENT_Z_D_ALPHA',config,state)
 
 grad_moment_y_alpha= SU2.eval.grad('D_MOMENT_Z_D_ALPHA','CONTINUOUS_ADJOINT',config,state)
 
-print 'D_DRAG_D_ALPHA     =' , drag_alpha
-print 'D_MOMENT_Y_D_ALPHA =' , moment_y_alpha
+print('D_DRAG_D_ALPHA     =' , drag_alpha)
+print('D_MOMENT_Y_D_ALPHA =' , moment_y_alpha)
 
-print 'DD_MOMENT_Y_D_ALPHA_D_X =', grad_moment_y_alpha
+print('DD_MOMENT_Y_D_ALPHA_D_X =', grad_moment_y_alpha)

--- a/SU2_PY/config_gui.py
+++ b/SU2_PY/config_gui.py
@@ -29,6 +29,9 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with SU2. If not, see <http://www.gnu.org/licenses/>.
 
+# make print(*args) function available in PY2.6+, does'nt work on PY < 2.6
+from __future__ import print_function
+
 from parse_config import *
 import wx, sys
 import wx.lib.scrolledpanel as sp
@@ -209,10 +212,10 @@ class config_gui(wx.Frame):
     self.SetInitialSize()
 
   def OnCheck(self,event):
-    print event
-    print dir(event)
-    print event.GetEventObject()
-    print event.GetEventObject().GetValue()
+    print(event)
+    print(dir(event))
+    print(event.GetEventObject())
+    print(event.GetEventObject().GetValue())
 
   def OnResize(self,event):
   # There is surely a better way to do this....
@@ -270,7 +273,7 @@ class config_gui(wx.Frame):
     sys.exit(1)
 
   def OnAbout(self,event):
-    print "OnAbout"
+    print("OnAbout")
 
   def list_click(self, event):
 

--- a/SU2_PY/continuous_adjoint.py
+++ b/SU2_PY/continuous_adjoint.py
@@ -29,7 +29,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with SU2. If not, see <http://www.gnu.org/licenses/>.
 
-import os, sys, shutil, copy
+import os, sys
 from optparse import OptionParser
 sys.path.append(os.environ['SU2_RUN'])
 import SU2

--- a/SU2_PY/direct_differentiation.py
+++ b/SU2_PY/direct_differentiation.py
@@ -29,7 +29,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with SU2. If not, see <http://www.gnu.org/licenses/>.
 
-import os, sys, shutil, copy
+import os, sys
 from optparse import OptionParser
 sys.path.append(os.environ['SU2_RUN'])
 import SU2

--- a/SU2_PY/discrete_adjoint.py
+++ b/SU2_PY/discrete_adjoint.py
@@ -29,7 +29,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with SU2. If not, see <http://www.gnu.org/licenses/>.
 
-import os, sys, shutil, copy
+import os, sys
 from optparse import OptionParser
 sys.path.append(os.environ['SU2_RUN'])
 import SU2

--- a/SU2_PY/downstream_function.py
+++ b/SU2_PY/downstream_function.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python 
 ## \file downstream_function.py
 
+# make print(*args) function available in PY2.6+, does'nt work on PY < 2.6
+from __future__ import print_function
 
-import os, sys, shutil, copy
+import os, sys
 import numpy as np
-from optparse import OptionParser
 sys.path.append(os.environ['SU2_RUN'])
 import SU2
 
@@ -15,7 +16,7 @@ def downstream_function(config, state ):
       nvar = nvar+1
   d_in = [0.0]*nvar
   obj = objective(config, state,d_in)
-  print " objective ", obj
+  print(" objective ", obj)
   return obj
 
 def objective(config, state, d_in ):

--- a/SU2_PY/finite_differences.py
+++ b/SU2_PY/finite_differences.py
@@ -29,7 +29,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with SU2. If not, see <http://www.gnu.org/licenses/>.
 
-import os, sys, shutil, copy
+import os, sys
 from optparse import OptionParser
 sys.path.append(os.environ['SU2_RUN'])
 import SU2

--- a/SU2_PY/merge_solution.py
+++ b/SU2_PY/merge_solution.py
@@ -29,8 +29,6 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with SU2. If not, see <http://www.gnu.org/licenses/>.
 
-
-import os, time, numpy, sys
 from optparse import OptionParser
 import SU2
 

--- a/SU2_PY/mesh_adaptation.py
+++ b/SU2_PY/mesh_adaptation.py
@@ -30,7 +30,6 @@
 # License along with SU2. If not, see <http://www.gnu.org/licenses/>.
 
 import SU2
-import os, time, sys, shutil
 from optparse import OptionParser
 
 # -------------------------------------------------------------------

--- a/SU2_PY/mesh_deformation.py
+++ b/SU2_PY/mesh_deformation.py
@@ -29,7 +29,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with SU2. If not, see <http://www.gnu.org/licenses/>.
 
-import os, sys, shutil, copy
+import os, sys
 from optparse import OptionParser
 sys.path.append(os.environ['SU2_RUN'])
 import SU2

--- a/SU2_PY/package_tests.py
+++ b/SU2_PY/package_tests.py
@@ -28,7 +28,10 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with SU2. If not, see <http://www.gnu.org/licenses/>.
 
-import os, sys, shutil, copy
+# make print(*args) function available in PY2.6+, does'nt work on PY < 2.6
+from __future__ import print_function
+
+import os, sys, copy
 sys.path.append(os.environ['SU2_RUN'])
 import SU2
 
@@ -70,7 +73,7 @@ def main():
     
     mesh0()
     
-    print 'DONE!'
+    print('DONE!')
     
 def io0():
     folder='test_io0'; pull='config_NACA0012.cfg'; link='mesh_NACA0012.su2'
@@ -79,8 +82,9 @@ def io0():
         config_name = 'config_NACA0012.cfg'
         config = SU2.io.Config(filename=config_name)
         
-        print config
-        
+        print(config)
+
+
         config.ADAPT_CYCLES
         config['ADAPT_CYCLES']
         
@@ -92,7 +96,7 @@ def io0():
         
         config_diff = config.diff(konfig)
         
-        print config_diff
+        print(config_diff)
         
     
     wait = 0
@@ -148,7 +152,7 @@ def level1():
         info = SU2.run.projection(config)
         state.update(info)
         
-        print state
+        print(state)
         
         SU2.io.save_data('state.pkl',state)
         data = SU2.io.load_data('state.pkl')
@@ -259,7 +263,7 @@ def level4():
         data = project.data
         
     wait = 0
-    print "Done!"
+    print("Done!")
     
 def level5():
     folder='test_level5'; pull='config_NACA0012.cfg'; link='mesh_NACA0012.su2'

--- a/SU2_PY/parallel_computation.py
+++ b/SU2_PY/parallel_computation.py
@@ -29,7 +29,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with SU2. If not, see <http://www.gnu.org/licenses/>.
 
-import os, sys, shutil, copy
+import os, sys
 from optparse import OptionParser
 sys.path.append(os.environ['SU2_RUN'])
 import SU2

--- a/SU2_PY/parse_config.py
+++ b/SU2_PY/parse_config.py
@@ -29,6 +29,9 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with SU2. If not, see <http://www.gnu.org/licenses/>.
 
+# make print(*args) function available in PY2.6+, does'nt work on PY < 2.6
+from __future__ import print_function
+
 import os,sys,xlwt
 
 # note: requires xlwt for spreadsheet output
@@ -51,13 +54,13 @@ class config_option:
     self.option_description = description
 
   def print_data(self):
-    print 'Option Name: %s '%        self.option_name
-    print 'Option Type: %s '%        self.option_type
-    print 'Option Category: %s '%    self.option_category
-    print 'Option values: ',         self.option_values
-    print 'Option default: %s'%      self.option_default
-    print 'Option description: %s '% self.option_description
-    print ''
+    print('Option Name: %s '%        self.option_name)
+    print('Option Type: %s '%        self.option_type)
+    print('Option Category: %s '%    self.option_category)
+    print('Option values: ',         self.option_values)
+    print('Option default: %s'%      self.option_default)
+    print('Option description: %s '% self.option_description)
+    print('')
 
 def parse_config(config_cpp, config_hpp):
 
@@ -114,7 +117,7 @@ def parse_config(config_cpp, config_hpp):
     # Check for a category description
     if line.find('CONFIG_CATEGORY')>-1:
       present_category = line.split(':')[1].strip().strip('*/').strip()
-      print present_category
+      print(present_category)
 
     # Check for an option type
     for option_type in option_types:
@@ -129,12 +132,12 @@ def parse_config(config_cpp, config_hpp):
             enum_mapname = line.split(',')[2].strip()
             values = enum_options[enum_mapname]
           except KeyError:
-            print "KeyError, key=%s"%enum_mapname 
-            print "enum_options: ",enum_options
+            print("KeyError, key=%s"%enum_mapname)
+            print("enum_options: ",enum_options)
             sys.exit(1)
           except TypeError:
-            print "TypeError, key=%s"%enum_mapname 
-            print "enum_options: ",enum_options
+            print("TypeError, key=%s"%enum_mapname)
+            print("enum_options: ",enum_options)
             sys.exit(1)
         elif option_type=='AddMathProblem':
           values = ['DIRECT','CONTINUOUS_ADJOINT','LINEARIZED']
@@ -148,7 +151,7 @@ def parse_config(config_cpp, config_hpp):
           values = ['List']
         elif option_type == 'AddConvectOption':
           values = scheme_list
-          print "Convect Option: ", name
+          print("Convect Option: ", name)
         elif option_type == 'AddEnumListOption':
           values = ['Enum list'] 
         elif option_type == 'AddDVParamOption':

--- a/SU2_PY/patient_designspace.py
+++ b/SU2_PY/patient_designspace.py
@@ -29,7 +29,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with SU2. If not, see <http://www.gnu.org/licenses/>.
 
-import os, sys, numpy, time, shutil, glob, traceback
+import os, sys, time
 from optparse import OptionParser
 sys.path.append(os.environ['SU2_RUN'])
 import SU2
@@ -84,11 +84,3 @@ def main():
 # this is only accessed if running from command prompt
 if __name__ == '__main__':
     main()
-    
-    
-    
-    
-
-
-
-

--- a/SU2_PY/set_ffd_design_var.py
+++ b/SU2_PY/set_ffd_design_var.py
@@ -30,7 +30,9 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with SU2. If not, see <http://www.gnu.org/licenses/>.
 
-import os, time
+# make print(*args) function available in PY2.6+, does'nt work on PY < 2.6
+from __future__ import print_function
+
 from optparse import OptionParser
 from numpy import *
 
@@ -73,8 +75,8 @@ options.zMove = float(options.zMove)
 
 if options.dim == 3:
   
-  print " "
-  print "FFD_CONTROL_POINT"
+  print(" ")
+  print("FFD_CONTROL_POINT")
 
   iVariable = 0
   dvList = "DEFINITION_DV= "
@@ -88,10 +90,10 @@ if options.dim == 3:
           dvList = dvList + "; "
 
 
-  print dvList
+  print(dvList)
 
-  print " "
-  print "FFD_CAMBER & FFD_THICKNESS"
+  print(" ")
+  print("FFD_CAMBER & FFD_THICKNESS")
 
   iVariable = 0
   dvList = "DEFINITION_DV= "
@@ -110,7 +112,7 @@ if options.dim == 3:
       if iVariable < (options.iOrder*(options.jOrder)):
         dvList = dvList + "; "
 
-  print dvList
+  print(dvList)
 
 if options.dim == 2:
 
@@ -124,10 +126,10 @@ if options.dim == 2:
       if iVariable < (options.iOrder*options.jOrder):
         dvList = dvList + "; "
 
-  print dvList
+  print(dvList)
 
-  print " "
-  print "FFD_CAMBER & FFD_THICKNESS"
+  print(" ")
+  print("FFD_CAMBER & FFD_THICKNESS")
 
   iVariable = 0
   dvList = "DEFINITION_DV= "
@@ -144,9 +146,4 @@ if options.dim == 2:
     if iVariable < (options.iOrder):
       dvList = dvList + "; "
 
-  print dvList
-
-
-
-
-
+  print(dvList)

--- a/SU2_PY/shape_optimization.py
+++ b/SU2_PY/shape_optimization.py
@@ -29,7 +29,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with SU2. If not, see <http://www.gnu.org/licenses/>.
 
-import os, sys, shutil, copy
+import os, sys, shutil
 from optparse import OptionParser
 sys.path.append(os.environ['SU2_RUN'])
 import SU2


### PR DESCRIPTION
Main changes from python 2 to python 3 are:
'raise Exception "message"'  ->  'raise Exception("message")'
print "message"  -> print("message")
long, int  ->  int
raw_input  -> input
cPickle  ->  pickle

input  -> eval(input()) # not used in SU2, just for information

This commit also removes unused import, especially import of os, shutil and copy

Useful links:
  - https://docs.python.org/3/howto/pyporting.html
  - http://python3porting.com
  - https://docs.python.org/3/whatsnew/3.0.html#library-changes, 4th item.