### PR TITLE
Major update in grid deformation subroutines

### DIFF
--- a/Common/include/config_structure.hpp
+++ b/Common/include/config_structure.hpp
@@ -418,6 +418,7 @@ private:
   unsigned short Deform_Stiffness_Type; /*!< \brief Type of element stiffness imposed for FEA mesh deformation. */
   bool Deform_Output;  /*!< \brief Print the residuals during mesh deformation to the console. */
   su2double Deform_Tol_Factor; /*!< Factor to multiply smallest volume for deform tolerance (0.001 default) */
+  su2double Deform_Coeff; /*!< Deform coeffienct */
   unsigned short Deform_Linear_Solver; /*!< Numerical method to deform the grid */
   unsigned short FFD_Continuity; /*!< Surface continuity at the intersection with the FFD */
   su2double Deform_ElasticityMod, Deform_PoissonRatio; /*!< young's modulus and poisson ratio for volume deformation stiffness model */
@@ -2904,6 +2905,12 @@ public:
 	 * \return Factor to multiply smallest volume for deform tolerance.
 	 */
 	su2double GetDeform_Tol_Factor(void);
+  
+  /*!
+   * \brief Get factor to multiply smallest volume for deform tolerance.
+   * \return Factor to multiply smallest volume for deform tolerance.
+   */
+  su2double GetDeform_Coeff(void);
 
   /*!
    * \brief Get Young's modulus for deformation (constant stiffness deformation)

--- a/Common/include/config_structure.inl
+++ b/Common/include/config_structure.inl
@@ -610,6 +610,8 @@ inline bool CConfig::GetDeform_Output(void) { return Deform_Output; }
 
 inline su2double CConfig::GetDeform_Tol_Factor(void) { return Deform_Tol_Factor; }
 
+inline su2double CConfig::GetDeform_Coeff(void) { return Deform_Coeff; }
+
 inline su2double CConfig::GetDeform_ElasticityMod(void) { return Deform_ElasticityMod; }
 
 inline su2double CConfig::GetDeform_PoissonRatio(void) { return Deform_PoissonRatio; }

--- a/Common/include/grid_movement_structure.hpp
+++ b/Common/include/grid_movement_structure.hpp
@@ -797,29 +797,31 @@ public:
 	su2double SetFEAMethodContributions_Elem(CGeometry *geometry, CConfig *config);
   
   /*!
-	 * \brief Build the stiffness matrix for a 3-D hexahedron element. The result will be placed in StiffMatrix_Elem.
-	 * \param[in] geometry - Geometrical definition of the problem.
-	 * \param[in] config - Definition of the particular problem.
+   * \brief Build the stiffness matrix for a 3-D hexahedron element. The result will be placed in StiffMatrix_Elem.
+   * \param[in] geometry - Geometrical definition of the problem.
+   * \param[in] config - Definition of the particular problem.
    * \param[in] StiffMatrix_Elem - Element stiffness matrix to be filled.
-	 * \param[in] CoordCorners - Index value for Node 1 of the current hexahedron.
+   * \param[in] CoordCorners - Index value for Node 1 of the current hexahedron.
    * \param[in] PointCorners - Index values for element corners
    * \param[in] nNodes - Number of nodes defining the element.
    * \param[in] scale
-	 */
-  void SetFEA_StiffMatrix3D(CGeometry *geometry, CConfig *config, su2double **StiffMatrix_Elem, unsigned long PointCorners[8], su2double CoordCorners[8][3], unsigned short nNodes, su2double scale);
-	
-  /*!
-	 * \brief Build the stiffness matrix for a 3-D hexahedron element. The result will be placed in StiffMatrix_Elem.
-	 * \param[in] geometry - Geometrical definition of the problem.
-	 * \param[in] config - Definition of the particular problem.
-   * \param[in] StiffMatrix_Elem - Element stiffness matrix to be filled.
-	 * \param[in] CoordCorners - Index value for Node 1 of the current hexahedron.
-   * \param[in] PointCorners - Index values for element corners
-   * \param[in] nNodes - Number of nodes defining the element.
-   * \param[in] scale
-	 */
-  void SetFEA_StiffMatrix2D(CGeometry *geometry, CConfig *config, su2double **StiffMatrix_Elem, unsigned long PointCorners[8], su2double CoordCorners[8][3], unsigned short nNodes, su2double scale);
+   */
+  void SetFEA_StiffMatrix3D(CGeometry *geometry, CConfig *config, su2double **StiffMatrix_Elem, unsigned long PointCorners[8], su2double CoordCorners[8][3],
+                            unsigned short nNodes, su2double ElemVolume, su2double ElemDistance);
   
+  /*!
+   * \brief Build the stiffness matrix for a 3-D hexahedron element. The result will be placed in StiffMatrix_Elem.
+   * \param[in] geometry - Geometrical definition of the problem.
+   * \param[in] config - Definition of the particular problem.
+   * \param[in] StiffMatrix_Elem - Element stiffness matrix to be filled.
+   * \param[in] CoordCorners - Index value for Node 1 of the current hexahedron.
+   * \param[in] PointCorners - Index values for element corners
+   * \param[in] nNodes - Number of nodes defining the element.
+   * \param[in] scale
+   */
+  void SetFEA_StiffMatrix2D(CGeometry *geometry, CConfig *config, su2double **StiffMatrix_Elem, unsigned long PointCorners[8], su2double CoordCorners[8][3],
+                            unsigned short nNodes, su2double ElemVolume, su2double ElemDistance);
+    
   /*!
 	 * \brief Shape functions and derivative of the shape functions
    * \param[in] Xi - Local coordinates.
@@ -927,15 +929,16 @@ public:
 	 * \brief Check for negative volumes (all elements) after performing grid deformation.
 	 * \param[in] geometry - Geometrical definition of the problem.
 	 */
-	su2double Check_Grid(CGeometry *geometry);
+  void ComputeDeforming_Element_Volume(CGeometry *geometry, su2double &MinVolume, su2double &MaxVolume);
+  
   
   /*!
 	 * \brief Compute the minimum distance to the nearest deforming surface.
 	 * \param[in] geometry - Geometrical definition of the problem.
    * \param[in] config - Definition of the particular problem.
 	 */
-  void ComputeDeforming_Wall_Distance(CGeometry *geometry, CConfig *config);
-  
+  void ComputeDeforming_Wall_Distance(CGeometry *geometry, CConfig *config, su2double &MinDistance, su2double &MaxDistance);
+    
 	/*!
 	 * \brief Check the boundary vertex that are going to be moved.
 	 * \param[in] geometry - Geometrical definition of the problem.

--- a/Common/include/primal_grid_structure.hpp
+++ b/Common/include/primal_grid_structure.hpp
@@ -62,7 +62,8 @@ protected:
                                  correspond with a boundary element is stored. */
 	bool Divide;                  /*!< \brief Marker used to know if we are going to divide this element
                                  in the adaptation proccess. */
-  
+  su2double Volume;    /*!< \brief Volume of the element. */
+
 public:
 	
 	/*!
@@ -109,7 +110,20 @@ public:
 	 * \return Coordinates of the center of gravity.
 	 */
 	su2double GetCG(unsigned short val_dim);
-	
+		
+  /*!
+   * \brief Set the center of gravity of an element (including edges).
+   * \param[in] val_coord - Coordinates of the element.
+   */
+  void SetVolume(su2double val_volume);
+  
+  /*!
+   * \brief Get the center of gravity of an element (including edges).
+   * \param[in] val_dim - Coordinate of the center of gravity.
+   * \return Coordinates of the center of gravity.
+   */
+  su2double GetVolume(void);
+
 	/*!
 	 * \brief Get the CG of a face of an element.
 	 * \param[in] val_face - Local index of the face.

--- a/Common/include/primal_grid_structure.inl
+++ b/Common/include/primal_grid_structure.inl
@@ -45,6 +45,10 @@ inline void CPrimalGrid::SetNeighbor_Elements(unsigned long val_elem, unsigned s
 
 inline long CPrimalGrid::GetNeighbor_Elements(unsigned short val_face) { return Neighbor_Elements[val_face]; }
 
+inline su2double CPrimalGrid::GetVolume(void) { return Volume; }
+
+inline void CPrimalGrid::SetVolume(su2double val_volume) { Volume = val_volume; }
+
 inline su2double CPrimalGrid::GetCG(unsigned short val_dim) { return Coord_CG[val_dim]; }
 
 inline su2double CPrimalGrid::GetFaceCG(unsigned short val_face, unsigned short val_dim) { return Coord_FaceElems_CG[val_face][val_dim]; }

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -1109,17 +1109,17 @@ void CConfig::SetConfig_Options(unsigned short val_iZone, unsigned short val_nZo
 	/* DESCRIPTION: Visualize the deformation */
   addBoolOption("VISUALIZE_DEFORMATION", Visualize_Deformation, false);
   /* DESCRIPTION: Print the residuals during mesh deformation to the console */
-  addBoolOption("DEFORM_CONSOLE_OUTPUT", Deform_Output, false);
+  addBoolOption("DEFORM_CONSOLE_OUTPUT", Deform_Output, true);
   /* DESCRIPTION: Number of nonlinear deformation iterations (surface deformation increments) */
-  addUnsignedLongOption("DEFORM_NONLINEAR_ITER", GridDef_Nonlinear_Iter, 2);
+  addUnsignedLongOption("DEFORM_NONLINEAR_ITER", GridDef_Nonlinear_Iter, 1);
   /* DESCRIPTION: Number of smoothing iterations for FEA mesh deformation */
-  addUnsignedLongOption("DEFORM_LINEAR_ITER", GridDef_Linear_Iter, 500);
+  addUnsignedLongOption("DEFORM_LINEAR_ITER", GridDef_Linear_Iter, 1000);
   /* DESCRIPTION: Factor to multiply smallest volume for deform tolerance (0.001 default) */
-  addDoubleOption("DEFORM_TOL_FACTOR", Deform_Tol_Factor, 0.001);
+  addDoubleOption("DEFORM_TOL_FACTOR", Deform_Tol_Factor, 1E-6);
   /* DESCRIPTION: Deform coefficient (-1.0 to 0.5) */
   addDoubleOption("DEFORM_COEFF", Deform_Coeff, 1E6);
   /* DESCRIPTION: Type of element stiffness imposed for FEA mesh deformation (INVERSE_VOLUME, WALL_DISTANCE, CONSTANT_STIFFNESS) */
-  addEnumOption("DEFORM_STIFFNESS_TYPE", Deform_Stiffness_Type, Deform_Stiffness_Map, INVERSE_VOLUME);
+  addEnumOption("DEFORM_STIFFNESS_TYPE", Deform_Stiffness_Type, Deform_Stiffness_Map, WALL_DISTANCE);
   /* DESCRIPTION: Poisson's ratio for constant stiffness FEA method of grid deformation*/
   addDoubleOption("DEFORM_ELASTICITY_MODULUS", Deform_ElasticityMod, 2E11);
   /* DESCRIPTION: Young's modulus and Poisson's ratio for constant stiffness FEA method of grid deformation*/

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -1116,6 +1116,8 @@ void CConfig::SetConfig_Options(unsigned short val_iZone, unsigned short val_nZo
   addUnsignedLongOption("DEFORM_LINEAR_ITER", GridDef_Linear_Iter, 500);
   /* DESCRIPTION: Factor to multiply smallest volume for deform tolerance (0.001 default) */
   addDoubleOption("DEFORM_TOL_FACTOR", Deform_Tol_Factor, 0.001);
+  /* DESCRIPTION: Deform coefficient (-1.0 to 0.5) */
+  addDoubleOption("DEFORM_COEFF", Deform_Coeff, 1E6);
   /* DESCRIPTION: Type of element stiffness imposed for FEA mesh deformation (INVERSE_VOLUME, WALL_DISTANCE, CONSTANT_STIFFNESS) */
   addEnumOption("DEFORM_STIFFNESS_TYPE", Deform_Stiffness_Type, Deform_Stiffness_Map, INVERSE_VOLUME);
   /* DESCRIPTION: Poisson's ratio for constant stiffness FEA method of grid deformation*/

--- a/Common/src/grid_movement_structure.cpp
+++ b/Common/src/grid_movement_structure.cpp
@@ -524,7 +524,6 @@ void CVolumetricMovement::ComputeDeforming_Wall_Distance(CGeometry *geometry, CC
     if (((config->GetMarker_All_Moving(iMarker) == YES) && (Kind_SU2 == SU2_CFD)) ||
         ((config->GetMarker_All_DV(iMarker) == YES) && (Kind_SU2 == SU2_DOT)) ||
         ((config->GetMarker_All_DV(iMarker) == YES) && (Kind_SU2 == SU2_DEF)))
-      if (config->GetMarker_All_KindBC(iMarker) != INTERNAL_BOUNDARY)
         for (iVertex = 0; iVertex < geometry->GetnVertex(iMarker); iVertex++) {
           iPoint = geometry->vertex[iMarker][iVertex]->GetNode();
           for (iDim = 0; iDim < nDim; iDim++)
@@ -650,11 +649,6 @@ su2double CVolumetricMovement::SetFEAMethodContributions_Elem(CGeometry *geometr
     AddFEA_StiffMatrix(geometry, StiffMatrix_Elem, PointCorners, nNodes);
     
 	}
-  
-#ifdef HAVE_MPI
-  unsigned long ElemCounter_Local = ElemCounter; ElemCounter = 0;
-  SU2_MPI::Allreduce(&ElemCounter_Local, &ElemCounter, 1, MPI_UNSIGNED_LONG, MPI_SUM, MPI_COMM_WORLD);
-#endif
   
   /*--- Deallocate memory and exit ---*/
   

--- a/Common/src/grid_movement_structure.cpp
+++ b/Common/src/grid_movement_structure.cpp
@@ -116,7 +116,7 @@ void CVolumetricMovement::UpdateMultiGrid(CGeometry **geometry, CConfig *config)
 void CVolumetricMovement::SetVolume_Deformation(CGeometry *geometry, CConfig *config, bool UpdateGeo, bool Derivative) {
   
   unsigned long IterLinSol = 0, Smoothing_Iter, iNonlinear_Iter, MaxIter = 0, RestartIter = 50, Tot_Iter = 0, Nonlinear_Iter = 0;
-  su2double MinVolume, NumError, Tol_Factor, Residual = 0.0, Residual_Init = 0.0;
+  su2double MinVolume, MaxVolume, NumError, Tol_Factor, Residual = 0.0, Residual_Init = 0.0;
   bool Screen_Output;
   
   int rank = MASTER_NODE;
@@ -284,15 +284,14 @@ void CVolumetricMovement::SetVolume_Deformation(CGeometry *geometry, CConfig *co
     
     /*--- Check for failed deformation (negative volumes). ---*/
     
-    MinVolume = Check_Grid(geometry);
+    ComputeDeforming_Element_Volume(geometry, MinVolume, MaxVolume);
     
     /*--- Set number of iterations in the mesh update. ---*/
 
     Set_nIterMesh(Tot_Iter);
 
     if (rank == MASTER_NODE) {
-      cout << "Non-linear iter.: " << iNonlinear_Iter+1 << "/" << Nonlinear_Iter
-      << ". Linear iter.: " << Tot_Iter << ". ";
+      cout << "Non-linear iter.: " << iNonlinear_Iter+1 << "/" << Nonlinear_Iter  << ". Linear iter.: " << Tot_Iter << ". ";
       if (nDim == 2) cout << "Min. area: " << MinVolume << ". Error: " << Residual << "." << endl;
       else cout << "Min. volume: " << MinVolume << ". Error: " << Residual << "." << endl;
     }
@@ -302,22 +301,27 @@ void CVolumetricMovement::SetVolume_Deformation(CGeometry *geometry, CConfig *co
 
 }
 
-su2double CVolumetricMovement::Check_Grid(CGeometry *geometry) {
+void CVolumetricMovement::ComputeDeforming_Element_Volume(CGeometry *geometry, su2double &MinVolume, su2double &MaxVolume) {
   
-	unsigned long iElem, ElemCounter = 0, PointCorners[8];
-  su2double Area = 0.0, Volume = 0.0, MaxArea = -1E22, MaxVolume = -1E22, MinArea = 1E22, MinVolume = 1E22, CoordCorners[8][3];
+  unsigned long iElem, ElemCounter = 0, PointCorners[8];
+  su2double Volume = 0.0, CoordCorners[8][3];
   unsigned short nNodes = 0, iNodes, iDim;
   bool RightVol = true;
   
   int rank = MASTER_NODE;
   
 #ifdef HAVE_MPI
-	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 #endif
   
-	/*--- Load up each triangle and tetrahedron to check for negative volumes. ---*/
+  if (rank == MASTER_NODE)
+    cout << "Computing volumes of the grid elements." << endl;
   
-	for (iElem = 0; iElem < geometry->GetnElem(); iElem++) {
+  MaxVolume = -1E22; MinVolume = 1E22;
+  
+  /*--- Load up each triangle and tetrahedron to check for negative volumes. ---*/
+  
+  for (iElem = 0; iElem < geometry->GetnElem(); iElem++) {
     
     if (geometry->elem[iElem]->GetVTK_Type() == TRIANGLE)     nNodes = 3;
     if (geometry->elem[iElem]->GetVTK_Type() == QUADRILATERAL)    nNodes = 4;
@@ -333,41 +337,32 @@ su2double CVolumetricMovement::Check_Grid(CGeometry *geometry) {
       }
     }
     
-    /*--- Triangles ---*/
+    /*--- 2D elements ---*/
     
     if (nDim == 2) {
-      
-      if (nNodes == 3) Area = GetTriangle_Area(CoordCorners);
-      if (nNodes == 4) Area = GetQuadrilateral_Area(CoordCorners);
-      
-      if (Area >= -EPS) RightVol = true;
-      else RightVol = false;;
-      
-      MaxArea = max(MaxArea, Area);
-      MinArea = min(MinArea, Area);
-      
+      if (nNodes == 3) Volume = GetTriangle_Area(CoordCorners);
+      if (nNodes == 4) Volume = GetQuadrilateral_Area(CoordCorners);
     }
     
-    /*--- Tetrahedra ---*/
+    /*--- 3D Elementes ---*/
     
     if (nDim == 3) {
-      
       if (nNodes == 4) Volume = GetTetra_Volume(CoordCorners);
       if (nNodes == 5) Volume = GetPyram_Volume(CoordCorners);
       if (nNodes == 6) Volume = GetPrism_Volume(CoordCorners);
       if (nNodes == 8) Volume = GetHexa_Volume(CoordCorners);
-      
-      if (Volume >= -EPS) RightVol = true;
-      else RightVol = false;;
-      
-      MaxVolume = max(MaxVolume, Volume);
-      MinVolume = min(MinVolume, Volume);
-      
     }
+    
+    RightVol = true;
+    if (Volume < 0.0) RightVol = false;
+    
+    MaxVolume = max(MaxVolume, Volume);
+    MinVolume = min(MinVolume, Volume);
+    geometry->elem[iElem]->SetVolume(Volume);
     
     if (!RightVol) ElemCounter++;
     
-	}
+  }
   
 #ifdef HAVE_MPI
   unsigned long ElemCounter_Local = ElemCounter; ElemCounter = 0;
@@ -378,15 +373,19 @@ su2double CVolumetricMovement::Check_Grid(CGeometry *geometry) {
   SU2_MPI::Allreduce(&MinVolume_Local, &MinVolume, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
 #endif
   
+  /*--- Volume from  0 to 1 ---*/
+  
+  for (iElem = 0; iElem < geometry->GetnElem(); iElem++) {
+    Volume = geometry->elem[iElem]->GetVolume()/MaxVolume;
+    geometry->elem[iElem]->SetVolume(Volume);
+  }
+  
   if ((ElemCounter != 0) && (rank == MASTER_NODE))
     cout <<"There are " << ElemCounter << " elements with negative volume.\n" << endl;
   
-  if (nDim == 2) return MinArea;
-  else return MinVolume;
-  
 }
 
-void CVolumetricMovement::ComputeDeforming_Wall_Distance(CGeometry *geometry, CConfig *config) {
+void CVolumetricMovement::ComputeDeforming_Wall_Distance(CGeometry *geometry, CConfig *config, su2double &MinDistance, su2double &MaxDistance) {
   
   su2double *coord, dist2, dist;
   unsigned short iDim, iMarker;
@@ -396,6 +395,10 @@ void CVolumetricMovement::ComputeDeforming_Wall_Distance(CGeometry *geometry, CC
 #ifdef HAVE_MPI
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 #endif
+  
+  MaxDistance = -1E22; MinDistance = 1E22;
+  
+  
   if (rank == MASTER_NODE)
     cout << "Computing distances to the nearest deforming surface." << endl;
   
@@ -412,6 +415,7 @@ void CVolumetricMovement::ComputeDeforming_Wall_Distance(CGeometry *geometry, CC
   nVertex_SolidWall = 0;
   for (iMarker = 0; iMarker < config->GetnMarker_All(); iMarker++)
     if (((config->GetMarker_All_Moving(iMarker) == YES) && (Kind_SU2 == SU2_CFD)) ||
+        ((config->GetMarker_All_DV(iMarker) == YES) && (Kind_SU2 == SU2_DOT)) ||
         ((config->GetMarker_All_DV(iMarker) == YES) && (Kind_SU2 == SU2_DEF)))
       nVertex_SolidWall += geometry->GetnVertex(iMarker);
   
@@ -427,13 +431,14 @@ void CVolumetricMovement::ComputeDeforming_Wall_Distance(CGeometry *geometry, CC
   nVertex_SolidWall = 0;
   for (iMarker = 0; iMarker < config->GetnMarker_All(); iMarker++) {
     if (((config->GetMarker_All_Moving(iMarker) == YES) && (Kind_SU2 == SU2_CFD)) ||
+        ((config->GetMarker_All_DV(iMarker) == YES) && (Kind_SU2 == SU2_DOT)) ||
         ((config->GetMarker_All_DV(iMarker) == YES) && (Kind_SU2 == SU2_DEF)))
-      for (iVertex = 0; iVertex < geometry->GetnVertex(iMarker); iVertex++) {
-        iPoint = geometry->vertex[iMarker][iVertex]->GetNode();
-        for (iDim = 0; iDim < nDim; iDim++)
-          Coord_bound[nVertex_SolidWall][iDim] = geometry->node[iPoint]->GetCoord(iDim);
-        nVertex_SolidWall++;
-      }
+        for (iVertex = 0; iVertex < geometry->GetnVertex(iMarker); iVertex++) {
+          iPoint = geometry->vertex[iMarker][iVertex]->GetNode();
+          for (iDim = 0; iDim < nDim; iDim++)
+            Coord_bound[nVertex_SolidWall][iDim] = geometry->node[iPoint]->GetCoord(iDim);
+          nVertex_SolidWall++;
+        }
   }
   
   /*--- Loop over all interior mesh nodes and compute the distances to each
@@ -446,11 +451,21 @@ void CVolumetricMovement::ComputeDeforming_Wall_Distance(CGeometry *geometry, CC
     for (iVertex = 0; iVertex < nVertex_SolidWall; iVertex++) {
       dist2 = 0.0;
       for (iDim = 0; iDim < nDim; iDim++)
-        dist2 += (coord[iDim]-Coord_bound[iVertex][iDim])
-        *(coord[iDim]-Coord_bound[iVertex][iDim]);
+        dist2 += (coord[iDim]-Coord_bound[iVertex][iDim]) *(coord[iDim]-Coord_bound[iVertex][iDim]);
       if (dist2 < dist) dist = dist2;
     }
+    
+    MaxDistance = max(MaxDistance, sqrt(dist));
+    if (sqrt(dist)> EPS) MinDistance = min(MinDistance, sqrt(dist));
+    
     geometry->node[iPoint]->SetWall_Distance(sqrt(dist));
+  }
+  
+  /*--- Distance from  0 to 1 ---*/
+  
+  for (iPoint = 0; iPoint < geometry->GetnPoint(); iPoint++) {
+    dist = geometry->node[iPoint]->GetWall_Distance()/MaxDistance;
+    geometry->node[iPoint]->SetWall_Distance(dist);
   }
   
   /*--- Deallocate the vector of boundary coordinates. ---*/
@@ -465,6 +480,7 @@ void CVolumetricMovement::ComputeDeforming_Wall_Distance(CGeometry *geometry, CC
   /*--- Variables and buffers needed for MPI ---*/
   
   int iProcessor, nProcessor;
+  
   MPI_Comm_size(MPI_COMM_WORLD, &nProcessor);
   
   unsigned long nLocalVertex_NS = 0, nGlobalVertex_NS = 0, MaxLocalVertex_NS = 0;
@@ -476,6 +492,7 @@ void CVolumetricMovement::ComputeDeforming_Wall_Distance(CGeometry *geometry, CC
   
   for (iMarker = 0; iMarker < config->GetnMarker_All(); iMarker++)
     if (((config->GetMarker_All_Moving(iMarker) == YES) && (Kind_SU2 == SU2_CFD)) ||
+        ((config->GetMarker_All_DV(iMarker) == YES) && (Kind_SU2 == SU2_DOT)) ||
         ((config->GetMarker_All_DV(iMarker) == YES) && (Kind_SU2 == SU2_DEF)))
       nLocalVertex_NS += geometry->GetnVertex(iMarker);
   
@@ -505,14 +522,16 @@ void CVolumetricMovement::ComputeDeforming_Wall_Distance(CGeometry *geometry, CC
   nVertex_SolidWall = 0;
   for (iMarker = 0; iMarker < config->GetnMarker_All(); iMarker++)
     if (((config->GetMarker_All_Moving(iMarker) == YES) && (Kind_SU2 == SU2_CFD)) ||
+        ((config->GetMarker_All_DV(iMarker) == YES) && (Kind_SU2 == SU2_DOT)) ||
         ((config->GetMarker_All_DV(iMarker) == YES) && (Kind_SU2 == SU2_DEF)))
-      for (iVertex = 0; iVertex < geometry->GetnVertex(iMarker); iVertex++) {
-        iPoint = geometry->vertex[iMarker][iVertex]->GetNode();
-        for (iDim = 0; iDim < nDim; iDim++)
-          Buffer_Send_Coord[nVertex_SolidWall*nDim+iDim] = geometry->node[iPoint]->GetCoord(iDim);
-        nVertex_SolidWall++;
-      }
-
+      if (config->GetMarker_All_KindBC(iMarker) != INTERNAL_BOUNDARY)
+        for (iVertex = 0; iVertex < geometry->GetnVertex(iMarker); iVertex++) {
+          iPoint = geometry->vertex[iMarker][iVertex]->GetNode();
+          for (iDim = 0; iDim < nDim; iDim++)
+            Buffer_Send_Coord[nVertex_SolidWall*nDim+iDim] = geometry->node[iPoint]->GetCoord(iDim);
+          nVertex_SolidWall++;
+        }
+  
   SU2_MPI::Allgather(Buffer_Send_Coord, nBuffer, MPI_DOUBLE, Buffer_Receive_Coord, nBuffer, MPI_DOUBLE, MPI_COMM_WORLD);
   
   /*--- Loop over all interior mesh nodes on the local partition and compute
@@ -528,9 +547,26 @@ void CVolumetricMovement::ComputeDeforming_Wall_Distance(CGeometry *geometry, CC
         for (iDim = 0; iDim < nDim; iDim++)
           dist2 += (coord[iDim]-Buffer_Receive_Coord[(iProcessor*MaxLocalVertex_NS+iVertex)*nDim+iDim])*
           (coord[iDim]-Buffer_Receive_Coord[(iProcessor*MaxLocalVertex_NS+iVertex)*nDim+iDim]);
+        
         if (dist2 < dist) dist = dist2;
       }
+    
+    MaxDistance = max(MaxDistance, sqrt(dist));
+    if (sqrt(dist)> EPS)  MinDistance = min(MinDistance, sqrt(dist));
+    
     geometry->node[iPoint]->SetWall_Distance(sqrt(dist));
+  }
+  
+  su2double MaxDistance_Local = MaxDistance; MaxDistance = 0.0;
+  su2double MinDistance_Local = MinDistance; MinDistance = 0.0;
+  SU2_MPI::Allreduce(&MaxDistance_Local, &MaxDistance, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+  SU2_MPI::Allreduce(&MinDistance_Local, &MinDistance, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
+  
+  /*--- Distance from  0 to 1 ---*/
+  
+  for (iPoint = 0; iPoint < geometry->GetnPoint(); iPoint++) {
+    dist = geometry->node[iPoint]->GetWall_Distance()/MaxDistance;
+    geometry->node[iPoint]->SetWall_Distance(dist);
   }
   
   /*--- Deallocate the buffers needed for the MPI communication. ---*/
@@ -541,15 +577,20 @@ void CVolumetricMovement::ComputeDeforming_Wall_Distance(CGeometry *geometry, CC
   delete[] Buffer_Receive_nVertex;
   
 #endif
-
+  
 }
 
 su2double CVolumetricMovement::SetFEAMethodContributions_Elem(CGeometry *geometry, CConfig *config) {
   
-	unsigned short iVar, iDim, nNodes = 0, iNodes, StiffMatrix_nElem = 0;
-	unsigned long Point_0, Point_1, iElem, iEdge, ElemCounter = 0, PointCorners[8];
-  su2double *Coord_0, *Coord_1, Length, MinLength = 1E10, **StiffMatrix_Elem = NULL, Scale, CoordCorners[8][3];
-  su2double *Edge_Vector = new su2double [nDim];
+  unsigned short iVar, iDim, nNodes = 0, iNodes, StiffMatrix_nElem = 0;
+  unsigned long iElem, PointCorners[8];
+  su2double **StiffMatrix_Elem = NULL, CoordCorners[8][3];
+  su2double MinVolume = 0.0, MaxVolume = 0.0, MinDistance = 0.0, MaxDistance = 0.0, ElemVolume = 0.0, ElemDistance = 0.0;
+  
+  int rank = MASTER_NODE;
+#ifdef HAVE_MPI
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+#endif
   
   /*--- Allocate maximum size (quadrilateral and hexahedron) ---*/
   
@@ -560,50 +601,30 @@ su2double CVolumetricMovement::SetFEAMethodContributions_Elem(CGeometry *geometr
   for (iVar = 0; iVar < StiffMatrix_nElem; iVar++)
     StiffMatrix_Elem[iVar] = new su2double [StiffMatrix_nElem];
   
-  /*--- Check the minimum edge length in the entire mesh. ---*/
-  
-	for (iEdge = 0; iEdge < geometry->GetnEdge(); iEdge++) {
-    
-		/*--- Points in edge and coordinates ---*/
-    
-		Point_0 = geometry->edge[iEdge]->GetNode(0);  Coord_0 = geometry->node[Point_0]->GetCoord();
-		Point_1 = geometry->edge[iEdge]->GetNode(1);  Coord_1 = geometry->node[Point_1]->GetCoord();
-    
-		/*--- Compute Edge_Vector ---*/
-    
-		Length = 0.0;
-		for (iDim = 0; iDim < nDim; iDim++) {
-			Edge_Vector[iDim] = Coord_1[iDim] - Coord_0[iDim];
-			Length += Edge_Vector[iDim]*Edge_Vector[iDim];
-		}
-		Length = sqrt(Length);
-		MinLength = min(Length, MinLength);
-    
-	}
-  
   /*--- Compute min volume in the entire mesh. ---*/
   
-  Scale = Check_Grid(geometry);
+  ComputeDeforming_Element_Volume(geometry, MinVolume, MaxVolume);
+  if (rank == MASTER_NODE) cout <<"Min. volume: "<< MinVolume <<", max. volume: "<< MaxVolume <<"." << endl;
+  
   
   /*--- Compute the distance to the nearest deforming surface if needed
-   as part of the stiffness calculation. In this case, we can scale based
-   on the minimum edge length. ---*/
+   as part of the stiffness calculation.. ---*/
   
   if (config->GetDeform_Stiffness_Type() == WALL_DISTANCE) {
-    ComputeDeforming_Wall_Distance(geometry, config);
-    Scale = MinLength;
+    ComputeDeforming_Wall_Distance(geometry, config, MinDistance, MaxDistance);
+    if (rank == MASTER_NODE) cout <<"Min. distance: "<< MinDistance <<", max. distance: "<< MaxDistance <<"." << endl;
   }
   
 	/*--- Compute contributions from each element by forming the stiffness matrix (FEA) ---*/
   
 	for (iElem = 0; iElem < geometry->GetnElem(); iElem++) {
     
-    if (geometry->elem[iElem]->GetVTK_Type() == TRIANGLE)     nNodes = 3;
-    if (geometry->elem[iElem]->GetVTK_Type() == QUADRILATERAL)    nNodes = 4;
-    if (geometry->elem[iElem]->GetVTK_Type() == TETRAHEDRON)  nNodes = 4;
-    if (geometry->elem[iElem]->GetVTK_Type() == PYRAMID)      nNodes = 5;
-    if (geometry->elem[iElem]->GetVTK_Type() == PRISM)        nNodes = 6;
-    if (geometry->elem[iElem]->GetVTK_Type() == HEXAHEDRON)   nNodes = 8;
+    if (geometry->elem[iElem]->GetVTK_Type() == TRIANGLE)      nNodes = 3;
+    if (geometry->elem[iElem]->GetVTK_Type() == QUADRILATERAL) nNodes = 4;
+    if (geometry->elem[iElem]->GetVTK_Type() == TETRAHEDRON)   nNodes = 4;
+    if (geometry->elem[iElem]->GetVTK_Type() == PYRAMID)       nNodes = 5;
+    if (geometry->elem[iElem]->GetVTK_Type() == PRISM)         nNodes = 6;
+    if (geometry->elem[iElem]->GetVTK_Type() == HEXAHEDRON)    nNodes = 8;
     
     for (iNodes = 0; iNodes < nNodes; iNodes++) {
       PointCorners[iNodes] = geometry->elem[iElem]->GetNode(iNodes);
@@ -612,9 +633,20 @@ su2double CVolumetricMovement::SetFEAMethodContributions_Elem(CGeometry *geometr
       }
     }
     
-    if (nDim == 2) SetFEA_StiffMatrix2D(geometry, config, StiffMatrix_Elem, PointCorners, CoordCorners, nNodes, Scale);
-    if (nDim == 3) SetFEA_StiffMatrix3D(geometry, config, StiffMatrix_Elem, PointCorners, CoordCorners, nNodes, Scale);
-
+    /*--- Extract Element volume and distance to compute the stiffness ---*/
+    
+    ElemVolume = geometry->elem[iElem]->GetVolume();
+    
+    if (config->GetDeform_Stiffness_Type() == WALL_DISTANCE) {
+      ElemDistance = 0.0;
+      for (iNodes = 0; iNodes < nNodes; iNodes++)
+        ElemDistance += geometry->node[PointCorners[iNodes]]->GetWall_Distance();
+      ElemDistance = ElemDistance/(su2double)nNodes;
+    }
+    
+    if (nDim == 2) SetFEA_StiffMatrix2D(geometry, config, StiffMatrix_Elem, PointCorners, CoordCorners, nNodes, ElemVolume, ElemDistance);
+    if (nDim == 3) SetFEA_StiffMatrix3D(geometry, config, StiffMatrix_Elem, PointCorners, CoordCorners, nNodes, ElemVolume, ElemDistance);
+    
     AddFEA_StiffMatrix(geometry, StiffMatrix_Elem, PointCorners, nNodes);
     
 	}
@@ -630,17 +662,8 @@ su2double CVolumetricMovement::SetFEAMethodContributions_Elem(CGeometry *geometr
     delete [] StiffMatrix_Elem[iVar];
   delete [] StiffMatrix_Elem;
   
-  delete [] Edge_Vector;
-  
-  /*--- If there are no degenerate cells, use the minimum volume instead ---*/
-  if (ElemCounter == 0) MinLength = Scale;
-  
-#ifdef HAVE_MPI
-  su2double MinLength_Local = MinLength; MinLength = 0.0;
-  SU2_MPI::Allreduce(&MinLength_Local, &MinLength, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
-#endif
-      
-	return MinLength;
+  return MinVolume;
+
 }
 
 su2double CVolumetricMovement::ShapeFunc_Triangle(su2double Xi, su2double Eta, su2double CoordCorners[8][3], su2double DShapeFunction[8][4]) {
@@ -1379,11 +1402,12 @@ su2double CVolumetricMovement::GetHexa_Volume(su2double CoordCorners[8][3]) {
 
 }
 
-void CVolumetricMovement::SetFEA_StiffMatrix2D(CGeometry *geometry, CConfig *config, su2double **StiffMatrix_Elem, unsigned long PointCorners[8], su2double CoordCorners[8][3], unsigned short nNodes, su2double scale) {
+void CVolumetricMovement::SetFEA_StiffMatrix2D(CGeometry *geometry, CConfig *config, su2double **StiffMatrix_Elem, unsigned long PointCorners[8], su2double CoordCorners[8][3],
+                                               unsigned short nNodes, su2double ElemVolume, su2double ElemDistance) {
   
   su2double B_Matrix[3][8], D_Matrix[3][3], Aux_Matrix[8][3];
-  su2double Xi = 0.0, Eta = 0.0, Det = 0.0, E, Lambda = 0.0, Nu, Mu = 0.0, Avg_Wall_Dist;
-  unsigned short iNode, jNode, iVar, jVar, kVar, iGauss, nGauss = 0;
+  su2double Xi = 0.0, Eta = 0.0, Det = 0.0, E = 1/EPS, Lambda = 0.0, Mu = 0.0, Nu = 0.0;
+  unsigned short iNode, iVar, jVar, kVar, iGauss, nGauss = 0;
   su2double DShapeFunction[8][4] = {{0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0},
     {0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0}};
   su2double Location[4][3], Weight[4];
@@ -1394,12 +1418,6 @@ void CVolumetricMovement::SetFEA_StiffMatrix2D(CGeometry *geometry, CConfig *con
       StiffMatrix_Elem[iVar][jVar] = 0.0;
     }
   }
-  
-  /*--- Each element uses their own stiffness which is inversely
-   proportional to the area/volume of the cell. Using Mu = E & Lambda = -E
-   is a modification to help allow rigid rotation of elements (see
-   "Robust Mesh Deformation using the Linear Elasticity Equations" by
-   R. P. Dwight. ---*/
   
   /*--- Integration formulae from "Shape functions and points of
    integration of the Résumé" by Josselin DELMAS (2013) ---*/
@@ -1445,31 +1463,14 @@ void CVolumetricMovement::SetFEA_StiffMatrix2D(CGeometry *geometry, CConfig *con
     /*--- Impose a type of stiffness for each element ---*/
     
     switch (config->GetDeform_Stiffness_Type()) {
-        
-      case INVERSE_VOLUME:
-        E = scale / (Weight[iGauss] * Det) ;
-        Mu = E;
-        Lambda = -E;
-        break;
-        
-      case WALL_DISTANCE:
-        Avg_Wall_Dist = 0.0;
-        for (jNode = 0; jNode < nNodes; jNode++) {
-          Avg_Wall_Dist += geometry->node[PointCorners[jNode]]->GetWall_Distance()/((su2double)nNodes);
-        }
-        E = scale / (Weight[iGauss] * Avg_Wall_Dist);
-        Mu = E;
-        Lambda = -E;
-        break;
-        
-      case CONSTANT_STIFFNESS:
-        E=config->GetDeform_ElasticityMod();
-        Nu=config->GetDeform_PoissonRatio();
-        //E = 2E11; Nu = 0.30;
-        Mu = E / (2.0*(1.0 + Nu));
-        Lambda = Nu*E/((1.0+Nu)*(1.0-2.0*Nu));
-        break;
+      case INVERSE_VOLUME: E = 1.0 / ElemVolume; break;
+      case WALL_DISTANCE: E = 1.0 / ElemDistance; break;
+      case CONSTANT_STIFFNESS: E=1.0/EPS; break;
     }
+    
+    Nu = config->GetDeform_Coeff();
+    Mu = E / (2.0*(1.0 + Nu));
+    Lambda = Nu*E/((1.0+Nu)*(1.0-2.0*Nu));
     
     /*--- Compute the D Matrix (for plane strain and 3-D)---*/
     
@@ -1494,7 +1495,7 @@ void CVolumetricMovement::SetFEA_StiffMatrix2D(CGeometry *geometry, CConfig *con
     for (iVar = 0; iVar < nNodes*nVar; iVar++) {
       for (jVar = 0; jVar < nNodes*nVar; jVar++) {
         for (kVar = 0; kVar < 3; kVar++) {
-          StiffMatrix_Elem[iVar][jVar] += Weight[iGauss] * Aux_Matrix[iVar][kVar]*B_Matrix[kVar][jVar] * Det;
+          StiffMatrix_Elem[iVar][jVar] += Weight[iGauss] * Aux_Matrix[iVar][kVar]*B_Matrix[kVar][jVar] * fabs(Det);
         }
       }
     }
@@ -1503,28 +1504,23 @@ void CVolumetricMovement::SetFEA_StiffMatrix2D(CGeometry *geometry, CConfig *con
   
 }
 
-void CVolumetricMovement::SetFEA_StiffMatrix3D(CGeometry *geometry, CConfig *config, su2double **StiffMatrix_Elem, unsigned long PointCorners[8], su2double CoordCorners[8][3], unsigned short nNodes, su2double scale) {
+void CVolumetricMovement::SetFEA_StiffMatrix3D(CGeometry *geometry, CConfig *config, su2double **StiffMatrix_Elem, unsigned long PointCorners[8], su2double CoordCorners[8][3],
+                                               unsigned short nNodes, su2double ElemVolume, su2double ElemDistance) {
   
   su2double B_Matrix[6][24], D_Matrix[6][6] = {{0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
     {0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0, 0.0, 0.0}}, Aux_Matrix[24][6];
-  su2double Xi = 0.0, Eta = 0.0, Zeta = 0.0, Det = 0.0, Mu = 0.0, E = 0.0, Lambda = 0.0, Nu = 0.0, Avg_Wall_Dist;
-  unsigned short iNode, jNode, iVar, jVar, kVar, iGauss, nGauss = 0;
+  su2double Xi = 0.0, Eta = 0.0, Zeta = 0.0, Det = 0.0, Mu = 0.0, E = 0.0, Lambda = 0.0, Nu = 0.0;
+  unsigned short iNode, iVar, jVar, kVar, iGauss, nGauss = 0;
   su2double DShapeFunction[8][4] = {{0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0},
     {0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0}};
   su2double Location[8][3], Weight[8];
   unsigned short nVar = geometry->GetnDim();
-
+  
   for (iVar = 0; iVar < nNodes*nVar; iVar++) {
     for (jVar = 0; jVar < nNodes*nVar; jVar++) {
       StiffMatrix_Elem[iVar][jVar] = 0.0;
     }
   }
-  
-  /*--- Each element uses their own stiffness which is inversely
-   proportional to the area/volume of the cell. Using Mu = E & Lambda = -E
-   is a modification to help allow rigid rotation of elements (see
-   "Robust Mesh Deformation using the Linear Elasticity Equations" by
-   R. P. Dwight. ---*/
   
   /*--- Integration formulae from "Shape functions and points of
    integration of the Résumé" by Josselin Delmas (2013) ---*/
@@ -1606,31 +1602,14 @@ void CVolumetricMovement::SetFEA_StiffMatrix3D(CGeometry *geometry, CConfig *con
     /*--- Impose a type of stiffness for each element ---*/
     
     switch (config->GetDeform_Stiffness_Type()) {
-        
-      case INVERSE_VOLUME:
-        E = scale / (Weight[iGauss] * Det) ;
-        Mu = E;
-        Lambda = -E;
-        break;
-        
-      case WALL_DISTANCE:
-        Avg_Wall_Dist = 0.0;
-        for (jNode = 0; jNode < nNodes; jNode++) {
-          Avg_Wall_Dist += geometry->node[PointCorners[jNode]]->GetWall_Distance()/((su2double)nNodes);
-        }
-        E = scale / (Weight[iGauss] * Avg_Wall_Dist);
-        Mu = E;
-        Lambda = -E;
-        break;
-        
-      case CONSTANT_STIFFNESS:
-        E=config->GetDeform_ElasticityMod();
-        Nu=config->GetDeform_PoissonRatio();
-        //E = 2E11; Nu = 0.30;
-        Mu = E / (2.0*(1.0 + Nu));
-        Lambda = Nu*E/((1.0+Nu)*(1.0-2.0*Nu));
-        break;
+      case INVERSE_VOLUME: E = 1.0 / ElemVolume; break;
+      case WALL_DISTANCE: E = 1.0 / ElemDistance; break;
+      case CONSTANT_STIFFNESS: E=1.0/EPS; break;
     }
+    
+    Nu = config->GetDeform_Coeff();
+    Mu = E / (2.0*(1.0 + Nu));
+    Lambda = Nu*E/((1.0+Nu)*(1.0-2.0*Nu));
     
     /*--- Compute the D Matrix (for plane strain and 3-D)---*/
     
@@ -1658,7 +1637,7 @@ void CVolumetricMovement::SetFEA_StiffMatrix3D(CGeometry *geometry, CConfig *con
     for (iVar = 0; iVar < nNodes*nVar; iVar++) {
       for (jVar = 0; jVar < nNodes*nVar; jVar++) {
         for (kVar = 0; kVar < 6; kVar++) {
-          StiffMatrix_Elem[iVar][jVar] += Weight[iGauss] * Aux_Matrix[iVar][kVar]*B_Matrix[kVar][jVar] * Det;
+          StiffMatrix_Elem[iVar][jVar] += Weight[iGauss] * Aux_Matrix[iVar][kVar]*B_Matrix[kVar][jVar] * fabs(Det);
         }
       }
     }

--- a/SU2_IDE/Xcode/SU2_DEF.xcodeproj/project.pbxproj
+++ b/SU2_IDE/Xcode/SU2_DEF.xcodeproj/project.pbxproj
@@ -239,7 +239,7 @@
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0510;
+				LastUpgradeCheck = 0720;
 			};
 			buildConfigurationList = 1DEB923508733DC60010E9CD /* Build configuration list for PBXProject "SU2_DEF" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -317,6 +317,7 @@
 		1DEB923608733DC60010E9CD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_OPTIMIZATION_LEVEL = 3;
 				GCC_PREPROCESSOR_DEFINITIONS = (

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -744,6 +744,9 @@ DEFORM_CONSOLE_OUTPUT= NO
 % Factor to multiply smallest cell volume for deform tolerance (0.001 default)
 DEFORM_TOL_FACTOR = 0.001
 %
+% Deformation coefficient (in theory from -1.0 to 0.5, a large value is also valid)
+DEFORM_COEFF = 1E6
+%
 % Type of element stiffness imposed for FEA mesh deformation (INVERSE_VOLUME, 
 %                                          WALL_DISTANCE, CONSTANT_STIFFNESS)
 DEFORM_STIFFNESS_TYPE= INVERSE_VOLUME

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -733,16 +733,16 @@ DV_VALUE= 0.01
 DEFORM_LINEAR_SOLVER= FGMRES
 %
 % Number of smoothing iterations for mesh deformation
-DEFORM_LINEAR_ITER= 500
+DEFORM_LINEAR_ITER= 1000
 %
 % Number of nonlinear deformation iterations (surface deformation increments)
-DEFORM_NONLINEAR_ITER= 2
+DEFORM_NONLINEAR_ITER= 1
 %
 % Print the residuals during mesh deformation to the console (YES, NO)
-DEFORM_CONSOLE_OUTPUT= NO
+DEFORM_CONSOLE_OUTPUT= YES
 %
 % Factor to multiply smallest cell volume for deform tolerance (0.001 default)
-DEFORM_TOL_FACTOR = 0.001
+DEFORM_TOL_FACTOR = 1E-6
 %
 % Deformation coefficient (in theory from -1.0 to 0.5, a large value is also valid)
 DEFORM_COEFF = 1E6

--- a/config_template_basic.cfg
+++ b/config_template_basic.cfg
@@ -436,17 +436,17 @@ DV_VALUE= 0.01
 DEFORM_LINEAR_SOLVER= FGMRES
 %
 % Number of smoothing iterations for FEA mesh deformation
-DEFORM_LINEAR_ITER= 500
+DEFORM_LINEAR_ITER= 1000
 %
 % Number of nonlinear deformation iterations (surface deformation increments)
-DEFORM_NONLINEAR_ITER= 2
+DEFORM_NONLINEAR_ITER= 1
 %
 % Print the residuals during mesh deformation to the console (YES, NO)
-DEFORM_CONSOLE_OUTPUT= NO
+DEFORM_CONSOLE_OUTPUT= YES
 %
 % Type of element stiffness imposed for FEA mesh deformation (INVERSE_VOLUME, 
 %                                          WALL_DISTANCE, CONSTANT_STIFFNESS)
-DEFORM_STIFFNESS_TYPE= INVERSE_VOLUME
+DEFORM_STIFFNESS_TYPE= WALL_DISTANCE
 %
 % Visualize the deformation (NO, YES)
 VISUALIZE_DEFORMATION= NO


### PR DESCRIPTION
Several bugs have been fixed in the grid deformation and the config file have been updated. 

In particular, the inverse volume method uses now an element volume computed in ComputeDeforming_Element_Volume (not the incomplete determinant computed in FEM). fabs have been added to the determinant in the final evaluation of the FEM stiffness matrix (depending on the element orientation, the determinant was negative). The formulation Mu = E / (2.0*(1.0 + Nu)), Lambda = Nu*E/((1.0+Nu)*(1.0-2.0*Nu)) is used instead of the basic simplification Mu = E, Lambda = -E. We can recover that formulation using a large number for Nu (DEFORM_COEFF). The code has been simplified and that IO is now more clear.

I have performed some tests and large deformations are now possible. 

However, systematic regression tests for grid deformation is required using all the different kinds of elements. I remember that T. Economon put together some basic grids to test the mesh deformation, we should use those to check that everything is working fine before closing the release.