### PR TITLE
Fixes SU2_DOT for unsteady problems

### DIFF
--- a/Common/src/geometry_structure.cpp
+++ b/Common/src/geometry_structure.cpp
@@ -12801,7 +12801,7 @@ void CPhysicalGeometry::SetBoundSensitivity(CConfig *config) {
   su2double delta_T, total_T;
   if (config->GetUnsteady_Simulation() && config->GetWrt_Unsteady()) {
     nExtIter = config->GetUnst_AdjointIter();
-    delta_T  = config->GetDelta_UnstTimeND();
+    delta_T  = config->GetDelta_UnstTime();
     total_T  = (su2double)nExtIter*delta_T;
   } else if (config->GetUnsteady_Simulation() == HARMONIC_BALANCE) {
     


### PR DESCRIPTION
Addresses issue #296 . The problem was that the non-dimensional time step was not computed and therefore zero. We can simply use the dimensional one, as the non-dimensionalization factor cancels out anyway.