### PR TITLE
Cleaning up compiler warnings

### DIFF
--- a/Common/include/option_structure.hpp
+++ b/Common/include/option_structure.hpp
@@ -144,14 +144,14 @@ const int MASTER_NODE = 0;			/*!< \brief Master node for MPI parallelization. */
 const int SINGLE_NODE = 1;			/*!< \brief There is only a node in the MPI parallelization. */
 const int SINGLE_ZONE = 1;			/*!< \brief There is only a zone. */
 
-const unsigned int N_ELEM_TYPES = 7;           /*!< \brief General output & CGNS defines. */
-const unsigned int N_POINTS_LINE = 2;          /*!< \brief General output & CGNS defines. */
-const unsigned int N_POINTS_TRIANGLE = 3;      /*!< \brief General output & CGNS defines. */
-const unsigned int N_POINTS_QUADRILATERAL = 4; /*!< \brief General output & CGNS defines. */
-const unsigned int N_POINTS_TETRAHEDRON = 4;   /*!< \brief General output & CGNS defines. */
-const unsigned int N_POINTS_HEXAHEDRON = 8;    /*!< \brief General output & CGNS defines. */
-const unsigned int N_POINTS_PYRAMID = 5;       /*!< \brief General output & CGNS defines. */
-const unsigned int N_POINTS_PRISM = 6;         /*!< \brief General output & CGNS defines. */
+const unsigned short N_ELEM_TYPES = 7;           /*!< \brief General output & CGNS defines. */
+const unsigned short N_POINTS_LINE = 2;          /*!< \brief General output & CGNS defines. */
+const unsigned short N_POINTS_TRIANGLE = 3;      /*!< \brief General output & CGNS defines. */
+const unsigned short N_POINTS_QUADRILATERAL = 4; /*!< \brief General output & CGNS defines. */
+const unsigned short N_POINTS_TETRAHEDRON = 4;   /*!< \brief General output & CGNS defines. */
+const unsigned short N_POINTS_HEXAHEDRON = 8;    /*!< \brief General output & CGNS defines. */
+const unsigned short N_POINTS_PYRAMID = 5;       /*!< \brief General output & CGNS defines. */
+const unsigned short N_POINTS_PRISM = 6;         /*!< \brief General output & CGNS defines. */
 
 /*!
  * \brief Boolean answers

--- a/Common/include/option_structure.hpp
+++ b/Common/include/option_structure.hpp
@@ -144,14 +144,14 @@ const int MASTER_NODE = 0;			/*!< \brief Master node for MPI parallelization. */
 const int SINGLE_NODE = 1;			/*!< \brief There is only a node in the MPI parallelization. */
 const int SINGLE_ZONE = 1;			/*!< \brief There is only a zone. */
 
-const unsigned short N_ELEM_TYPES = 7;           /*!< \brief General output & CGNS defines. */
-const unsigned short N_POINTS_LINE = 2;          /*!< \brief General output & CGNS defines. */
-const unsigned short N_POINTS_TRIANGLE = 3;      /*!< \brief General output & CGNS defines. */
-const unsigned short N_POINTS_QUADRILATERAL = 4; /*!< \brief General output & CGNS defines. */
-const unsigned short N_POINTS_TETRAHEDRON = 4;   /*!< \brief General output & CGNS defines. */
-const unsigned short N_POINTS_HEXAHEDRON = 8;    /*!< \brief General output & CGNS defines. */
-const unsigned short N_POINTS_PYRAMID = 5;       /*!< \brief General output & CGNS defines. */
-const unsigned short N_POINTS_PRISM = 6;         /*!< \brief General output & CGNS defines. */
+const short N_ELEM_TYPES = 7;           /*!< \brief General output & CGNS defines. */
+const short N_POINTS_LINE = 2;          /*!< \brief General output & CGNS defines. */
+const short N_POINTS_TRIANGLE = 3;      /*!< \brief General output & CGNS defines. */
+const short N_POINTS_QUADRILATERAL = 4; /*!< \brief General output & CGNS defines. */
+const short N_POINTS_TETRAHEDRON = 4;   /*!< \brief General output & CGNS defines. */
+const short N_POINTS_HEXAHEDRON = 8;    /*!< \brief General output & CGNS defines. */
+const short N_POINTS_PYRAMID = 5;       /*!< \brief General output & CGNS defines. */
+const short N_POINTS_PRISM = 6;         /*!< \brief General output & CGNS defines. */
 
 /*!
  * \brief Boolean answers

--- a/Common/include/option_structure.hpp
+++ b/Common/include/option_structure.hpp
@@ -144,14 +144,14 @@ const int MASTER_NODE = 0;			/*!< \brief Master node for MPI parallelization. */
 const int SINGLE_NODE = 1;			/*!< \brief There is only a node in the MPI parallelization. */
 const int SINGLE_ZONE = 1;			/*!< \brief There is only a zone. */
 
-const short N_ELEM_TYPES = 7;           /*!< \brief General output & CGNS defines. */
-const short N_POINTS_LINE = 2;          /*!< \brief General output & CGNS defines. */
-const short N_POINTS_TRIANGLE = 3;      /*!< \brief General output & CGNS defines. */
-const short N_POINTS_QUADRILATERAL = 4; /*!< \brief General output & CGNS defines. */
-const short N_POINTS_TETRAHEDRON = 4;   /*!< \brief General output & CGNS defines. */
-const short N_POINTS_HEXAHEDRON = 8;    /*!< \brief General output & CGNS defines. */
-const short N_POINTS_PYRAMID = 5;       /*!< \brief General output & CGNS defines. */
-const short N_POINTS_PRISM = 6;         /*!< \brief General output & CGNS defines. */
+const unsigned short N_ELEM_TYPES = 7;           /*!< \brief General output & CGNS defines. */
+const unsigned short N_POINTS_LINE = 2;          /*!< \brief General output & CGNS defines. */
+const unsigned short N_POINTS_TRIANGLE = 3;      /*!< \brief General output & CGNS defines. */
+const unsigned short N_POINTS_QUADRILATERAL = 4; /*!< \brief General output & CGNS defines. */
+const unsigned short N_POINTS_TETRAHEDRON = 4;   /*!< \brief General output & CGNS defines. */
+const unsigned short N_POINTS_HEXAHEDRON = 8;    /*!< \brief General output & CGNS defines. */
+const unsigned short N_POINTS_PYRAMID = 5;       /*!< \brief General output & CGNS defines. */
+const unsigned short N_POINTS_PRISM = 6;         /*!< \brief General output & CGNS defines. */
 
 /*!
  * \brief Boolean answers

--- a/Common/include/option_structure.hpp
+++ b/Common/include/option_structure.hpp
@@ -144,14 +144,14 @@ const int MASTER_NODE = 0;			/*!< \brief Master node for MPI parallelization. */
 const int SINGLE_NODE = 1;			/*!< \brief There is only a node in the MPI parallelization. */
 const int SINGLE_ZONE = 1;			/*!< \brief There is only a zone. */
 
-const int N_ELEM_TYPES = 7;           /*!< \brief General output & CGNS defines. */
-const int N_POINTS_LINE = 2;          /*!< \brief General output & CGNS defines. */
-const int N_POINTS_TRIANGLE = 3;      /*!< \brief General output & CGNS defines. */
-const int N_POINTS_QUADRILATERAL = 4; /*!< \brief General output & CGNS defines. */
-const int N_POINTS_TETRAHEDRON = 4;   /*!< \brief General output & CGNS defines. */
-const int N_POINTS_HEXAHEDRON = 8;    /*!< \brief General output & CGNS defines. */
-const int N_POINTS_PYRAMID = 5;       /*!< \brief General output & CGNS defines. */
-const int N_POINTS_PRISM = 6;         /*!< \brief General output & CGNS defines. */
+const unsigned int N_ELEM_TYPES = 7;           /*!< \brief General output & CGNS defines. */
+const unsigned int N_POINTS_LINE = 2;          /*!< \brief General output & CGNS defines. */
+const unsigned int N_POINTS_TRIANGLE = 3;      /*!< \brief General output & CGNS defines. */
+const unsigned int N_POINTS_QUADRILATERAL = 4; /*!< \brief General output & CGNS defines. */
+const unsigned int N_POINTS_TETRAHEDRON = 4;   /*!< \brief General output & CGNS defines. */
+const unsigned int N_POINTS_HEXAHEDRON = 8;    /*!< \brief General output & CGNS defines. */
+const unsigned int N_POINTS_PYRAMID = 5;       /*!< \brief General output & CGNS defines. */
+const unsigned int N_POINTS_PRISM = 6;         /*!< \brief General output & CGNS defines. */
 
 /*!
  * \brief Boolean answers

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -1,7 +1,7 @@
 /*!
  * \file config_structure.cpp
  * \brief Main file for managing the config file
- * \author F. Palacios, T. Economon, B. Tracey
+ * \author F. Palacios, T. Economon, B. Tracey, H. Kline
  * \version 4.3.0 "Cardinal"
  *
  * SU2 Lead Developers: Dr. Francisco Palacios (Francisco.D.Palacios@boeing.com).

--- a/Common/src/geometry_structure.cpp
+++ b/Common/src/geometry_structure.cpp
@@ -5708,11 +5708,11 @@ void CPhysicalGeometry::Read_SU2_Format_Parallel(CConfig *config, string val_mes
             elem_line >> vnodes_triangle[2];
             
             if (actuator_disk) {
-              for (unsigned short i = 0; i<N_POINTS_TRIANGLE; i++) {
+              for (short i = 0; i<N_POINTS_TRIANGLE; i++) {
                 if (ActDisk_Bool[vnodes_triangle[i]]) {
                   
                   Xcg = 0.0; Counter = 0;
-                  for (unsigned short j = 0; j<N_POINTS_TRIANGLE; j++) {
+                  for (short j = 0; j<N_POINTS_TRIANGLE; j++) {
                     if (vnodes_triangle[j] < Global_nPoint-ActDiskNewPoints) {
                       Xcg += CoordXVolumePoint[VolumePoint_Inv[vnodes_triangle[j]]];
                       Counter++;
@@ -5801,7 +5801,7 @@ void CPhysicalGeometry::Read_SU2_Format_Parallel(CConfig *config, string val_mes
              any of the nodes making up this element have a global index value
              that falls within the range of our linear partitioning. ---*/
             
-            for (unsigned short i = 0; i < N_POINTS_QUADRILATERAL; i++) {
+            for (short i = 0; i < N_POINTS_QUADRILATERAL; i++) {
               
               local_index = vnodes_quad[i]-starting_node[rank];
               
@@ -5866,7 +5866,7 @@ void CPhysicalGeometry::Read_SU2_Format_Parallel(CConfig *config, string val_mes
              any of the nodes making up this element have a global index value
              that falls within the range of our linear partitioning. ---*/
             
-            for (unsigned short i = 0; i < N_POINTS_TETRAHEDRON; i++) {
+            for (short i = 0; i < N_POINTS_TETRAHEDRON; i++) {
               
               local_index = vnodes_tetra[i]-starting_node[rank];
               
@@ -5881,7 +5881,7 @@ void CPhysicalGeometry::Read_SU2_Format_Parallel(CConfig *config, string val_mes
 #ifdef HAVE_MPI
 #ifdef HAVE_PARMETIS
                 /*--- Build adjacency assuming the VTK connectivity ---*/
-                for (unsigned short j=0; j<N_POINTS_TETRAHEDRON; j++) {
+                for (short j=0; j<N_POINTS_TETRAHEDRON; j++) {
                   if (i != j) adj_nodes[local_index].push_back(vnodes_tetra[j]);
                 }
 #endif
@@ -5932,7 +5932,7 @@ void CPhysicalGeometry::Read_SU2_Format_Parallel(CConfig *config, string val_mes
              any of the nodes making up this element have a global index value
              that falls within the range of our linear partitioning. ---*/
             
-            for (unsigned short i = 0; i < N_POINTS_HEXAHEDRON; i++) {
+            for (short i = 0; i < N_POINTS_HEXAHEDRON; i++) {
               
               local_index = vnodes_hexa[i]-starting_node[rank];
               
@@ -6001,7 +6001,7 @@ void CPhysicalGeometry::Read_SU2_Format_Parallel(CConfig *config, string val_mes
              any of the nodes making up this element have a global index value
              that falls within the range of our linear partitioning. ---*/
             
-            for (unsigned short i = 0; i < N_POINTS_PRISM; i++) {
+            for (short i = 0; i < N_POINTS_PRISM; i++) {
               
               local_index = vnodes_prism[i]-starting_node[rank];
               
@@ -6069,7 +6069,7 @@ void CPhysicalGeometry::Read_SU2_Format_Parallel(CConfig *config, string val_mes
              any of the nodes making up this element have a global index value
              that falls within the range of our linear partitioning. ---*/
             
-            for (unsigned short i = 0; i < N_POINTS_PYRAMID; i++) {
+            for (short i = 0; i < N_POINTS_PYRAMID; i++) {
               
               local_index = vnodes_pyramid[i]-starting_node[rank];
               
@@ -8012,13 +8012,13 @@ void CPhysicalGeometry::Read_CGNS_Format_Parallel(CConfig *config, string val_me
               
             case TRIANGLE:
               
-              for ( unsigned short j = 0; j < N_POINTS_TRIANGLE; j++ ) {
+              for (short j = 0; j < N_POINTS_TRIANGLE; j++ ) {
                 vnodes_cgns[j] = connElems[k][s][j+1][i];
               }
               global_id = connElems[k][s][N_POINTS_TRIANGLE+1][i];
-              for (unsigned short ii=0; ii<N_POINTS_TRIANGLE; ii++) {
+              for (short ii=0; ii<N_POINTS_TRIANGLE; ii++) {
                 if ((vnodes_cgns[ii]>=starting_node[rank])&&(vnodes_cgns[ii]<ending_node[rank])) {
-                  for (unsigned short j=0; j<N_POINTS_TRIANGLE; j++) {
+                  for (short j=0; j<N_POINTS_TRIANGLE; j++) {
                     if (ii!=j) {
                       adj_nodes[vnodes_cgns[ii]-starting_node[rank]].push_back(vnodes_cgns[j]);
                     }
@@ -8032,12 +8032,12 @@ void CPhysicalGeometry::Read_CGNS_Format_Parallel(CConfig *config, string val_me
               
             case QUADRILATERAL:
               
-              for ( unsigned short j = 0; j < N_POINTS_QUADRILATERAL; j++ ) {
+              for (short j = 0; j < N_POINTS_QUADRILATERAL; j++ ) {
                 vnodes_cgns[j] = connElems[k][s][j+1][i];
               }
               global_id = connElems[k][s][N_POINTS_QUADRILATERAL+1][i];
               
-              for (unsigned short ii=0; ii<N_POINTS_QUADRILATERAL; ii++) {
+              for (short ii=0; ii<N_POINTS_QUADRILATERAL; ii++) {
                 if ((vnodes_cgns[ii]>=starting_node[rank])&&(vnodes_cgns[ii]<ending_node[rank])) {
                   
                   /*--- Build adjacency assuming the VTK connectivity ---*/
@@ -8055,13 +8055,13 @@ void CPhysicalGeometry::Read_CGNS_Format_Parallel(CConfig *config, string val_me
               
             case TETRAHEDRON:
               
-              for ( unsigned short j = 0; j < N_POINTS_TETRAHEDRON; j++ ) {
+              for (short j = 0; j < N_POINTS_TETRAHEDRON; j++ ) {
                 vnodes_cgns[j] = connElems[k][s][j+1][i];
               }
               global_id = connElems[k][s][N_POINTS_TETRAHEDRON+1][i];
-              for (unsigned short ii=0; ii<N_POINTS_TETRAHEDRON; ii++) {
+              for (short ii=0; ii<N_POINTS_TETRAHEDRON; ii++) {
                 if ((vnodes_cgns[ii]>=starting_node[rank])&&(vnodes_cgns[ii]<ending_node[rank])) {
-                  for (unsigned short j=0; j<N_POINTS_TETRAHEDRON; j++) {
+                  for (short j=0; j<N_POINTS_TETRAHEDRON; j++) {
                     if (ii!=j) {
                       adj_nodes[vnodes_cgns[ii]-starting_node[rank]].push_back(vnodes_cgns[j]);
                     }
@@ -8075,12 +8075,12 @@ void CPhysicalGeometry::Read_CGNS_Format_Parallel(CConfig *config, string val_me
               
             case HEXAHEDRON:
               
-              for ( unsigned short j = 0; j < N_POINTS_HEXAHEDRON; j++ ) {
+              for (short j = 0; j < N_POINTS_HEXAHEDRON; j++ ) {
                 vnodes_cgns[j] = connElems[k][s][j+1][i];
               }
               global_id = connElems[k][s][N_POINTS_HEXAHEDRON+1][i];
               
-              for (unsigned short ii=0; ii<N_POINTS_HEXAHEDRON; ii++) {
+              for (short ii=0; ii<N_POINTS_HEXAHEDRON; ii++) {
                 if ((vnodes_cgns[ii]>=starting_node[rank])&&(vnodes_cgns[ii]<ending_node[rank])) {
                   
                   /*--- Build adjacency assuming the VTK connectivity ---*/
@@ -8104,12 +8104,12 @@ void CPhysicalGeometry::Read_CGNS_Format_Parallel(CConfig *config, string val_me
               
             case PRISM:
               
-              for ( unsigned short j = 0; j < N_POINTS_PRISM; j++ ) {
+              for (short j = 0; j < N_POINTS_PRISM; j++ ) {
                 vnodes_cgns[j] = connElems[k][s][j+1][i];
               }
               global_id = connElems[k][s][N_POINTS_PRISM+1][i];
               
-              for (unsigned short ii=0; ii<N_POINTS_PRISM; ii++) {
+              for (short ii=0; ii<N_POINTS_PRISM; ii++) {
                 if ((vnodes_cgns[ii]>=starting_node[rank])&&(vnodes_cgns[ii]<ending_node[rank])) {
                   
                   /*--- Build adjacency assuming the VTK connectivity ---*/
@@ -8133,12 +8133,12 @@ void CPhysicalGeometry::Read_CGNS_Format_Parallel(CConfig *config, string val_me
               
             case PYRAMID:
               
-              for ( unsigned short j = 0; j < N_POINTS_PYRAMID; j++ ) {
+              for (short j = 0; j < N_POINTS_PYRAMID; j++ ) {
                 vnodes_cgns[j] = connElems[k][s][j+1][i];
               }
               global_id = connElems[k][s][N_POINTS_PYRAMID+1][i];
               
-              for (unsigned short ii=0; ii<N_POINTS_PYRAMID; ii++) {
+              for (short ii=0; ii<N_POINTS_PYRAMID; ii++) {
                 if ((vnodes_cgns[ii]>=starting_node[rank])&&(vnodes_cgns[ii]<ending_node[rank])) {
                   
                   /*--- Build adjacency assuming the VTK connectivity ---*/

--- a/Common/src/geometry_structure.cpp
+++ b/Common/src/geometry_structure.cpp
@@ -5708,11 +5708,11 @@ void CPhysicalGeometry::Read_SU2_Format_Parallel(CConfig *config, string val_mes
             elem_line >> vnodes_triangle[2];
             
             if (actuator_disk) {
-              for (short i = 0; i<N_POINTS_TRIANGLE; i++) {
+              for (unsigned short i = 0; i<N_POINTS_TRIANGLE; i++) {
                 if (ActDisk_Bool[vnodes_triangle[i]]) {
                   
                   Xcg = 0.0; Counter = 0;
-                  for (short j = 0; j<N_POINTS_TRIANGLE; j++) {
+                  for (unsigned short j = 0; j<N_POINTS_TRIANGLE; j++) {
                     if (vnodes_triangle[j] < Global_nPoint-ActDiskNewPoints) {
                       Xcg += CoordXVolumePoint[VolumePoint_Inv[vnodes_triangle[j]]];
                       Counter++;
@@ -5801,7 +5801,7 @@ void CPhysicalGeometry::Read_SU2_Format_Parallel(CConfig *config, string val_mes
              any of the nodes making up this element have a global index value
              that falls within the range of our linear partitioning. ---*/
             
-            for (short i = 0; i < N_POINTS_QUADRILATERAL; i++) {
+            for (unsigned short i = 0; i < N_POINTS_QUADRILATERAL; i++) {
               
               local_index = vnodes_quad[i]-starting_node[rank];
               
@@ -5866,7 +5866,7 @@ void CPhysicalGeometry::Read_SU2_Format_Parallel(CConfig *config, string val_mes
              any of the nodes making up this element have a global index value
              that falls within the range of our linear partitioning. ---*/
             
-            for (short i = 0; i < N_POINTS_TETRAHEDRON; i++) {
+            for (unsigned short i = 0; i < N_POINTS_TETRAHEDRON; i++) {
               
               local_index = vnodes_tetra[i]-starting_node[rank];
               
@@ -5881,7 +5881,7 @@ void CPhysicalGeometry::Read_SU2_Format_Parallel(CConfig *config, string val_mes
 #ifdef HAVE_MPI
 #ifdef HAVE_PARMETIS
                 /*--- Build adjacency assuming the VTK connectivity ---*/
-                for (short j=0; j<N_POINTS_TETRAHEDRON; j++) {
+                for (unsigned short j=0; j<N_POINTS_TETRAHEDRON; j++) {
                   if (i != j) adj_nodes[local_index].push_back(vnodes_tetra[j]);
                 }
 #endif
@@ -5932,7 +5932,7 @@ void CPhysicalGeometry::Read_SU2_Format_Parallel(CConfig *config, string val_mes
              any of the nodes making up this element have a global index value
              that falls within the range of our linear partitioning. ---*/
             
-            for (short i = 0; i < N_POINTS_HEXAHEDRON; i++) {
+            for (unsigned short i = 0; i < N_POINTS_HEXAHEDRON; i++) {
               
               local_index = vnodes_hexa[i]-starting_node[rank];
               
@@ -6001,7 +6001,7 @@ void CPhysicalGeometry::Read_SU2_Format_Parallel(CConfig *config, string val_mes
              any of the nodes making up this element have a global index value
              that falls within the range of our linear partitioning. ---*/
             
-            for (short i = 0; i < N_POINTS_PRISM; i++) {
+            for (unsigned short i = 0; i < N_POINTS_PRISM; i++) {
               
               local_index = vnodes_prism[i]-starting_node[rank];
               
@@ -6069,7 +6069,7 @@ void CPhysicalGeometry::Read_SU2_Format_Parallel(CConfig *config, string val_mes
              any of the nodes making up this element have a global index value
              that falls within the range of our linear partitioning. ---*/
             
-            for (short i = 0; i < N_POINTS_PYRAMID; i++) {
+            for (unsigned short i = 0; i < N_POINTS_PYRAMID; i++) {
               
               local_index = vnodes_pyramid[i]-starting_node[rank];
               
@@ -8012,13 +8012,13 @@ void CPhysicalGeometry::Read_CGNS_Format_Parallel(CConfig *config, string val_me
               
             case TRIANGLE:
               
-              for (short j = 0; j < N_POINTS_TRIANGLE; j++ ) {
+              for ( unsigned short j = 0; j < N_POINTS_TRIANGLE; j++ ) {
                 vnodes_cgns[j] = connElems[k][s][j+1][i];
               }
               global_id = connElems[k][s][N_POINTS_TRIANGLE+1][i];
-              for (short ii=0; ii<N_POINTS_TRIANGLE; ii++) {
+              for (unsigned short ii=0; ii<N_POINTS_TRIANGLE; ii++) {
                 if ((vnodes_cgns[ii]>=starting_node[rank])&&(vnodes_cgns[ii]<ending_node[rank])) {
-                  for (short j=0; j<N_POINTS_TRIANGLE; j++) {
+                  for (unsigned short j=0; j<N_POINTS_TRIANGLE; j++) {
                     if (ii!=j) {
                       adj_nodes[vnodes_cgns[ii]-starting_node[rank]].push_back(vnodes_cgns[j]);
                     }
@@ -8032,12 +8032,12 @@ void CPhysicalGeometry::Read_CGNS_Format_Parallel(CConfig *config, string val_me
               
             case QUADRILATERAL:
               
-              for (short j = 0; j < N_POINTS_QUADRILATERAL; j++ ) {
+              for ( unsigned short j = 0; j < N_POINTS_QUADRILATERAL; j++ ) {
                 vnodes_cgns[j] = connElems[k][s][j+1][i];
               }
               global_id = connElems[k][s][N_POINTS_QUADRILATERAL+1][i];
               
-              for (short ii=0; ii<N_POINTS_QUADRILATERAL; ii++) {
+              for (unsigned short ii=0; ii<N_POINTS_QUADRILATERAL; ii++) {
                 if ((vnodes_cgns[ii]>=starting_node[rank])&&(vnodes_cgns[ii]<ending_node[rank])) {
                   
                   /*--- Build adjacency assuming the VTK connectivity ---*/
@@ -8055,13 +8055,13 @@ void CPhysicalGeometry::Read_CGNS_Format_Parallel(CConfig *config, string val_me
               
             case TETRAHEDRON:
               
-              for (short j = 0; j < N_POINTS_TETRAHEDRON; j++ ) {
+              for ( unsigned short j = 0; j < N_POINTS_TETRAHEDRON; j++ ) {
                 vnodes_cgns[j] = connElems[k][s][j+1][i];
               }
               global_id = connElems[k][s][N_POINTS_TETRAHEDRON+1][i];
-              for (short ii=0; ii<N_POINTS_TETRAHEDRON; ii++) {
+              for (unsigned short ii=0; ii<N_POINTS_TETRAHEDRON; ii++) {
                 if ((vnodes_cgns[ii]>=starting_node[rank])&&(vnodes_cgns[ii]<ending_node[rank])) {
-                  for (short j=0; j<N_POINTS_TETRAHEDRON; j++) {
+                  for (unsigned short j=0; j<N_POINTS_TETRAHEDRON; j++) {
                     if (ii!=j) {
                       adj_nodes[vnodes_cgns[ii]-starting_node[rank]].push_back(vnodes_cgns[j]);
                     }
@@ -8075,12 +8075,12 @@ void CPhysicalGeometry::Read_CGNS_Format_Parallel(CConfig *config, string val_me
               
             case HEXAHEDRON:
               
-              for (short j = 0; j < N_POINTS_HEXAHEDRON; j++ ) {
+              for ( unsigned short j = 0; j < N_POINTS_HEXAHEDRON; j++ ) {
                 vnodes_cgns[j] = connElems[k][s][j+1][i];
               }
               global_id = connElems[k][s][N_POINTS_HEXAHEDRON+1][i];
               
-              for (short ii=0; ii<N_POINTS_HEXAHEDRON; ii++) {
+              for (unsigned short ii=0; ii<N_POINTS_HEXAHEDRON; ii++) {
                 if ((vnodes_cgns[ii]>=starting_node[rank])&&(vnodes_cgns[ii]<ending_node[rank])) {
                   
                   /*--- Build adjacency assuming the VTK connectivity ---*/
@@ -8104,12 +8104,12 @@ void CPhysicalGeometry::Read_CGNS_Format_Parallel(CConfig *config, string val_me
               
             case PRISM:
               
-              for (short j = 0; j < N_POINTS_PRISM; j++ ) {
+              for ( unsigned short j = 0; j < N_POINTS_PRISM; j++ ) {
                 vnodes_cgns[j] = connElems[k][s][j+1][i];
               }
               global_id = connElems[k][s][N_POINTS_PRISM+1][i];
               
-              for (short ii=0; ii<N_POINTS_PRISM; ii++) {
+              for (unsigned short ii=0; ii<N_POINTS_PRISM; ii++) {
                 if ((vnodes_cgns[ii]>=starting_node[rank])&&(vnodes_cgns[ii]<ending_node[rank])) {
                   
                   /*--- Build adjacency assuming the VTK connectivity ---*/
@@ -8133,12 +8133,12 @@ void CPhysicalGeometry::Read_CGNS_Format_Parallel(CConfig *config, string val_me
               
             case PYRAMID:
               
-              for (short j = 0; j < N_POINTS_PYRAMID; j++ ) {
+              for ( unsigned short j = 0; j < N_POINTS_PYRAMID; j++ ) {
                 vnodes_cgns[j] = connElems[k][s][j+1][i];
               }
               global_id = connElems[k][s][N_POINTS_PYRAMID+1][i];
               
-              for (short ii=0; ii<N_POINTS_PYRAMID; ii++) {
+              for (unsigned short ii=0; ii<N_POINTS_PYRAMID; ii++) {
                 if ((vnodes_cgns[ii]>=starting_node[rank])&&(vnodes_cgns[ii]<ending_node[rank])) {
                   
                   /*--- Build adjacency assuming the VTK connectivity ---*/

--- a/Common/src/geometry_structure.cpp
+++ b/Common/src/geometry_structure.cpp
@@ -5735,7 +5735,7 @@ void CPhysicalGeometry::Read_SU2_Format_Parallel(CConfig *config, string val_mes
              any of the nodes making up this element have a global index value
              that falls within the range of our linear partitioning. ---*/
             
-            for (int i = 0; i < N_POINTS_TRIANGLE; i++) {
+            for (unsigned short i = 0; i < N_POINTS_TRIANGLE; i++) {
               
               local_index = vnodes_triangle[i]-starting_node[rank];
               
@@ -5750,7 +5750,7 @@ void CPhysicalGeometry::Read_SU2_Format_Parallel(CConfig *config, string val_mes
 #ifdef HAVE_MPI
 #ifdef HAVE_PARMETIS
                 /*--- Build adjacency assuming the VTK connectivity ---*/
-                for (int j=0; j<N_POINTS_TRIANGLE; j++) {
+                for (unsigned short j=0; j<N_POINTS_TRIANGLE; j++) {
                   if (i != j) adj_nodes[local_index].push_back(vnodes_triangle[j]);
                 }
 #endif
@@ -5801,7 +5801,7 @@ void CPhysicalGeometry::Read_SU2_Format_Parallel(CConfig *config, string val_mes
              any of the nodes making up this element have a global index value
              that falls within the range of our linear partitioning. ---*/
             
-            for (int i = 0; i < N_POINTS_QUADRILATERAL; i++) {
+            for (unsigned short i = 0; i < N_POINTS_QUADRILATERAL; i++) {
               
               local_index = vnodes_quad[i]-starting_node[rank];
               
@@ -5866,7 +5866,7 @@ void CPhysicalGeometry::Read_SU2_Format_Parallel(CConfig *config, string val_mes
              any of the nodes making up this element have a global index value
              that falls within the range of our linear partitioning. ---*/
             
-            for (int i = 0; i < N_POINTS_TETRAHEDRON; i++) {
+            for (unsigned short i = 0; i < N_POINTS_TETRAHEDRON; i++) {
               
               local_index = vnodes_tetra[i]-starting_node[rank];
               
@@ -5881,7 +5881,7 @@ void CPhysicalGeometry::Read_SU2_Format_Parallel(CConfig *config, string val_mes
 #ifdef HAVE_MPI
 #ifdef HAVE_PARMETIS
                 /*--- Build adjacency assuming the VTK connectivity ---*/
-                for (int j=0; j<N_POINTS_TETRAHEDRON; j++) {
+                for (unsigned short j=0; j<N_POINTS_TETRAHEDRON; j++) {
                   if (i != j) adj_nodes[local_index].push_back(vnodes_tetra[j]);
                 }
 #endif
@@ -5932,7 +5932,7 @@ void CPhysicalGeometry::Read_SU2_Format_Parallel(CConfig *config, string val_mes
              any of the nodes making up this element have a global index value
              that falls within the range of our linear partitioning. ---*/
             
-            for (int i = 0; i < N_POINTS_HEXAHEDRON; i++) {
+            for (unsigned short i = 0; i < N_POINTS_HEXAHEDRON; i++) {
               
               local_index = vnodes_hexa[i]-starting_node[rank];
               
@@ -6001,7 +6001,7 @@ void CPhysicalGeometry::Read_SU2_Format_Parallel(CConfig *config, string val_mes
              any of the nodes making up this element have a global index value
              that falls within the range of our linear partitioning. ---*/
             
-            for (int i = 0; i < N_POINTS_PRISM; i++) {
+            for (unsigned short i = 0; i < N_POINTS_PRISM; i++) {
               
               local_index = vnodes_prism[i]-starting_node[rank];
               
@@ -6069,7 +6069,7 @@ void CPhysicalGeometry::Read_SU2_Format_Parallel(CConfig *config, string val_mes
              any of the nodes making up this element have a global index value
              that falls within the range of our linear partitioning. ---*/
             
-            for (int i = 0; i < N_POINTS_PYRAMID; i++) {
+            for (unsigned short i = 0; i < N_POINTS_PYRAMID; i++) {
               
               local_index = vnodes_pyramid[i]-starting_node[rank];
               
@@ -8012,7 +8012,7 @@ void CPhysicalGeometry::Read_CGNS_Format_Parallel(CConfig *config, string val_me
               
             case TRIANGLE:
               
-              for ( int j = 0; j < N_POINTS_TRIANGLE; j++ ) {
+              for ( unsigned short j = 0; j < N_POINTS_TRIANGLE; j++ ) {
                 vnodes_cgns[j] = connElems[k][s][j+1][i];
               }
               global_id = connElems[k][s][N_POINTS_TRIANGLE+1][i];
@@ -8032,7 +8032,7 @@ void CPhysicalGeometry::Read_CGNS_Format_Parallel(CConfig *config, string val_me
               
             case QUADRILATERAL:
               
-              for ( int j = 0; j < N_POINTS_QUADRILATERAL; j++ ) {
+              for ( unsigned short j = 0; j < N_POINTS_QUADRILATERAL; j++ ) {
                 vnodes_cgns[j] = connElems[k][s][j+1][i];
               }
               global_id = connElems[k][s][N_POINTS_QUADRILATERAL+1][i];
@@ -8055,7 +8055,7 @@ void CPhysicalGeometry::Read_CGNS_Format_Parallel(CConfig *config, string val_me
               
             case TETRAHEDRON:
               
-              for ( int j = 0; j < N_POINTS_TETRAHEDRON; j++ ) {
+              for ( unsigned short j = 0; j < N_POINTS_TETRAHEDRON; j++ ) {
                 vnodes_cgns[j] = connElems[k][s][j+1][i];
               }
               global_id = connElems[k][s][N_POINTS_TETRAHEDRON+1][i];
@@ -8075,7 +8075,7 @@ void CPhysicalGeometry::Read_CGNS_Format_Parallel(CConfig *config, string val_me
               
             case HEXAHEDRON:
               
-              for ( int j = 0; j < N_POINTS_HEXAHEDRON; j++ ) {
+              for ( unsigned short j = 0; j < N_POINTS_HEXAHEDRON; j++ ) {
                 vnodes_cgns[j] = connElems[k][s][j+1][i];
               }
               global_id = connElems[k][s][N_POINTS_HEXAHEDRON+1][i];
@@ -8104,7 +8104,7 @@ void CPhysicalGeometry::Read_CGNS_Format_Parallel(CConfig *config, string val_me
               
             case PRISM:
               
-              for ( int j = 0; j < N_POINTS_PRISM; j++ ) {
+              for ( unsigned short j = 0; j < N_POINTS_PRISM; j++ ) {
                 vnodes_cgns[j] = connElems[k][s][j+1][i];
               }
               global_id = connElems[k][s][N_POINTS_PRISM+1][i];
@@ -8133,7 +8133,7 @@ void CPhysicalGeometry::Read_CGNS_Format_Parallel(CConfig *config, string val_me
               
             case PYRAMID:
               
-              for ( int j = 0; j < N_POINTS_PYRAMID; j++ ) {
+              for ( unsigned short j = 0; j < N_POINTS_PYRAMID; j++ ) {
                 vnodes_cgns[j] = connElems[k][s][j+1][i];
               }
               global_id = connElems[k][s][N_POINTS_PYRAMID+1][i];

--- a/SU2_CFD/include/output_structure.hpp
+++ b/SU2_CFD/include/output_structure.hpp
@@ -182,6 +182,7 @@ public:
   
   /*!
 	 * \brief Writes one dimensional output.
+	 * \author H. Kline
 	 * \param[in] solver_container - Container vector with all the solutions.
 	 * \param[in] geometry - Geometrical definition of the problem.
 	 * \param[in] config - Definition of the particular problem.

--- a/SU2_CFD/src/driver_structure.cpp
+++ b/SU2_CFD/src/driver_structure.cpp
@@ -2188,7 +2188,7 @@ void CDriver::Iteration_Preprocessing() {
 
 void CDriver::Interface_Preprocessing() {
 
-  int rank = MASTER_NODE, nProcessor = 1;
+  int rank = MASTER_NODE;
   unsigned short donorZone, targetZone;
   unsigned short nVar, nVarTransfer;
 
@@ -2201,7 +2201,7 @@ void CDriver::Interface_Preprocessing() {
   int markDonor, markTarget, Donor_check, Target_check, iMarkerInt, nMarkerInt;
 
   #ifdef HAVE_MPI
-  int *Buffer_Recv_mark=NULL, iRank;
+  int *Buffer_Recv_mark=NULL, iRank, nProcessor=1;
 
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &nProcessor);

--- a/SU2_CFD/src/solver_adjoint_mean.cpp
+++ b/SU2_CFD/src/solver_adjoint_mean.cpp
@@ -1,7 +1,7 @@
 /*!
  * \file solution_adjoint_mean.cpp
- * \brief Main subrotuines for solving adjoint problems (Euler, Navier-Stokes, etc.).
- * \author F. Palacios, T. Economon
+ * \brief Main subroutines for solving adjoint problems (Euler, Navier-Stokes, etc.).
+ * \author F. Palacios, T. Economon, H. Kline
  * \version 4.3.0 "Cardinal"
  *
  * SU2 Lead Developers: Dr. Francisco Palacios (Francisco.D.Palacios@boeing.com).

--- a/SU2_CFD/src/solver_adjoint_mean.cpp
+++ b/SU2_CFD/src/solver_adjoint_mean.cpp
@@ -5916,7 +5916,7 @@ void CAdjEulerSolver::BC_Engine_Exhaust(CGeometry *geometry, CSolver **solver_co
 void CAdjEulerSolver::BC_ActDisk_Inlet(CGeometry *geometry, CSolver **solver_container, CNumerics *conv_numerics, CNumerics *visc_numerics, CConfig *config, unsigned short val_marker) {
   
   su2double *Normal, *V_domain, *V_inlet, *Psi_domain, *Psi_inlet,
-  UnitNormal[3], Area;
+  Area;
   unsigned short iVar, iDim;
   unsigned long iVertex, iPoint, GlobalIndex_inlet, GlobalIndex;
   
@@ -5944,14 +5944,6 @@ void CAdjEulerSolver::BC_ActDisk_Inlet(CGeometry *geometry, CSolver **solver_con
       for (iDim = 0; iDim < nDim; iDim++) Normal[iDim] = -Normal[iDim];
       conv_numerics->SetNormal(Normal);
       
-      Area = 0.0;
-      for (iDim = 0; iDim < nDim; iDim++)
-        Area += Normal[iDim]*Normal[iDim];
-      Area = sqrt (Area);
-      
-      for (iDim = 0; iDim < nDim; iDim++)
-        UnitNormal[iDim] = Normal[iDim]/Area;
-      
       /*--- Allocate the value at the inlet ---*/
       
       V_inlet = solver_container[FLOW_SOL]->GetCharacPrimVar(val_marker, iVertex);
@@ -5968,7 +5960,16 @@ void CAdjEulerSolver::BC_ActDisk_Inlet(CGeometry *geometry, CSolver **solver_con
       }
       
 #ifdef CHECK
+      su2double UnitNormal[3];
       
+      Area = 0.0;
+      for (iDim = 0; iDim < nDim; iDim++)
+        Area += Normal[iDim]*Normal[iDim];
+      Area = sqrt (Area);
+
+      for (iDim = 0; iDim < nDim; iDim++)
+        UnitNormal[iDim] = Normal[iDim]/Area;
+
       /*--- Subsonic flow is assumed, note that there is no non-dimensionalization. ---*/
       
       P_Fan = V_domain[nDim+1] ;
@@ -6048,7 +6049,7 @@ void CAdjEulerSolver::BC_ActDisk_Inlet(CGeometry *geometry, CSolver **solver_con
 
 void CAdjEulerSolver::BC_ActDisk_Outlet(CGeometry *geometry, CSolver **solver_container, CNumerics *conv_numerics, CNumerics *visc_numerics, CConfig *config, unsigned short val_marker) {
   
-  unsigned long iVertex, iPoint, Point_Normal, GlobalIndex_inlet, GlobalIndex;
+  unsigned long iVertex, iPoint, GlobalIndex_inlet, GlobalIndex;
   su2double *Normal, *V_domain, *V_outlet, *Psi_domain, *Psi_outlet;
   unsigned short iVar, iDim;
   
@@ -6078,10 +6079,6 @@ void CAdjEulerSolver::BC_ActDisk_Outlet(CGeometry *geometry, CSolver **solver_co
       for (iDim = 0; iDim < nDim; iDim++) Normal[iDim] = -Normal[iDim];
       conv_numerics->SetNormal(Normal);
       
-      /*--- Index of the closest interior node ---*/
-      
-      Point_Normal = geometry->vertex[val_marker][iVertex]->GetNormal_Neighbor();
-      
       /*--- Allocate the value at the outlet ---*/
       
       V_outlet = solver_container[FLOW_SOL]->GetCharacPrimVar(val_marker, iVertex);
@@ -6098,6 +6095,10 @@ void CAdjEulerSolver::BC_ActDisk_Outlet(CGeometry *geometry, CSolver **solver_co
       }
       
 #ifdef CHECK
+      unsigned long Point_Normal;
+      /*--- Index of the closest interior node ---*/
+
+      Point_Normal = geometry->vertex[val_marker][iVertex]->GetNormal_Neighbor();
       
       /*--- Adjoint flow solution at the outlet (this should be improved using characteristics bc) ---*/
       

--- a/SU2_CFD/src/solver_adjoint_mean.cpp
+++ b/SU2_CFD/src/solver_adjoint_mean.cpp
@@ -5915,8 +5915,7 @@ void CAdjEulerSolver::BC_Engine_Exhaust(CGeometry *geometry, CSolver **solver_co
 
 void CAdjEulerSolver::BC_ActDisk_Inlet(CGeometry *geometry, CSolver **solver_container, CNumerics *conv_numerics, CNumerics *visc_numerics, CConfig *config, unsigned short val_marker) {
   
-  su2double *Normal, *V_domain, *V_inlet, *Psi_domain, *Psi_inlet,
-  Area;
+  su2double *Normal, *V_domain, *V_inlet, *Psi_domain, *Psi_inlet;
   unsigned short iVar, iDim;
   unsigned long iVertex, iPoint, GlobalIndex_inlet, GlobalIndex;
   
@@ -5960,9 +5959,8 @@ void CAdjEulerSolver::BC_ActDisk_Inlet(CGeometry *geometry, CSolver **solver_con
       }
       
 #ifdef CHECK
-      su2double UnitNormal[3];
+      su2double UnitNormal[3], Area=0.0;
       
-      Area = 0.0;
       for (iDim = 0; iDim < nDim; iDim++)
         Area += Normal[iDim]*Normal[iDim];
       Area = sqrt (Area);

--- a/SU2_CFD/src/solver_direct_mean.cpp
+++ b/SU2_CFD/src/solver_direct_mean.cpp
@@ -7853,7 +7853,7 @@ void CEulerSolver::GetSurface_Distortion(CGeometry *geometry, CConfig *config, u
   unsigned short iStation, iAngle, nAngle, Theta, nStation;
   su2double *** ProbeArray, *Mach_Station, *Mach_Station_Min, *PT_Sector, *PT_Station, *PT_Station_Min,
   PT_Sector_Min, PT_Mean, Mach_Mean, q_Mean, UpVector[3], radians, RotatedVector[3],
-  RefDensity, RefVel, DC60, IDR, IDC, IDC_Mach;
+  DC60, IDR, IDC, IDC_Mach;
   su2double Pressure, Temperature, Density, SoundSpeed, Velocity2, Mach,  Gamma, TotalPressure, Mach_Inf, TotalPressure_Inf, Pressure_Inf;
   su2double dMach_dVel_x = 0.0, dMach_dVel_y = 0.0, dMach_dVel_z = 0.0, dMach_dT = 0.0, Gas_Constant;
   su2double dMach_dx = 0.0, dMach_dy = 0.0, dMach_dz = 0.0, dPT_dP = 0.0, dPT_dMach = 0.0, Aux = 0.0;
@@ -8370,9 +8370,6 @@ void CEulerSolver::GetSurface_Distortion(CGeometry *geometry, CConfig *config, u
         for (iAngle = 1; iAngle < nAngle; iAngle++) {
           if (PT_Sector[iAngle] <= PT_Sector_Min) PT_Sector_Min = PT_Sector[iAngle];
         }
-        
-        RefDensity  = GetDensity_Inf();
-        RefVel = GetModVelocity_Inf();
         
         /*--- Set the value of the distortion, it only works for one surface ---*/
         
@@ -9468,6 +9465,7 @@ void CEulerSolver::GetPower_Properties(CGeometry *geometry, CConfig *config, uns
           su2double Ref = config->GetDensity_Ref() * config->GetVelocity_Ref() * config->GetVelocity_Ref() * 1.0 * 1.0;
           su2double DmT = GetTotal_CD() * Factor;
           
+          /*
           su2double ModDmT = 0.0;
           if (nDim == 2) ModDmT = sqrt(GetTotal_CFx()*GetTotal_CFx() +
                                        GetTotal_CFy()*GetTotal_CFy());
@@ -9475,7 +9473,7 @@ void CEulerSolver::GetPower_Properties(CGeometry *geometry, CConfig *config, uns
           if (nDim == 3) ModDmT = sqrt(GetTotal_CFx()*GetTotal_CFx() +
                                        GetTotal_CFy()*GetTotal_CFy() +
                                        GetTotal_CFz()*GetTotal_CFz());
-          
+          */
           su2double SolidSurf_Drag = DmT - Force;
           su2double SolidSurf_CD = SolidSurf_Drag / Factor;
           

--- a/SU2_CFD/src/solver_direct_mean.cpp
+++ b/SU2_CFD/src/solver_direct_mean.cpp
@@ -6252,10 +6252,9 @@ void CEulerSolver::Momentum_Forces(CGeometry *geometry, CConfig *config) {
 
 #ifdef HAVE_MPI
   su2double MyAllBound_CD_Mnt, MyAllBound_CL_Mnt, MyAllBound_CSF_Mnt,
-  MyAllBound_CEff_Mnt,
 MyAllBound_CMx_Mnt, MyAllBound_CMy_Mnt, MyAllBound_CMz_Mnt,
   MyAllBound_CFx_Mnt, MyAllBound_CFy_Mnt, MyAllBound_CFz_Mnt, MyAllBound_CT_Mnt,
-  MyAllBound_CQ_Mnt, MyAllBound_CMerit_Mnt, MyAllBound_CNearFieldOF_Mnt,
+  MyAllBound_CQ_Mnt,
   *MySurface_CL_Mnt = NULL, *MySurface_CD_Mnt = NULL, *MySurface_CSF_Mnt = NULL,
   *MySurface_CEff_Mnt = NULL, *MySurface_CFx_Mnt = NULL, *MySurface_CFy_Mnt = NULL,
   *MySurface_CFz_Mnt = NULL,
@@ -6473,7 +6472,6 @@ MyAllBound_CMx_Mnt, MyAllBound_CMy_Mnt, MyAllBound_CMz_Mnt,
   MyAllBound_CD_Mnt        = AllBound_CD_Mnt;        AllBound_CD_Mnt = 0.0;
   MyAllBound_CL_Mnt        = AllBound_CL_Mnt;        AllBound_CL_Mnt = 0.0;
   MyAllBound_CSF_Mnt   = AllBound_CSF_Mnt;   AllBound_CSF_Mnt = 0.0;
-  MyAllBound_CEff_Mnt         = AllBound_CEff_Mnt;         AllBound_CEff_Mnt = 0.0;
   MyAllBound_CMx_Mnt          = AllBound_CMx_Mnt;          AllBound_CMx_Mnt = 0.0;
   MyAllBound_CMy_Mnt          = AllBound_CMy_Mnt;          AllBound_CMy_Mnt = 0.0;
   MyAllBound_CMz_Mnt          = AllBound_CMz_Mnt;          AllBound_CMz_Mnt = 0.0;
@@ -6482,7 +6480,6 @@ MyAllBound_CMx_Mnt, MyAllBound_CMy_Mnt, MyAllBound_CMz_Mnt,
   MyAllBound_CFz_Mnt          = AllBound_CFz_Mnt;          AllBound_CFz_Mnt = 0.0;
   MyAllBound_CT_Mnt           = AllBound_CT_Mnt;           AllBound_CT_Mnt = 0.0;
   MyAllBound_CQ_Mnt           = AllBound_CQ_Mnt;           AllBound_CQ_Mnt = 0.0;
-  MyAllBound_CMerit_Mnt       = AllBound_CMerit_Mnt;       AllBound_CMerit_Mnt = 0.0;
   
   SU2_MPI::Allreduce(&MyAllBound_CD_Mnt, &AllBound_CD_Mnt, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
   SU2_MPI::Allreduce(&MyAllBound_CL_Mnt, &AllBound_CL_Mnt, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
@@ -7849,14 +7846,14 @@ void CEulerSolver::GetSurface_Properties(CGeometry *geometry, CNumerics *conv_nu
 void CEulerSolver::GetSurface_Distortion(CGeometry *geometry, CConfig *config, unsigned short iMesh, bool Output) {
   
   unsigned short iMarker, iDim;
-  unsigned long iPoint, iVertex, Global_Index;
+  unsigned long iPoint, iVertex;
   su2double xCoord = 0.0, yCoord = 0.0, zCoord = 0.0, q = 0.0, PT = 0.0, Area = 0.0, *Vector, TotalArea = 0.0;
   su2double xCoord_CG = 0.0, yCoord_CG = 0.0, zCoord_CG = 0.0, TipRadius, HubRadius, Distance = 0.0, Distance_Mirror = 0.0;
   su2double *r, MinDistance, xCoord_ = 0.0, yCoord_ = 0.0, zCoord_ = 0, dx = 0.0, dy = 0.0, dz = 0.0, dx_ = 0.0, dy_ = 0.0, dz_ = 0.0;
   unsigned short iStation, iAngle, nAngle, Theta, nStation;
   su2double *** ProbeArray, *Mach_Station, *Mach_Station_Min, *PT_Sector, *PT_Station, *PT_Station_Min,
   PT_Sector_Min, PT_Mean, Mach_Mean, q_Mean, UpVector[3], radians, RotatedVector[3],
-  RefDensity, RefVel, Factor, DC60, IDR, IDC, IDC_Mach;
+  RefDensity, RefVel, DC60, IDR, IDC, IDC_Mach;
   su2double Pressure, Temperature, Density, SoundSpeed, Velocity2, Mach,  Gamma, TotalPressure, Mach_Inf, TotalPressure_Inf, Pressure_Inf;
   su2double dMach_dVel_x = 0.0, dMach_dVel_y = 0.0, dMach_dVel_z = 0.0, dMach_dT = 0.0, Gas_Constant;
   su2double dMach_dx = 0.0, dMach_dy = 0.0, dMach_dz = 0.0, dPT_dP = 0.0, dPT_dMach = 0.0, Aux = 0.0;
@@ -8154,7 +8151,6 @@ void CEulerSolver::GetSurface_Distortion(CGeometry *geometry, CConfig *config, u
             /*--- Current index position and global index ---*/
             
             Total_Index = iProcessor*MaxLocalVertex_Surface+iVertex;
-            Global_Index = Buffer_Recv_GlobalIndex[Total_Index];
             
             /*--- Retrieve the merged data for this node ---*/
             
@@ -8199,7 +8195,6 @@ void CEulerSolver::GetSurface_Distortion(CGeometry *geometry, CConfig *config, u
             /*--- Current index position and global index ---*/
             
             Total_Index = iProcessor*MaxLocalVertex_Surface+iVertex;
-            Global_Index = Buffer_Recv_GlobalIndex[Total_Index];
             
             /*--- Retrieve the merged data for this node ---*/
             
@@ -8287,7 +8282,6 @@ void CEulerSolver::GetSurface_Distortion(CGeometry *geometry, CConfig *config, u
                 /*--- Current index position and global index ---*/
                 
                 Total_Index = iProcessor*MaxLocalVertex_Surface+iVertex;
-                Global_Index = Buffer_Recv_GlobalIndex[Total_Index];
                 
                 /*--- Retrieve the merged data for this node ---*/
                 
@@ -8379,7 +8373,6 @@ void CEulerSolver::GetSurface_Distortion(CGeometry *geometry, CConfig *config, u
         
         RefDensity  = GetDensity_Inf();
         RefVel = GetModVelocity_Inf();
-        Factor = (0.5*RefDensity*RefVel*RefVel);
         
         /*--- Set the value of the distortion, it only works for one surface ---*/
         
@@ -8473,7 +8466,6 @@ void CEulerSolver::GetSurface_Distortion(CGeometry *geometry, CConfig *config, u
                 /*--- Current index position and global index ---*/
                 
                 Total_Index = iProcessor*MaxLocalVertex_Surface+iVertex;
-                Global_Index = Buffer_Recv_GlobalIndex[Total_Index];
                 
                 /*--- Retrieve the merged data for this node ---*/
                 
@@ -8594,7 +8586,6 @@ void CEulerSolver::GetSurface_Distortion(CGeometry *geometry, CConfig *config, u
                 /*--- Current index position and global index ---*/
                 
                 Total_Index = iProcessor*MaxLocalVertex_Surface+iVertex;
-                Global_Index = Buffer_Recv_GlobalIndex[Total_Index];
                 
                 /*--- Retrieve the merged data for this node ---*/
                 
@@ -8778,8 +8769,8 @@ void CEulerSolver::GetPower_Properties(CGeometry *geometry, CConfig *config, uns
   unsigned long iVertex, iPoint;
   su2double  *V_inlet = NULL, *V_outlet = NULL, Pressure, Temperature, Velocity[3], Vn,
   Velocity2, Density, Area, SoundSpeed, TotalPressure, Vel_Infty2, RamDrag,
-  TotalTemperature, Pressure_Infty, VelocityJet, VelocityIdeal, Pinf_To,
-  Vel_Infty, MassFlow_Inlet, MaxPressure, MinPressure, MFR, InfVel2;
+  TotalTemperature, VelocityJet,
+  Vel_Infty, MaxPressure, MinPressure, MFR, InfVel2;
   unsigned short iMarker_Inlet, iMarker_Outlet, nMarker_Inlet, nMarker_Outlet;
   string Inlet_TagBound, Outlet_TagBound, Marker_Tag;
   su2double DeltaPress = 0.0, DeltaTemp = 0.0, TotalPressRatio = 0.0, TotalTempRatio = 0.0, StaticPressRatio = 0.0, StaticTempRatio = 0.0,
@@ -8876,7 +8867,6 @@ void CEulerSolver::GetPower_Properties(CGeometry *geometry, CConfig *config, uns
             
             Temperature     = V_inlet[0];
             Pressure                = V_inlet[nDim+1];
-            Pressure_Infty  = GetPressure_Inf();
             
             Density                         = V_inlet[nDim+2];
             SoundSpeed  = sqrt(Gamma*Pressure/Density);
@@ -8947,12 +8937,11 @@ void CEulerSolver::GetPower_Properties(CGeometry *geometry, CConfig *config, uns
             
             Temperature         = V_outlet[0];
             Pressure                    = V_outlet[nDim+1];
-            Pressure_Infty  = GetPressure_Inf();
             
             Density                         = V_outlet[nDim+2];
             SoundSpeed  = sqrt(Gamma*Pressure/Density);
             
-            Velocity2 = 0.0; Area = 0.0; MassFlow = 0.0; Vel_Infty2 = 0.0; MassFlow_Inlet = 0.0;
+            Velocity2 = 0.0; Area = 0.0; MassFlow = 0.0; Vel_Infty2 = 0.0;
             for (iDim = 0; iDim < nDim; iDim++) {
               Area += Vector[iDim]*Vector[iDim];
               Velocity[iDim] = V_outlet[iDim+1];
@@ -9478,7 +9467,6 @@ void CEulerSolver::GetPower_Properties(CGeometry *geometry, CConfig *config, uns
           su2double Factor = (0.5*RefDensity*RefAreaCoeff*RefVel2);
           su2double Ref = config->GetDensity_Ref() * config->GetVelocity_Ref() * config->GetVelocity_Ref() * 1.0 * 1.0;
           su2double DmT = GetTotal_CD() * Factor;
-          su2double DmTVector[3] = {0.0, 0.0, 0.0};
           
           su2double ModDmT = 0.0;
           if (nDim == 2) ModDmT = sqrt(GetTotal_CFx()*GetTotal_CFx() +
@@ -9487,10 +9475,6 @@ void CEulerSolver::GetPower_Properties(CGeometry *geometry, CConfig *config, uns
           if (nDim == 3) ModDmT = sqrt(GetTotal_CFx()*GetTotal_CFx() +
                                        GetTotal_CFy()*GetTotal_CFy() +
                                        GetTotal_CFz()*GetTotal_CFz());
-          
-          DmTVector[0] = GetTotal_CFx()/ModDmT;
-          DmTVector[1] = GetTotal_CFy()/ModDmT;
-          if (nDim == 3)  DmTVector[2] = GetTotal_CFz()/ModDmT;
           
           su2double SolidSurf_Drag = DmT - Force;
           su2double SolidSurf_CD = SolidSurf_Drag / Factor;
@@ -9784,14 +9768,13 @@ void CEulerSolver::SetActDisk_BCThrust(CGeometry *geometry, CSolver **solver_con
   su2double Massflow = 0.0 , Target_Massflow = 0.0, DragMinusThrust = 0.0 , Target_DragMinusThrust = 0.0, Target_NetThrust = 0.0, BCThrust = 0.0, BCThrust_inc = 0.0;
   unsigned short iDim, iMarker;
   unsigned long iVertex, iPoint;
-  su2double  *V_inlet = NULL, Pressure, Temperature,
-  Density, T0_Ti, ATerm, BTerm, LHS, RHS, RHS_PDelta, RHS_MDelta, F, DF_DLa, CTerm, CTerm_, DTerm, DTerm_,
+  su2double  *V_inlet = NULL, Pressure,
+  Density, T0_Ti, ATerm, BTerm, LHS, RHS, RHS_PDelta, RHS_MDelta, F, DF_DLa, CTerm_, DTerm_,
   ETerm, La, La_old, TotalArea, To_Ti, DeltaT, Po_Pi, DeltaP, Area, Velocity_Normal,
   SoundSpeed2, Force_Normal,
   RefDensity, RefAreaCoeff, RefVel2, Factor, Ref;
   unsigned short iter;
   string ActDiskInlet_TagBound, ActDiskOutlet_TagBound, Marker_Tag;
-  su2double Omega;
   su2double Target_Force, Force, Target_Power, Power, NetThrust, BCThrust_old, Initial_BCThrust;
   bool ActDisk_Info;
   su2double MyBCThrust, BCThrust_Init;
@@ -9828,24 +9811,20 @@ void CEulerSolver::SetActDisk_BCThrust(CGeometry *geometry, CSolver **solver_con
           if (config->GetMach()  < 0.5) {
             DeltaP       = config->GetActDisk_PressJump(Marker_Tag, 0);
             DeltaT       = config->GetActDisk_TempJump(Marker_Tag, 0);
-            Omega        = config->GetActDisk_Omega(Marker_Tag, 0)*(PI_NUMBER/30.0);
           }
           else {
             DeltaP       = config->GetActDisk_PressJump(Marker_Tag, 1);
             DeltaT       = config->GetActDisk_TempJump(Marker_Tag, 1);
-            Omega        = config->GetActDisk_Omega(Marker_Tag, 1)*(PI_NUMBER/30.0);
           }
         }
         else {
           if (config->GetMach()  < 0.5) {
             DeltaP       = max(0.0, config->GetActDisk_PressJump(Marker_Tag, 0) / config->GetPressure_Ref());
             DeltaT       = max(0.0, config->GetActDisk_TempJump(Marker_Tag, 0) / config->GetTemperature_Ref());
-            Omega        = config->GetActDisk_Omega(Marker_Tag, 0)*(PI_NUMBER/30.0);
           }
           else {
             DeltaP       = max(0.0, config->GetActDisk_PressJump(Marker_Tag, 1) / config->GetPressure_Ref());
             DeltaT       = max(0.0, config->GetActDisk_TempJump(Marker_Tag, 1) / config->GetTemperature_Ref());
-            Omega        = config->GetActDisk_Omega(Marker_Tag, 1)*(PI_NUMBER/30.0);
           }
         }
         
@@ -9966,11 +9945,9 @@ void CEulerSolver::SetActDisk_BCThrust(CGeometry *geometry, CSolver **solver_con
             
             if (config->GetMach() < 0.5) {
               Target_NetThrust    = fabs( config->GetActDisk_PressJump(Marker_Tag, 0) / Ref);
-              Omega               = config->GetActDisk_Omega(Marker_Tag, 0)*(PI_NUMBER/30.0);
             }
             else {
               Target_NetThrust    = fabs( config->GetActDisk_PressJump(Marker_Tag, 1) / Ref);
-              Omega               = config->GetActDisk_Omega(Marker_Tag, 1)*(PI_NUMBER/30.0);
             }
             NetThrust    = config->GetActDisk_NetThrust(Marker_Tag);
             BCThrust_old = config->GetActDisk_BCThrust_Old(Marker_Tag);
@@ -9988,11 +9965,9 @@ void CEulerSolver::SetActDisk_BCThrust(CGeometry *geometry, CSolver **solver_con
             
             if (config->GetMach() < 0.5) {
               Target_Force =  fabs( config->GetActDisk_PressJump(Marker_Tag, 0) / Ref);
-              Omega = config->GetActDisk_Omega(Marker_Tag, 0)*(PI_NUMBER/30.0);
             }
             else {
               Target_Force =  fabs( config->GetActDisk_PressJump(Marker_Tag, 1) / Ref);
-              Omega = config->GetActDisk_Omega(Marker_Tag, 1)*(PI_NUMBER/30.0);
             }
             
             Force        = -config->GetActDisk_Force(Marker_Tag);
@@ -10013,11 +9988,9 @@ void CEulerSolver::SetActDisk_BCThrust(CGeometry *geometry, CSolver **solver_con
             
             if (config->GetMach() < 0.5) {
               Target_Power =  fabs( config->GetActDisk_PressJump(Marker_Tag, 0) / (Ref * config->GetVelocity_Ref() /  550.0));
-              Omega        = config->GetActDisk_Omega(Marker_Tag, 0)*(PI_NUMBER/30.0);
             }
             else {
               Target_Power =  fabs( config->GetActDisk_PressJump(Marker_Tag, 1) / (Ref * config->GetVelocity_Ref() /  550.0));
-              Omega        = config->GetActDisk_Omega(Marker_Tag, 1)*(PI_NUMBER/30.0);
             }
             
             Power        = config->GetActDisk_Power(Marker_Tag);
@@ -10036,11 +10009,9 @@ void CEulerSolver::SetActDisk_BCThrust(CGeometry *geometry, CSolver **solver_con
             
             if (config->GetMach() < 0.5) {
               Target_DragMinusThrust  =  -fabs(config->GetActDisk_PressJump(Marker_Tag, 0)) * Factor;
-              Omega        = config->GetActDisk_Omega(Marker_Tag, 0)*(PI_NUMBER/30.0);
             }
             else {
               Target_DragMinusThrust  =  -fabs(config->GetActDisk_PressJump(Marker_Tag, 1)) * Factor;
-              Omega        = config->GetActDisk_Omega(Marker_Tag, 1)*(PI_NUMBER/30.0);
             }
             
             DragMinusThrust = GetTotal_CD() * Factor;
@@ -10061,12 +10032,10 @@ void CEulerSolver::SetActDisk_BCThrust(CGeometry *geometry, CSolver **solver_con
             if (config->GetMach() < 0.5) {
               Target_Massflow  =  fabs(config->GetActDisk_PressJump(Marker_Tag, 0) / (config->GetDensity_Ref() * config->GetVelocity_Ref()));
               if (config->GetSystemMeasurements() == US) Target_Massflow /= 32.174;
-              Omega        = config->GetActDisk_Omega(Marker_Tag, 0)*(PI_NUMBER/30.0);
             }
             else {
               Target_Massflow  =  fabs(config->GetActDisk_PressJump(Marker_Tag, 1) / (config->GetDensity_Ref() * config->GetVelocity_Ref()));
               if (config->GetSystemMeasurements() == US) Target_Massflow /= 32.174;
-              Omega        = config->GetActDisk_Omega(Marker_Tag, 1)*(PI_NUMBER/30.0);
             }
             
             Massflow = config->GetActDisk_MassFlow(Marker_Tag);
@@ -10145,7 +10114,6 @@ void CEulerSolver::SetActDisk_BCThrust(CGeometry *geometry, CSolver **solver_con
               if (config->GetMarker_All_KindBC(iMarker) == ACTDISK_OUTLET)
                 V_inlet = GetDonorPrimVar(iMarker, iVertex);
               
-              Temperature   = V_inlet[0];
               Density       = V_inlet[nDim+2];
               Pressure      = V_inlet[nDim+1];
               SoundSpeed2   = Pressure*Gamma/Density;
@@ -10170,9 +10138,7 @@ void CEulerSolver::SetActDisk_BCThrust(CGeometry *geometry, CSolver **solver_con
                 BTerm = 0.5*(Gamma+1.0)/(Gamma-1.0);
                 LHS = fabs(Velocity_Normal)/(sqrt(SoundSpeed2)*pow(ATerm,BTerm));
                 
-                CTerm = (Gamma-1.0)/(Gamma+1.0);
                 CTerm_ = (PolyCoeff-1.0)/(PolyCoeff+1.0);
-                DTerm = 1.0/(Gamma-1.0);
                 DTerm_ = 1.0/(PolyCoeff-1.0);
                 
                 La = EPS, La_old = EPS;
@@ -13747,44 +13713,40 @@ void CEulerSolver::BC_Fluid_Interface(CGeometry *geometry, CSolver **solver_cont
   bool implicit      = (config->GetKind_TimeIntScheme_Flow() == EULER_IMPLICIT);
   bool grid_movement = config->GetGrid_Movement();
   
-  su2double Density, sq_vel, StaticEnergy;
-  
   su2double *Normal = new su2double[nDim];
   su2double *PrimVar_i = new su2double[nPrimVar];
   su2double *PrimVar_j = new su2double[nPrimVar];
   
   su2double P_static, rho_static;
-  
-  int rank = MASTER_NODE, irank = 1;
-  
-    for (iMarker = 0; iMarker < config->GetnMarker_All(); iMarker++) {
 
-      if (config->GetMarker_All_KindBC(iMarker) == FLUID_INTERFACE) {
+  for (iMarker = 0; iMarker < config->GetnMarker_All(); iMarker++) {
 
-        for (iVertex = 0; iVertex < geometry->nVertex[iMarker]; iVertex++) {
-          iPoint = geometry->vertex[iMarker][iVertex]->GetNode();
+    if (config->GetMarker_All_KindBC(iMarker) == FLUID_INTERFACE) {
 
-          if (geometry->node[iPoint]->GetDomain()) {
+      for (iVertex = 0; iVertex < geometry->nVertex[iMarker]; iVertex++) {
+        iPoint = geometry->vertex[iMarker][iVertex]->GetNode();
+
+        if (geometry->node[iPoint]->GetDomain()) {
 
           for (iVar = 0; iVar < nPrimVar; iVar++) {
             PrimVar_i[iVar] = node[iPoint]->GetPrimitive(iVar);
             PrimVar_j[iVar] = GetSlidingState(iMarker, iVertex, iVar);
           }
-          
+
           /*--- Set primitive variables ---*/
 
           numerics->SetPrimitive( PrimVar_i, PrimVar_j );
-          
+
           if( !( config->GetKind_FluidModel() == STANDARD_AIR || config->GetKind_FluidModel() == IDEAL_GAS ) ){
             Secondary_i = node[iPoint]->GetSecondary();
 
             P_static   = PrimVar_j[nDim+1];
             rho_static = PrimVar_j[nDim+2];           
             FluidModel->SetTDState_Prho(P_static, rho_static);
-            
+
             Secondary_j[0] = FluidModel->GetdPdrho_e();
             Secondary_j[1] = FluidModel->GetdPde_rho();  
-                   
+
             numerics->SetSecondary(Secondary_i, Secondary_j);
           }
 
@@ -13962,16 +13924,16 @@ void CEulerSolver::BC_ActDisk(CGeometry *geometry, CSolver **solver_container, C
     unsigned short iDim, iVar, jVar, jDim;
     unsigned long iVertex, iPoint, iPoint_Normal, GlobalIndex_donor, GlobalIndex;
     su2double Pressure, Velocity[3], Target_Press_Jump, Target_Temp_Jump,
-    Velocity2, Entropy, Density, Energy, Riemann, Vn, SoundSpeed, Mach_Inlet, Vn_Inlet, Mach_Outlet,
+    Velocity2, Entropy, Density, Energy, Riemann, Vn, SoundSpeed, Vn_Inlet, Mach_Outlet,
     Area, UnitNormal[3], *V_outlet, *V_domain, *V_inlet, P_Total, T_Total, H_Total, Temperature,
     Mach2, SoundSpeed2, SoundSpeed_Total2, Vel_Mag, alpha, aa, bb, cc, dd;
     su2double Factor, P_static, T_static, SoS_outlet, Rho_outlet, Rho_inlet;
     su2double Vel_normal_inlet[3], Vel_tangent_inlet[3], Vel_inlet[3];
     su2double Vel_normal_outlet[3], Vel_tangent_outlet[3], Vel_outlet[3];
     su2double Vel_normal_inlet_, Vel_tangent_inlet_, Vel_inlet_;
-    su2double Vel_normal_outlet_, Vel_tangent_outlet_, Vel_outlet_;
+    su2double Vel_normal_outlet_, Vel_outlet_;
     su2double turb_ke, a2, phi;
-    bool ReverseFlow, ActDisk_Perimeter;
+    bool ReverseFlow; //, ActDisk_Perimeter;
 
     bool implicit           = (config->GetKind_TimeIntScheme_Flow() == EULER_IMPLICIT);
     su2double Gas_Constant  = config->GetGas_ConstantND();
@@ -14003,7 +13965,7 @@ void CEulerSolver::BC_ActDisk(CGeometry *geometry, CSolver **solver_container, C
         iPoint_Normal = geometry->vertex[val_marker][iVertex]->GetNormal_Neighbor();
         GlobalIndex = geometry->node[iPoint]->GetGlobalIndex();
         GlobalIndex_donor = GetDonorGlobalIndex(val_marker, iVertex);
-        ActDisk_Perimeter = geometry->vertex[val_marker][iVertex]->GetActDisk_Perimeter();
+        //ActDisk_Perimeter = geometry->vertex[val_marker][iVertex]->GetActDisk_Perimeter();
 
         /*--- Check if the node belongs to the domain (i.e., not a halo node) ---*/
 
@@ -14068,7 +14030,6 @@ void CEulerSolver::BC_ActDisk(CGeometry *geometry, CSolver **solver_container, C
                     }
                     Pressure   = V_domain[nDim+1];
                     SoundSpeed = sqrt(Gamma*Pressure/Density);
-                    Mach_Inlet  = min(sqrt(Velocity2)/SoundSpeed, 1.0);
 
                     Entropy = Pressure*pow(1.0/Density, Gamma);
                     Riemann = Vn + 2.0*SoundSpeed/Gamma_Minus_One;
@@ -14136,7 +14097,6 @@ void CEulerSolver::BC_ActDisk(CGeometry *geometry, CSolver **solver_container, C
            no jump in the tangential velocity ---*/
 
                     Vel_normal_outlet_ = (1.0-SecondaryFlow/100.0)*(Rho_inlet*Vel_normal_inlet_)/Rho_outlet;
-                    Vel_tangent_outlet_ = Vel_tangent_inlet_;
 
                     Vel_outlet_ = 0.0;
                     for (iDim = 0; iDim < nDim; iDim++) {
@@ -16499,7 +16459,7 @@ CNSSolver::CNSSolver(CGeometry *geometry, CConfig *config, unsigned short iMesh)
 }
 
 CNSSolver::~CNSSolver(void) {
-  unsigned short iMarker, iDim, iVertex;
+  unsigned short iMarker, iDim;
   
   if (CD_Visc != NULL)          delete [] CD_Visc;
   if (CL_Visc != NULL)          delete [] CL_Visc;

--- a/SU2_CFD/src/transfer_physics.cpp
+++ b/SU2_CFD/src/transfer_physics.cpp
@@ -373,7 +373,6 @@ void CTransfer_SlidingInterface::GetPhysical_Constants(CSolver *donor_solution, 
 void CTransfer_SlidingInterface::GetDonor_Variable(CSolver *donor_solution, CGeometry *donor_geometry, CConfig *donor_config,
 					   	   	   	   	   	   	   	   unsigned long Marker_Donor, unsigned long Vertex_Donor, unsigned long Point_Donor){
 
-  su2double *Solution;
   unsigned short iVar;
 
   /*--- Retrieve solution and set it as the donor variable ---*/

--- a/SU2_CFD/src/transfer_structure.cpp
+++ b/SU2_CFD/src/transfer_structure.cpp
@@ -407,7 +407,7 @@ void CTransfer::Scatter_InterfaceData(CSolver *donor_solution, CSolver *target_s
       Buffer_Recv_TargetIndices[iVariable] = Buffer_Send_TargetIndices[iVariable];
 #endif
     
-    long indexPoint_iVertex, Point_Target_Check;
+    long indexPoint_iVertex, Point_Target_Check =0;
     
     /*--- For the target marker we are studying ---*/
     if (Marker_Target >= 0) {
@@ -724,7 +724,7 @@ void CTransfer::Broadcast_InterfaceData_Matching(CSolver *donor_solution, CSolve
     SU2_MPI::Bcast(Buffer_Bcast_Indices, nBuffer_BcastIndices, MPI_LONG, MASTER_NODE, MPI_COMM_WORLD);
 #endif
     
-    long indexPoint_iVertex, Point_Target_Check;
+    long indexPoint_iVertex, Point_Target_Check=0;
 
     /*--- For the target marker we are studying ---*/
     if (Marker_Target >= 0) {
@@ -1050,7 +1050,7 @@ void CTransfer::Broadcast_InterfaceData_Interpolate(CSolver *donor_solution, CSo
     SU2_MPI::Bcast(Buffer_Bcast_Indices, nBuffer_BcastIndices, MPI_LONG, MASTER_NODE, MPI_COMM_WORLD);
 #endif
 
-    long indexPoint_iVertex, Point_Target_Check;
+    long indexPoint_iVertex, Point_Target_Check=0;
     unsigned short iDonorPoint, nDonorPoints;
     su2double donorCoeff;
     
@@ -1339,7 +1339,7 @@ void CTransfer::Allgather_InterfaceData(CSolver *donor_solution, CSolver *target
       Buffer_Recv_DonorIndices[iVariable] = Buffer_Send_DonorIndices[iVariable];
 #endif
     
-    long indexPoint_iVertex, Point_Target_Check;
+    long indexPoint_iVertex, Point_Target_Check = 0;
     unsigned short iDonorPoint, nDonorPoints;
     su2double donorCoeff;
     

--- a/SU2_CFD/src/transfer_structure.cpp
+++ b/SU2_CFD/src/transfer_structure.cpp
@@ -98,7 +98,7 @@ void CTransfer::Scatter_InterfaceData(CSolver *donor_solution, CSolver *target_s
 #ifdef HAVE_MPI
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &size);
-  int *Buffer_Recv_mark, iRank;
+  int *Buffer_Recv_mark=NULL, iRank;
   
   if (rank == MASTER_NODE) 
     Buffer_Recv_mark = new int[size];
@@ -492,7 +492,7 @@ void CTransfer::Broadcast_InterfaceData_Matching(CSolver *donor_solution, CSolve
 #ifdef HAVE_MPI
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &size);
-  int *Buffer_Recv_mark, iRank;
+  int *Buffer_Recv_mark=NULL, iRank;
   
   if (rank == MASTER_NODE) 
     Buffer_Recv_mark = new int[size];
@@ -811,7 +811,7 @@ void CTransfer::Broadcast_InterfaceData_Interpolate(CSolver *donor_solution, CSo
 #ifdef HAVE_MPI
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &size);
-  int *Buffer_Recv_mark, iRank;
+  int *Buffer_Recv_mark=NULL, iRank;
   
   if (rank == MASTER_NODE) 
     Buffer_Recv_mark = new int[size];
@@ -1150,7 +1150,7 @@ void CTransfer::Allgather_InterfaceData(CSolver *donor_solution, CSolver *target
   int rank = MASTER_NODE;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &size);
-  int *Buffer_Recv_mark, iRank;
+  int *Buffer_Recv_mark=NULL, iRank;
   
   if (rank == MASTER_NODE) 
     Buffer_Recv_mark = new int[size];


### PR DESCRIPTION
There were several places where the compiler was returning warnings, for things like comparing signed and unsigned integers, uninitialized variables, unused variables, etc. 
This pull request corrects for these warnings; the largest change is in changing the type of some consts that previously returned signed-unsigned comparison warnings. 
