### PR TITLE
added custom MPI command set by user-defined environment variable

### DIFF
--- a/Common/src/interpolation_structure.cpp
+++ b/Common/src/interpolation_structure.cpp
@@ -297,14 +297,14 @@ void CNearestNeighbor::Set_TransferCoeff(CConfig **config) {
   unsigned short iDim, nDim, iMarkerInt, nMarkerInt, iDonor;    
 
   unsigned long nVertexDonor, nVertexTarget, Point_Target, jVertex, iVertexTarget;
-  unsigned long Global_Point_Donor, pGlobalPoint;
+  unsigned long Global_Point_Donor, pGlobalPoint=0;
 
   su2double *Coord_i, Coord_j[3], dist, mindist, maxdist;
 
 #ifdef HAVE_MPI
 
   int rank = MASTER_NODE;
-  int *Buffer_Recv_mark, iRank;
+  int *Buffer_Recv_mark=NULL, iRank;
   
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &nProcessor);
@@ -526,7 +526,7 @@ void CIsoparametric::Set_TransferCoeff(CConfig **config) {
 
 #ifdef HAVE_MPI
 
-  int *Buffer_Recv_mark, iRank;
+  int *Buffer_Recv_mark=NULL, iRank;
   
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &nProcessor);
@@ -1108,7 +1108,7 @@ void CMirror::Set_TransferCoeff(CConfig **config) {
   int nProcessor = SINGLE_NODE;
 
 #ifdef HAVE_MPI
-  int *Buffer_Recv_mark, iRank;
+  int *Buffer_Recv_mark=NULL, iRank;
   
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &nProcessor);

--- a/SU2_CFD/src/driver_structure.cpp
+++ b/SU2_CFD/src/driver_structure.cpp
@@ -378,8 +378,6 @@ CDriver::CDriver(char* confFile,
 
 void CDriver::Postprocessing() {
 
-  unsigned short jZone;
-
   int rank = MASTER_NODE;
   int size = SINGLE_NODE;
 #ifdef HAVE_MPI
@@ -2203,7 +2201,7 @@ void CDriver::Interface_Preprocessing() {
   int markDonor, markTarget, Donor_check, Target_check, iMarkerInt, nMarkerInt;
 
   #ifdef HAVE_MPI
-  int *Buffer_Recv_mark, iRank;
+  int *Buffer_Recv_mark=NULL, iRank;
 
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &nProcessor);
@@ -3218,7 +3216,7 @@ CFluidDriver::~CFluidDriver(void) { }
 
 void CFluidDriver::Run() {
   
-  unsigned short iZone, jZone, checkConvergence;
+  unsigned short iZone, , checkConvergence;
   unsigned long IntIter, nIntIter;
   bool unsteady;
 

--- a/SU2_CFD/src/output_structure.cpp
+++ b/SU2_CFD/src/output_structure.cpp
@@ -8914,7 +8914,7 @@ void COutput::SetEquivalentArea(CSolver *solver_container, CGeometry *geometry, 
 void COutput::WriteSurface_Analysis(CConfig *config, CGeometry *geometry, CSolver *FlowSolver) {
 
 	unsigned short iMarker, iDim, iMarker_Analyze;
-	unsigned long iPoint, iVertex, Global_Index;
+	unsigned long iPoint, iVertex;
 	su2double xCoord = 0.0, yCoord = 0.0, zCoord = 0.0, Area = 0.0, *Vector, TotalArea = 0.0;
 	su2double xCoord_CG = 0.0, yCoord_CG = 0.0, zCoord_CG = 0.0, TipRadius, HubRadius, Distance = 0.0, Distance_Mirror = 0.0;
 	su2double *r, MinDistance, xCoord_ = 0.0, yCoord_ = 0.0, zCoord_ = 0;
@@ -9437,7 +9437,6 @@ void COutput::WriteSurface_Analysis(CConfig *config, CGeometry *geometry, CSolve
 				/*--- Current index position and global index ---*/
 
 				Total_Index = iProcessor*MaxLocalVertex_Surface+iVertex;
-				Global_Index = Buffer_Recv_GlobalIndex[Total_Index];
 
 				/*--- Retrieve the merged data for this node ---*/
 
@@ -9472,7 +9471,6 @@ void COutput::WriteSurface_Analysis(CConfig *config, CGeometry *geometry, CSolve
 				/*--- Current index position and global index ---*/
 
 				Total_Index = iProcessor*MaxLocalVertex_Surface+iVertex;
-				Global_Index = Buffer_Recv_GlobalIndex[Total_Index];
 
 				/*--- Retrieve the merged data for this node ---*/
 
@@ -9556,7 +9554,6 @@ void COutput::WriteSurface_Analysis(CConfig *config, CGeometry *geometry, CSolve
 						/*--- Current index position and global index ---*/
 
 						Total_Index = iProcessor*MaxLocalVertex_Surface+iVertex;
-						Global_Index = Buffer_Recv_GlobalIndex[Total_Index];
 
 						/*--- Retrieve the merged data for this node ---*/
 

--- a/SU2_CFD/src/solver_adjoint_mean.cpp
+++ b/SU2_CFD/src/solver_adjoint_mean.cpp
@@ -1242,8 +1242,8 @@ void CAdjEulerSolver::Set_MPI_ActDisk(CSolver **solver_container, CGeometry *geo
   /*--- MPI status and request arrays for non-blocking communications ---*/
   
   MPI_Status status, status_;
-  MPI_Request request, request_;
   
+
 #endif
   
   /*--- Define buffer vector interior domain ---*/
@@ -1558,8 +1558,8 @@ void CAdjEulerSolver::Set_MPI_Nearfield(CGeometry *geometry, CConfig *config) {
   /*--- MPI status and request arrays for non-blocking communications ---*/
   
   MPI_Status status, status_;
-  MPI_Request request, request_;
   
+
 #endif
   
   /*--- Define buffer vector interior domain ---*/
@@ -1881,8 +1881,8 @@ void CAdjEulerSolver::Set_MPI_Interface(CGeometry *geometry, CConfig *config) {
   /*--- MPI status and request arrays for non-blocking communications ---*/
   
   MPI_Status status, status_;
-  MPI_Request request, request_;
   
+
 #endif
   
   /*--- Define buffer vector interior domain ---*/
@@ -5834,7 +5834,7 @@ void CAdjEulerSolver::BC_Engine_Inflow(CGeometry *geometry, CSolver **solver_con
 void CAdjEulerSolver::BC_Engine_Exhaust(CGeometry *geometry, CSolver **solver_container, CNumerics *conv_numerics, CNumerics *visc_numerics, CConfig *config, unsigned short val_marker) {
   
   unsigned long iVertex, iPoint, Point_Normal;
-  su2double Area, UnitNormal[3], *Normal, *V_domain, *V_exhaust, *Psi_domain, *Psi_exhaust;
+  su2double Area, *Normal, *V_domain, *V_exhaust, *Psi_domain, *Psi_exhaust;
   unsigned short iVar, iDim;
   
   bool implicit = (config->GetKind_TimeIntScheme_AdjFlow() == EULER_IMPLICIT);
@@ -5862,9 +5862,6 @@ void CAdjEulerSolver::BC_Engine_Exhaust(CGeometry *geometry, CSolver **solver_co
       for (iDim = 0; iDim < nDim; iDim++)
         Area += Normal[iDim]*Normal[iDim];
       Area = sqrt (Area);
-      
-      for (iDim = 0; iDim < nDim; iDim++)
-        UnitNormal[iDim] = Normal[iDim]/Area;
       
       /*--- Index of the closest interior node ---*/
       

--- a/SU2_CFD/src/solver_direct_mean.cpp
+++ b/SU2_CFD/src/solver_direct_mean.cpp
@@ -2389,7 +2389,7 @@ void CEulerSolver::Set_MPI_ActDisk(CSolver **solver_container, CGeometry *geomet
   long nDomain = 0, iDomain, jDomain;
   int rank = MASTER_NODE;
   int size = SINGLE_NODE;
-  bool ActDisk_Perimeter;
+  //bool ActDisk_Perimeter;
   bool rans = ((config->GetKind_Solver() == RANS )|| (config->GetKind_Solver() == DISC_ADJ_RANS));
   
   unsigned short nPrimVar_ = nPrimVar;
@@ -2448,7 +2448,7 @@ void CEulerSolver::Set_MPI_ActDisk(CSolver **solver_container, CGeometry *geomet
       if ((config->GetMarker_All_KindBC(iMarker) == ACTDISK_INLET) ||
           (config->GetMarker_All_KindBC(iMarker) == ACTDISK_OUTLET)) {
         for (iVertex = 0; iVertex < geometry->nVertex[iMarker]; iVertex++) {
-          ActDisk_Perimeter = geometry->vertex[iMarker][iVertex]->GetActDisk_Perimeter();
+          //ActDisk_Perimeter = geometry->vertex[iMarker][iVertex]->GetActDisk_Perimeter();
           iPoint = geometry->vertex[iMarker][iVertex]->GetNode();
           jDomain = geometry->vertex[iMarker][iVertex]->GetDonorProcessor();
 //          if ((iDomain == jDomain) && (geometry->node[iPoint]->GetDomain()) && (!ActDisk_Perimeter)) {
@@ -2555,7 +2555,7 @@ void CEulerSolver::Set_MPI_ActDisk(CSolver **solver_container, CGeometry *geomet
           iPoint = geometry->vertex[iMarker][iVertex]->GetNode();
           
           jDomain = geometry->vertex[iMarker][iVertex]->GetDonorProcessor();
-          ActDisk_Perimeter = geometry->vertex[iMarker][iVertex]->GetActDisk_Perimeter();
+          //ActDisk_Perimeter = geometry->vertex[iMarker][iVertex]->GetActDisk_Perimeter();
           
 //          if ((iDomain == jDomain) && (geometry->node[iPoint]->GetDomain()) && (!ActDisk_Perimeter)) {
           if ((iDomain == jDomain) && (geometry->node[iPoint]->GetDomain())) {
@@ -2756,8 +2756,8 @@ void CEulerSolver::Set_MPI_Nearfield(CGeometry *geometry, CConfig *config) {
   /*--- MPI status and request arrays for non-blocking communications ---*/
   
   MPI_Status status, status_;
-  MPI_Request request, request_;
   
+
 #endif
   
   /*--- Define buffer vector interior domain ---*/
@@ -3081,8 +3081,8 @@ void CEulerSolver::Set_MPI_Interface(CGeometry *geometry, CConfig *config) {
   /*--- MPI status and request arrays for non-blocking communications ---*/
   
   MPI_Status status, status_;
-  MPI_Request request, request_;
   
+
 #endif
   
   /*--- Define buffer vector interior domain ---*/
@@ -6239,8 +6239,8 @@ void CEulerSolver::Momentum_Forces(CGeometry *geometry, CConfig *config) {
   unsigned long iVertex, iPoint;
   unsigned short iDim, iMarker, Boundary, Monitoring, iMarker_Monitoring;
   su2double *Normal = NULL, MomentDist[3] = {0.0,0.0,0.0}, *Coord, Area,
-  factor, RefVel2, RefTemp, RefDensity, RefPressure, Mach2Vel, Mach_Motion,
-  UnitNormal[3] = {0.0,0.0,0.0}, Force[3] = {0.0,0.0,0.0}, Velocity[3], MassFlow, Density, Vel_Infty2, Vel_Infty;
+  factor, RefVel2, RefTemp, RefDensity,  Mach2Vel, Mach_Motion,
+  Force[3] = {0.0,0.0,0.0}, Velocity[3], MassFlow, Density;
   string Marker_Tag, Monitoring_Tag;
   su2double MomentX_Force[3] = {0.0,0.0,0.0}, MomentY_Force[3] = {0.0,0.0,0.0}, MomentZ_Force[3] = {0.0,0.0,0.0};
 
@@ -6271,7 +6271,6 @@ MyAllBound_CMx_Mnt, MyAllBound_CMy_Mnt, MyAllBound_CMz_Mnt,
   
   RefTemp     = Temperature_Inf;
   RefDensity  = Density_Inf;
-  RefPressure = Pressure_Inf;
   if (grid_movement) {
     Mach2Vel = sqrt(Gamma*Gas_Constant*RefTemp);
     Mach_Motion = config->GetMach_Motion();
@@ -6357,15 +6356,12 @@ MyAllBound_CMx_Mnt, MyAllBound_CMy_Mnt, MyAllBound_CMz_Mnt,
           
           Area = 0.0; for (iDim = 0; iDim < nDim; iDim++) Area += Normal[iDim]*Normal[iDim]; Area = sqrt(Area);
           
-          Vel_Infty2 =0.0; MassFlow = 0.0;
+          MassFlow = 0.0;
           for (iDim = 0; iDim < nDim; iDim++) {
             Velocity[iDim] 	= node[iPoint]->GetVelocity(iDim);
-            UnitNormal[iDim] = Normal[iDim]/Area;
             MomentDist[iDim] = Coord[iDim] - Origin[iDim];
             MassFlow -= Normal[iDim]*Velocity[iDim]*Density;
-            Vel_Infty2 += GetVelocity_Inf(iDim)*GetVelocity_Inf(iDim);
           }
-          Vel_Infty = sqrt (Vel_Infty2);
           
           /*--- Force computation, note the minus sign due to the
            orientation of the normal (outward) ---*/
@@ -13969,7 +13965,7 @@ void CEulerSolver::BC_ActDisk(CGeometry *geometry, CSolver **solver_container, C
 	su2double Vel_normal_inlet_, Vel_tangent_inlet_, Vel_inlet_;
 	su2double Vel_normal_outlet_, Vel_tangent_outlet_, Vel_outlet_;
 	su2double turb_ke, a2, phi;
-	bool ReverseFlow, ActDisk_Perimeter;
+	bool ReverseFlow;//, ActDisk_Perimeter;
 
 	bool implicit           = (config->GetKind_TimeIntScheme_Flow() == EULER_IMPLICIT);
 	su2double Gas_Constant  = config->GetGas_ConstantND();
@@ -14001,7 +13997,7 @@ void CEulerSolver::BC_ActDisk(CGeometry *geometry, CSolver **solver_container, C
 		iPoint_Normal = geometry->vertex[val_marker][iVertex]->GetNormal_Neighbor();
 		GlobalIndex = geometry->node[iPoint]->GetGlobalIndex();
 		GlobalIndex_donor = GetDonorGlobalIndex(val_marker, iVertex);
-		ActDisk_Perimeter = geometry->vertex[val_marker][iVertex]->GetActDisk_Perimeter();
+		//ActDisk_Perimeter = geometry->vertex[val_marker][iVertex]->GetActDisk_Perimeter();
 
 		/*--- Check if the node belongs to the domain (i.e., not a halo node) ---*/
 

--- a/SU2_PY/SU2/run/interface.py
+++ b/SU2_PY/SU2/run/interface.py
@@ -53,9 +53,6 @@ base_Command = os.path.join(SU2_RUN,'%s')
 # check for slurm
 slurm_job = os.environ.has_key('SLURM_JOBID')
 
-#check for tacc
-tacc_job = os.environ.has_key('TACC_PUBLIC_MACHINE')
-
 # Check for custom mpi command
 user_defined = os.environ.has_key('SU2_MPI_COMMAND')
 
@@ -64,8 +61,6 @@ if user_defined:
     mpi_Command = os.environ['SU2_MPI_COMMAND']
 elif slurm_job:
     mpi_Command = 'srun -n %i %s'
-    if tacc_job:
-        mpi_Command = 'ibrun -o 0 -n %i %s'
 elif not which('mpirun') is None:
     mpi_Command = 'mpirun -n %i %s'
 elif not which('mpiexec') is None:

--- a/SU2_PY/SU2/run/interface.py
+++ b/SU2_PY/SU2/run/interface.py
@@ -56,8 +56,13 @@ slurm_job = os.environ.has_key('SLURM_JOBID')
 #check for tacc
 tacc_job = os.environ.has_key('TACC_PUBLIC_MACHINE')
 
+# Check for custom mpi command
+user_defined = os.environ.has_key('SU2_MPI_COMMAND')
+
 # set mpi command
-if slurm_job:
+if user_defined:
+    mpi_Command = os.environ['SU2_MPI_COMMAND']
+elif slurm_job:
     mpi_Command = 'srun -n %i %s'
     if tacc_job:
         mpi_Command = 'ibrun -o 0 -n %i %s'


### PR DESCRIPTION
With this (very small) change, users can quickly change the system command used by the python scripts to launch parallel jobs without making any modifications to the code. 
Example:
(bash)
export SU2_MPI_COMMAND="mpiexec -n %i %s"

NOTE:
SU2_MPI_COMMAND must contain '%i' and  '%s', in that order, which will be replaced with the number of processors and the SU2 command (ie, 'SU2_CFD config.cfg') respectively.
If this environment variable exists in the workspace, whatever is in it will be used instead of the default options. This should allow things like nonstandard mpi launchers, additional arguments like hostfiles, etc. 



