### PR TITLE
Disabling the new parallel IO routines for the release.

### DIFF
--- a/SU2_CFD/src/driver_structure.cpp
+++ b/SU2_CFD/src/driver_structure.cpp
@@ -2670,11 +2670,8 @@ void CDriver::Output(unsigned long ExtIter) {
     /*--- Execute the routine for writing restart, volume solution,
      surface solution, and surface comma-separated value files. ---*/
     
-    if (size == SINGLE_NODE)
-      output->SetResult_Files(solver_container, geometry_container, config_container, ExtIter, nZone);
-    else
-      output->SetResult_Files_Parallel(solver_container, geometry_container, config_container, ExtIter, nZone);
-    
+    output->SetResult_Files(solver_container, geometry_container, config_container, ExtIter, nZone);
+
     /*--- Output a file with the forces breakdown. ---*/
     
     output->SetForces_Breakdown(geometry_container, solver_container,


### PR DESCRIPTION
To be safe for v5, we will disable the new parallel IO restart routines until we have time to test on more and larger machines (a few folks have reported issues). All of the necessary code remains in the develop branch, however, and we will be working on this heavily right after the release.