### PR TITLE
Feature py multiobj

### DIFF
--- a/SU2_CFD/src/output_structure.cpp
+++ b/SU2_CFD/src/output_structure.cpp
@@ -3966,8 +3966,7 @@ void COutput::SetConvHistory_Header(ofstream *ConvHist_file, CConfig *config) {
   bool output_1d = config->GetWrt_1D_Output();
   bool output_massflow = (config->GetKind_ObjFunc() == MASS_FLOW_RATE);
   bool output_comboObj = (config->GetnObj() > 1);
-  bool output_per_surface = false;
-  if ((config->GetnMarker_Monitoring() > 1) && (!output_comboObj)) output_per_surface = true;
+  bool output_per_surface = (config->GetnMarker_Monitoring() > 1);
   
   unsigned short direct_diff = config->GetDirectDiff();
   /* Flag for whether to print heat flux values */
@@ -4215,10 +4214,8 @@ void COutput::SetConvHistory_Body(ofstream *ConvHist_file,
     bool actuator_disk = ((config[val_iZone]->GetnMarker_ActDiskInlet() != 0) || (config[val_iZone]->GetnMarker_ActDiskOutlet() != 0));
     bool inv_design = (config[val_iZone]->GetInvDesign_Cp() || config[val_iZone]->GetInvDesign_HeatFlux());
     bool transition = (config[val_iZone]->GetKind_Trans_Model() == LM);
-    bool thermal = false; /* flag for whether to print heat flux values */
-    if (config[val_iZone]->GetKind_Solver() == RANS or config[val_iZone]->GetKind_Solver()  == NAVIER_STOKES) {
-      thermal = true;
-    }
+    /* Flag for whether to print heat flux values */
+    bool thermal = (config[val_iZone]->GetKind_Solver() == RANS or config[val_iZone]->GetKind_Solver()  == NAVIER_STOKES);
     bool turbulent = ((config[val_iZone]->GetKind_Solver() == RANS) || (config[val_iZone]->GetKind_Solver() == ADJ_RANS) ||
                       (config[val_iZone]->GetKind_Solver() == DISC_ADJ_RANS));
     bool adjoint = config[val_iZone]->GetContinuous_Adjoint() || config[val_iZone]->GetDiscrete_Adjoint();
@@ -4238,10 +4235,9 @@ void COutput::SetConvHistory_Body(ofstream *ConvHist_file,
     bool turbo = config[val_iZone]->GetBoolTurboPerf();
     string inMarker_Tag, outMarker_Tag;
     
-    bool output_per_surface = false;
- //   if ((config[val_iZone]->GetnMarker_Monitoring() > 1) && (config[val_iZone]->GetnObj() <= 1)) output_per_surface = true;
-
+    bool output_per_surface = (config[val_iZone]->GetnMarker_Monitoring() > 1);
     
+
     unsigned short direct_diff = config[val_iZone]->GetDirectDiff();
     
     

--- a/SU2_CFD/src/output_structure.cpp
+++ b/SU2_CFD/src/output_structure.cpp
@@ -3967,15 +3967,11 @@ void COutput::SetConvHistory_Header(ofstream *ConvHist_file, CConfig *config) {
   bool output_massflow = (config->GetKind_ObjFunc() == MASS_FLOW_RATE);
   bool output_comboObj = (config->GetnObj() > 1);
   bool output_per_surface = false;
-  //if ((config->GetnMarker_Monitoring() > 1) && (!output_comboObj)) output_per_surface = true;
+  if ((config->GetnMarker_Monitoring() > 1) && (!output_comboObj)) output_per_surface = true;
   
   unsigned short direct_diff = config->GetDirectDiff();
-
-  bool thermal = false; /* Flag for whether to print heat flux values */
-
-  if (config->GetKind_Solver() == RANS or config->GetKind_Solver()  == NAVIER_STOKES) {
-    thermal = true;
-  }
+  /* Flag for whether to print heat flux values */
+  bool thermal = (config->GetKind_Solver() == RANS or config->GetKind_Solver()  == NAVIER_STOKES);
 
   
   /*--- Write file name with extension ---*/

--- a/SU2_PY/SU2/eval/design.py
+++ b/SU2_PY/SU2/eval/design.py
@@ -272,13 +272,14 @@ def obj_dp(config,state,this_obj,def_objs):
     value = su2func(this_obj,config,state)
     valuec = float(def_objs[this_obj]['CVAL'])
     dpenalty = 0.0
+
     # Inequalities will be 0 or a positive value
     if ((def_objs[this_obj]['CTYPE']=='>' and value < valuec)  or\
          (def_objs[this_obj]['CTYPE']=='<' and value > valuec )):
         dpenalty=2.0*abs(valuec - value)
-    # Equalities will be positive if value>constraint, negative if value<constraint
     elif (def_objs[this_obj]['CTYPE']=='='):
-        depenalty=2.0*(value -valuec)
+        # Equalities will be positive if value>constraint, negative if value<constraint
+        dpenalty=2.0*(value -valuec)
 
     return dpenalty
 
@@ -326,8 +327,6 @@ def obj_df(dvs,config,state=None):
                 # For a penalty function, the term is scaled by the partial derivative
                 # d p(j) / dx = (dj / dx) * ( dp / dj)  
                 scale[i_obj]*=obj_dp(config, state, this_obj, def_objs)
-
- 
             
         config['OBJECTIVE_WEIGHT']=','.join(map(str,scale))
         

--- a/SU2_PY/SU2/eval/design.py
+++ b/SU2_PY/SU2/eval/design.py
@@ -233,15 +233,17 @@ def obj_f(dvs,config,state=None):
     for i_obj,this_obj in enumerate(objectives):
         scale = def_objs[this_obj]['SCALE']
         sign  = su2io.get_objectiveSign(this_obj)
-        # Evaluate Objective Function
-        # scaling and sign
+        # Evaluate Objective Function scaling and sign
+        # If default evaluate as normal, 
         if def_objs[this_obj]['OBJTYPE']=='DEFAULT':
             func += su2func(this_obj,config,state) * sign * scale
+        # otherwise evaluate the penalty function (OBJTYPE = '>','<', or '=')
         else:
             func += obj_p(config,state,this_obj,def_objs) * scale
     vals_out.append(func)
     #: for each objective
-    # If evaluating the combined function is desired, update it here
+    # If evaluating the combined function is desired, update it here.
+    # This is only used when OPT_COMBINE_OBJECTIVE = YES
     if state.FUNCTIONS.has_key('COMBO'):
         state['FUNCTIONS']['COMBO'] = func
         

--- a/SU2_PY/SU2/eval/design.py
+++ b/SU2_PY/SU2/eval/design.py
@@ -253,14 +253,16 @@ def obj_p(config,state,this_obj,def_objs):
     # Penalty function: square of the difference between value and limit
     # This function is used when a constraint-type term is added to OPT_OBJECTIVE
     # This code, and obj_dp, must be changed to use a non-quadratic penalty function
-    value = su2func(this_obj,config,state)
-    valuec = float(def_objs[this_obj]['CVAL'])
-    penalty = 0.0                   
+    funcval = su2func(this_obj,config,state)
+    constraint = float(def_objs[this_obj]['VALUE'])
+              
     if (def_objs[this_obj]['OBJTYPE']=='=' or \
-        (def_objs[this_obj]['OBJTYPE']=='>' and value < valuec) or \
-        (def_objs[this_obj]['OBJTYPE']=='<' and value > valuec )):
-        penalty = (valuec - value)**2.0
-        
+        (def_objs[this_obj]['OBJTYPE']=='>' and funcval < constraint) or \
+        (def_objs[this_obj]['OBJTYPE']=='<' and funcval > constraint )):
+        penalty = (constraint - funcval)**2.0
+    # If 'DEFAULT' objtype this returns the function value. 
+    else:
+        penalty = funcval
     return penalty
 
 #: def obj_p()
@@ -269,17 +271,21 @@ def obj_dp(config,state,this_obj,def_objs):
     # Partial Derivative of Penalty function: square of the difference between value and limit
     # This function is used when a constraint-type term is added to OPT_OBJECTIVE
     # This code, and obj_p, must be changed to use a non-quadratic penalty function
-    value = su2func(this_obj,config,state)
-    valuec = float(def_objs[this_obj]['CVAL'])
-    dpenalty = 0.0
+    funcval = su2func(this_obj,config,state)
+    constraint = float(def_objs[this_obj]['VALUE'])
+    
 
     # Inequalities will be 0 or a positive value
-    if ((def_objs[this_obj]['OBJTYPE']=='>' and value < valuec)  or\
-         (def_objs[this_obj]['OBJTYPE']=='<' and value > valuec )):
-        dpenalty=2.0*abs(valuec - value)
+    if ((def_objs[this_obj]['OBJTYPE']=='>' and funcval < constraint)  or\
+         (def_objs[this_obj]['OBJTYPE']=='<' and funcval > constraint )):
+        dpenalty=2.0*abs(constraint - funcval)
+    # Equalities dp will be positive if value>constraint, negative if value<constraint
     elif (def_objs[this_obj]['OBJTYPE']=='='):
-        # Equalities will be positive if value>constraint, negative if value<constraint
-        dpenalty=2.0*(value -valuec)
+        dpenalty=2.0*(funcval -constraint)
+    # If 'DEFAULT' objtype, this will return 1.0
+    else:
+        dpenalty = 1.0
+    
 
     return dpenalty
 

--- a/SU2_PY/SU2/eval/design.py
+++ b/SU2_PY/SU2/eval/design.py
@@ -235,7 +235,7 @@ def obj_f(dvs,config,state=None):
         sign  = su2io.get_objectiveSign(this_obj)
         # Evaluate Objective Function
         # scaling and sign
-        if def_objs[this_obj]['CTYPE']=='NONE':
+        if def_objs[this_obj]['OBJTYPE']=='DEFAULT':
             func += su2func(this_obj,config,state) * sign * scale
         else:
             func += obj_p(config,state,this_obj,def_objs) * scale
@@ -256,9 +256,9 @@ def obj_p(config,state,this_obj,def_objs):
     value = su2func(this_obj,config,state)
     valuec = float(def_objs[this_obj]['CVAL'])
     penalty = 0.0                   
-    if (def_objs[this_obj]['CTYPE']=='=' or \
-        (def_objs[this_obj]['CTYPE']=='>' and value < valuec) or \
-        (def_objs[this_obj]['CTYPE']=='<' and value > valuec )):
+    if (def_objs[this_obj]['OBJTYPE']=='=' or \
+        (def_objs[this_obj]['OBJTYPE']=='>' and value < valuec) or \
+        (def_objs[this_obj]['OBJTYPE']=='<' and value > valuec )):
         penalty = (valuec - value)**2.0
         
     return penalty
@@ -274,10 +274,10 @@ def obj_dp(config,state,this_obj,def_objs):
     dpenalty = 0.0
 
     # Inequalities will be 0 or a positive value
-    if ((def_objs[this_obj]['CTYPE']=='>' and value < valuec)  or\
-         (def_objs[this_obj]['CTYPE']=='<' and value > valuec )):
+    if ((def_objs[this_obj]['OBJTYPE']=='>' and value < valuec)  or\
+         (def_objs[this_obj]['OBJTYPE']=='<' and value > valuec )):
         dpenalty=2.0*abs(valuec - value)
-    elif (def_objs[this_obj]['CTYPE']=='='):
+    elif (def_objs[this_obj]['OBJTYPE']=='='):
         # Equalities will be positive if value>constraint, negative if value<constraint
         dpenalty=2.0*(value -valuec)
 
@@ -322,7 +322,7 @@ def obj_df(dvs,config,state=None):
         scale = [1.0]*n_obj
         for i_obj,this_obj in enumerate(objectives):
             scale[i_obj] = def_objs[this_obj]['SCALE']
-            if def_objs[this_obj]['CTYPE']== 'NONE':
+            if def_objs[this_obj]['OBJTYPE']== 'DEFAULT':
                 # Standard case
                 sign = su2io.get_objectiveSign(this_obj)
                 scale[i_obj]*=sign

--- a/SU2_PY/SU2/eval/functions.py
+++ b/SU2_PY/SU2/eval/functions.py
@@ -81,6 +81,7 @@ def function( func_name, config, state=None ):
     
     # check for multiple objectives
     multi_objective = (type(func_name)==list)
+
     # func_name_string is only used to check whether the function has already been evaluated. 
     func_name_string = func_name
     if multi_objective:   func_name_string = func_name[0]  
@@ -110,15 +111,17 @@ def function( func_name, config, state=None ):
         func_out = state['FUNCTIONS']
     elif (multi_objective):
         # If combine_objective is true, use the 'combo' output.
-        objectives=config.OPT_OBJECTIVE
-        func_out = 0.0
-        for func in func_name:
-            sign = su2io.get_objectiveSign(func)
-            func_out+=state['FUNCTIONS'][func]*objectives[func]['SCALE']*sign
-        state['FUNCTIONS']['COMBO'] = func_out
+        func_out = state['FUNCTIONS']['COMBO']
     else:
         func_out = state['FUNCTIONS'][func_name]
-        
+
+    if config['OPT_OBJECTIVE'].has_key(func_name_string):
+        marker = config['OPT_OBJECTIVE'][func_name_string]['MARKER']
+        if su2io.per_surface_map.has_key(func_name_string):
+            name = su2io.per_surface_map[func_name_string]+'_'+marker
+            if state['FUNCTIONS'].has_key(name):
+                func_out = state['FUNCTIONS'][name]
+
     
     return copy.deepcopy(func_out)
 
@@ -260,6 +263,7 @@ def aerodynamics( config, state=None ):
                 push.append(info.FILES['TARGET_HEATFLUX'])
                 
     #: with output redirection
+    su2io.update_persurface(config,state)
     # return output 
     funcs = su2util.ordered_bunch()
     for key in su2io.optnames_aero + su2io.grad_names_directdiff:
@@ -269,7 +273,7 @@ def aerodynamics( config, state=None ):
     if 'OUTFLOW_GENERALIZED' in config.OBJECTIVE_FUNCTION:    
         import downstream_function
         state['FUNCTIONS']['OUTFLOW_GENERALIZED']=downstream_function.downstream_function(config,state)
-
+        
     return funcs
 
 #: def aerodynamics()

--- a/SU2_PY/SU2/eval/gradients.py
+++ b/SU2_PY/SU2/eval/gradients.py
@@ -467,7 +467,10 @@ def findiff( config, state=None ):
         log_findiff = None
 
     # evaluate step
-    step = 0.001 * float(config.REF_LENGTH_MOMENT)
+    if config.has_key('FIN_DIFF_STEP'):
+        step = float(config.FIN_DIFF_STEP)
+    else:
+        step = 0.001 * float(config.REF_LENGTH_MOMENT)
 
     # ----------------------------------------------------
     #  Redundancy Check

--- a/SU2_PY/SU2/eval/gradients.py
+++ b/SU2_PY/SU2/eval/gradients.py
@@ -80,17 +80,17 @@ def gradient( func_name, method, config, state=None ):
     state = su2io.State(state)
     if func_name == 'ALL':
         raise Exception , "func_name = 'ALL' not yet supported"
-    func_name_string = func_name
+    func_output = func_name
     if (type(func_name)==list):
         if (config.OPT_COMBINE_OBJECTIVE=="YES"):
-            func_name_string = 'COMBO'
+            func_output = 'COMBO'
         else:
             func_name = func_name[0]
     else:
         config.OPT_COMBINE_OBJECTIVE="NO"
         config.OBJECTIVE_WEIGHT = "1.0"
     # redundancy check
-    if not state['GRADIENTS'].has_key(func_name_string):
+    if not state['GRADIENTS'].has_key(func_output):
 
         # Adjoint Gradients
         if any([method == 'CONTINUOUS_ADJOINT', method == 'DISCRETE_ADJOINT']):
@@ -103,22 +103,22 @@ def gradient( func_name, method, config, state=None ):
                 config.OBJ_CHAIN_RULE_COEFF = str(chaingrad[0:5])
                 
             # Aerodynamics
-            if func_name_string in su2io.optnames_aero:
+            if func_output in su2io.optnames_aero:
                 grads = adjoint( func_name, config, state )
 
             elif func_name[0] in su2io.optnames_aero:
                 grads = adjoint( func_name, config, state )
                 
             # Stability
-            elif func_name_string in su2io.optnames_stab:
+            elif func_output in su2io.optnames_stab:
                 grads = stability( func_name, config, state )
 
             # Geometry (actually a finite difference)
-            elif func_name_string in su2io.optnames_geo:
+            elif func_output in su2io.optnames_geo:
                 grads = geometry( func_name, config, state )
 
             else:
-                raise Exception, 'unknown function name: %s' % func_name_string
+                raise Exception, 'unknown function name: %s' % func_output
 
         # Finite Difference Gradients
         elif method == 'FINDIFF':
@@ -133,11 +133,11 @@ def gradient( func_name, method, config, state=None ):
         if ('CUSTOM' in config.DV_KIND and 'OUTFLOW_GENERALIZED' in ', '.join(func_name)):
             import downstream_function
             chaingrad = downstream_function.downstream_gradient(config,state)
-            n_dv = len(grads[func_name_string])
+            n_dv = len(grads[func_output])
             custom_dv=1
             for idv in range(n_dv):
                 if (config.DV_KIND[idv] == 'CUSTOM'):
-                    grads[func_name_string][idv] = chaingrad[4+custom_dv]
+                    grads[func_output][idv] = chaingrad[4+custom_dv]
                     custom_dv = custom_dv+1
         # store
         state['GRADIENTS'].update(grads)
@@ -145,7 +145,7 @@ def gradient( func_name, method, config, state=None ):
     # if not redundant
 
     # prepare output
-    grads_out = state['GRADIENTS'][func_name_string]
+    grads_out = state['GRADIENTS'][func_output]
 
     return copy.deepcopy(grads_out)
 
@@ -194,12 +194,13 @@ def adjoint( func_name, config, state=None ):
     state = su2io.State(state)
     special_cases = su2io.get_specialCases(config)
     
-    # check for multiple objectives
+    # When a list of objectives is used, they are combined 
+    # and the output name is 'COMBO'
     multi_objective = (type(func_name)==list)
-    func_name_string = func_name
-    if multi_objective:   func_name_string = 'COMBO'
+    func_output = func_name
+    if multi_objective:   func_output = 'COMBO'
 
-    ADJ_NAME = 'ADJOINT_'+func_name_string
+    ADJ_NAME = 'ADJOINT_'+func_output
 
     # console output
     if config.get('CONSOLE','VERBOSE') in ['QUIET','CONCISE']:
@@ -212,7 +213,7 @@ def adjoint( func_name, config, state=None ):
     # ----------------------------------------------------    
 
     # master redundancy check
-    if state['GRADIENTS'].has_key(func_name_string):
+    if state['GRADIENTS'].has_key(func_output):
         grads = state['GRADIENTS']
         return copy.deepcopy(grads)
 
@@ -274,7 +275,7 @@ def adjoint( func_name, config, state=None ):
     with redirect_folder( ADJ_NAME, pull, link ) as push:
         with redirect_output(log_adjoint):        
 
-            # setup config
+            # Format objective list in config
             if multi_objective:
                 config['OBJECTIVE_FUNCTION'] = ", ".join(func_name)
             else:
@@ -298,7 +299,7 @@ def adjoint( func_name, config, state=None ):
 
     # return output 
     grads = su2util.ordered_bunch()
-    grads[func_name_string] = state['GRADIENTS'][func_name_string]
+    grads[func_output] = state['GRADIENTS'][func_output]
     return grads
 
 #: def adjoint()

--- a/SU2_PY/SU2/eval/gradients.py
+++ b/SU2_PY/SU2/eval/gradients.py
@@ -467,11 +467,11 @@ def findiff( config, state=None ):
     else:
         log_findiff = None
 
-    # evaluate step
+    # evaluate step length or set default value
     if config.has_key('FIN_DIFF_STEP'):
         step = float(config.FIN_DIFF_STEP)
     else:
-        step = 0.001 * float(config.REF_LENGTH_MOMENT)
+        step = 0.001 
 
     # ----------------------------------------------------
     #  Redundancy Check

--- a/SU2_PY/SU2/io/config.py
+++ b/SU2_PY/SU2/io/config.py
@@ -324,12 +324,12 @@ def read_config(filename):
         for case in switch(this_param):
             
             # comma delimited lists of strings with or without paren's
-            if case("MARKER_EULER")      : pass
-            if case("MARKER_FAR")        : pass
-            if case("MARKER_PLOTTING")   : pass
-            if case("MARKER_MONITORING") : pass
-            if case("MARKER_SYM")        : pass
-            if case("DV_KIND")           : 
+            if case("MARKER_EULER")      or\
+               case("MARKER_FAR")        or\
+               case("MARKER_PLOTTING")   or\
+               case("MARKER_MONITORING") or\
+               case("MARKER_SYM")        or\
+               case("DV_KIND")           : 
                 # remove white space
                 this_value = ''.join(this_value.split())   
                 # remove parens
@@ -337,7 +337,7 @@ def read_config(filename):
                 # split by comma
                 data_dict[this_param] = this_value.split(",")
                 break
-            
+
             # semicolon delimited lists of comma delimited lists of floats
             if case("DV_PARAM"):
                 # remove white space
@@ -385,9 +385,9 @@ def read_config(filename):
                 break
             
             # comma delimited lists of floats
-            if case("DV_VALUE_OLD")    : pass
-            if case("DV_VALUE_NEW")    : pass
-            if case("DV_VALUE")        :           
+            if case("DV_VALUE_OLD")    or\
+               case("DV_VALUE_NEW")    or\
+               case("DV_VALUE")        :           
                 # remove white space
                 this_value = ''.join(this_value.split())                
                 # split by comma, map to float, store in dictionary
@@ -395,23 +395,23 @@ def read_config(filename):
                 break              
 
             # float parameters
-            if case("MACH_NUMBER")            : pass
-            if case("AoA")                    : pass
-            if case("FIN_DIFF_STEP")          : pass
-            if case("CFL_NUMBER")             : pass
-            if case("HB_PERIOD")    : pass
-            if case("WRT_SOL_FREQ")           :
+            if case("MACH_NUMBER")            or\
+               case("AoA")                    or\
+               case("FIN_DIFF_STEP")          or\
+               case("CFL_NUMBER")             or\
+               case("HB_PERIOD")              or\
+               case("WRT_SOL_FREQ")           :
                 data_dict[this_param] = float(this_value)
                 break   
             
             # int parameters
-            if case("NUMBER_PART")            : pass
-            if case("AVAILABLE_PROC")         : pass
-            if case("EXT_ITER")               : pass
-            if case("TIME_INSTANCES")         : pass
-            if case("UNST_ADJOINT_ITER")      : pass
-            if case("ITER_AVERAGE_OBJ")       : pass
-            if case("ADAPT_CYCLES")           :
+            if case("NUMBER_PART")            or\
+               case("AVAILABLE_PROC")         or\
+               case("EXT_ITER")               or\
+               case("TIME_INSTANCES")         or\
+               case("UNST_ADJOINT_ITER")      or\
+               case("ITER_AVERAGE_OBJ")       or\
+               case("ADAPT_CYCLES")           :
                 data_dict[this_param] = int(this_value)
                 break                
             
@@ -604,10 +604,9 @@ def read_config(filename):
       data_dict['GRAD_OBJFUNC_FILENAME'] = 'of_grad.dat'
  
     #
-    # The eval functions below requires definition of various optimization
-    # variables, though we are handling here only a direct solution.
-    # So, if they are missing in the cfg file (and only then), some dummy values are
-    # introduced here
+    # Default values for optimization parameters (needed for some eval functions
+    # that can be called outside of an opt. context.
+    #
     if not data_dict.has_key('OBJECTIVE_FUNCTION'):
         data_dict['OBJECTIVE_FUNCTION']='DRAG'
     if not data_dict.has_key('DV_KIND'):

--- a/SU2_PY/SU2/io/config.py
+++ b/SU2_PY/SU2/io/config.py
@@ -505,12 +505,12 @@ def read_config(filename):
                         this_type = this_sgn
                         this_val = this_obj[1]
                     else:
-                        this_type = 'NONE'
-                        this_val  = 0.0
+                        this_type = 'DEFAULT'
+                        this_val  = 0.0 
                     this_name = this_obj[0]
                        
                     # Set up dict for objective, including scale, whether it is a penalty, and constraint value 
-                    this_def.update({ this_name : {'SCALE':this_scale, 'OBJTYPE':this_type, 'CVAL':this_val} })
+                    this_def.update({ this_name : {'SCALE':this_scale, 'OBJTYPE':this_type, 'VALUE':this_val} })
                     if (len(data_dict['MARKER_MONITORING'])>1):
                         this_def[this_name]['MARKER'] = data_dict['MARKER_MONITORING'][len(this_def)-1]
                     else:
@@ -791,15 +791,15 @@ def write_config(filename,param_dict):
                 break
             
             if case("OPT_OBJECTIVE"):
-                i_name = 0
+                n_obj = 0
                 for name,value in new_value.iteritems():
-                    if i_name>0: output_file.write("; ")
+                    if n_obj>0: output_file.write("; ")
                     if value['OBJTYPE']=='DEFAULT':
                         output_file.write( "%s * %s " % (name,value['SCALE']) )
                     else:
                         output_file.write( "( %s %s %s ) * %s" 
-                                           % (name, value['OBJTYPE'], value['CVAL'], value['SCALE']) )
-                    i_name += 1
+                                           % (name, value['OBJTYPE'], value['VALUE'], value['SCALE']) )
+                    n_obj += 1
                 break
             
             if case("OPT_CONSTRAINT"):

--- a/SU2_PY/SU2/io/config.py
+++ b/SU2_PY/SU2/io/config.py
@@ -509,7 +509,7 @@ def read_config(filename):
                         this_val  = 0.0
                     this_name = this_obj[0]
                        
- 
+                    # Set up dict for objective, including scale, whether it is a penalty, and constraint value 
                     this_def.update({ this_name : {'SCALE':this_scale, 'CTYPE':this_type, 'CVAL':this_val} })
                     if (len(data_dict['MARKER_MONITORING'])>1):
                         this_def[this_name]['MARKER'] = data_dict['MARKER_MONITORING'][len(this_def)-1]

--- a/SU2_PY/SU2/io/config.py
+++ b/SU2_PY/SU2/io/config.py
@@ -510,7 +510,7 @@ def read_config(filename):
                     this_name = this_obj[0]
                        
                     # Set up dict for objective, including scale, whether it is a penalty, and constraint value 
-                    this_def.update({ this_name : {'SCALE':this_scale, 'CTYPE':this_type, 'CVAL':this_val} })
+                    this_def.update({ this_name : {'SCALE':this_scale, 'OBJTYPE':this_type, 'CVAL':this_val} })
                     if (len(data_dict['MARKER_MONITORING'])>1):
                         this_def[this_name]['MARKER'] = data_dict['MARKER_MONITORING'][len(this_def)-1]
                     else:
@@ -794,11 +794,11 @@ def write_config(filename,param_dict):
                 i_name = 0
                 for name,value in new_value.iteritems():
                     if i_name>0: output_file.write("; ")
-                    if value['CTYPE']=='NONE':
+                    if value['OBJTYPE']=='DEFAULT':
                         output_file.write( "%s * %s " % (name,value['SCALE']) )
                     else:
                         output_file.write( "( %s %s %s ) * %s" 
-                                           % (name, value['CTYPE'], value['CVAL'], value['SCALE']) )
+                                           % (name, value['OBJTYPE'], value['CVAL'], value['SCALE']) )
                     i_name += 1
                 break
             

--- a/SU2_PY/SU2/io/tools.py
+++ b/SU2_PY/SU2/io/tools.py
@@ -197,9 +197,9 @@ history_header_map = { "Iteration"       : "ITERATION"               ,
                  "CEquivArea"      : "EQUIVALENT_AREA"         ,
                  "CNearFieldOF"    : "NEARFIELD_PRESSURE"      ,
                  "Avg_TotalPress"  : "AVG_TOTAL_PRESSURE"      ,
-                 "Avg_Pressure"    : "AVG_OUTLET_PRESSURE"     ,
-                 "Avg_Density"     : "AVG_OUTLET_DENSITY"      ,
-                 "Avg_Velocity"    : "AVG_OUTLET_VELOCITY"     ,
+                 "FluxAvg_Pressure": "AVG_OUTLET_PRESSURE"     ,
+                 "FluxAvg_Density" : "FLUXAVG_OUTLET_DENSITY"  ,
+                 "FluxAvg_Velocity": "FLUXAVG_OUTLET_VELOCITY" ,
                  "Avg_Mach"        : "AVG_OUTLET_MACH"         ,
                  "Avg_Temperature" : "AVG_OUTLET_TEMPERATURE"  ,
                  "MassFlowRate"    : "MASS_FLOW_RATE"          ,
@@ -664,7 +664,7 @@ def get_gradFileFormat(grad_type,plot_format,kindID,special_cases=[]):
                 header.append(r',"Grad_AeroCDrag","Grad_Distortion"')
                 write_format.append(", %.10f, %.10f")
             if key == "1D_OUTPUT"     :
-                header.append(r',"Grad_Avg_TotalPress","Grad_Avg_Mach","Grad_Avg_Temperature","Grad_MassFlowRate","Grad_Avg_Pressure","Grad_Avg_Density","Grad_Avg_Velocity","Grad_Avg_Enthalpy"')
+                header.append(r',"Grad_Avg_TotalPress","Grad_Avg_Mach","Grad_Avg_Temperature","Grad_MassFlowRate","Grad_FluxAvg_Pressure","Grad_FluxAvg_Density","Grad_FluxAvg_Velocity","Grad_FluxAvg_Enthalpy"')
                 write_format.append(", %.10f, %.10f, %.10f, %.10f, %.10f, %.10f, %.10f, %.10f")
             if key == "INV_DESIGN_CP"     :
                 header.append(r',"Grad_Cp_Diff"')
@@ -789,7 +789,7 @@ def get_optFileFormat(plot_format,special_cases=None):
             header_list.extend(["AeroCDrag","Distortion"])
             write_format.append(r', %.10f, %.10f')
         if key == "1D_OUTPUT":
-            header_list.extend(["Avg_TotalPress","Avg_Mach","Avg_Temperature","MassFlowRate","Avg_Pressure","Avg_Density","Avg_Velocity","Avg_Enthalpy"])
+            header_list.extend(["Avg_TotalPress","Avg_Mach","Avg_Temperature","MassFlowRate","FluxAvg_Pressure","FluxAvg_Density","FluxAvg_Velocity","FluxAvg_Enthalpy"])
             write_format.append(r', %.10f, %.10f, %.10f, %.10f, %.10f, %.10f, %.10f, %.10f')
         if key == "INV_DESIGN_CP"     :
             header_list.extend(["Cp_Diff"])

--- a/SU2_PY/SU2/io/tools.py
+++ b/SU2_PY/SU2/io/tools.py
@@ -379,19 +379,18 @@ per_surface_map = {"LIFT"       :   "CLift" ,
 #  Include per-surface output from History File
 # ------------------------------------------------------------------- 
 def update_persurface(config, state):
+    # Update the header map (checking to make sure entries are not duplicated)
     header_map = get_headerMap()
     for base in per_surface_map:
         base2 = per_surface_map[base]
-        for obj in config['OPT_OBJECTIVE']:
-            marker = config['OPT_OBJECTIVE'][obj]['MARKER']
+        for marker in config['MARKER_MONITORING']:
             if not header_map.has_key(base2+'_'+marker):
                 header_map[base2+'_'+marker] = base2+'_'+marker
-
+    # Update the function values in state to include the per-surface quantities
     if state['HISTORY'].has_key('DIRECT'):
         for base in per_surface_map:
             base2 = per_surface_map[base]
-            for obj in config['OPT_OBJECTIVE']:
-                marker = config['OPT_OBJECTIVE'][obj]['MARKER']
+            for marker in config['MARKER_MONITORING']:
                 if state['HISTORY']['DIRECT'].has_key(base2+'_'+marker):
                     state['FUNCTIONS'][base2+'_'+marker] = state['HISTORY']['DIRECT'][base2+'_'+marker][-1]
                     

--- a/SU2_PY/SU2/opt/project.py
+++ b/SU2_PY/SU2/opt/project.py
@@ -111,6 +111,20 @@ class Project(object):
         # setup config
         config = copy.deepcopy(config)
         
+        # config data_dict creation automatically reorders objectives s.t. marker monitored 
+        # may not be in the correct order for multiple objectives. 
+        def_objs = config['OPT_OBJECTIVE']
+        if len(def_objs)>1:
+            objectives = def_objs.keys()
+            marker_monitoring = []
+            weights = []
+            for i_obj, this_obj in enumerate(objectives):
+                marker_monitoring+=[def_objs[this_obj]['MARKER']]
+                weights+=[str(def_objs[this_obj]['SCALE'])]
+            config['MARKER_MONITORING'] = marker_monitoring
+            config['OBJECTIVE_WEIGHT'] = ",".join(weights)
+            config['OBJECTIVE_FUNCTION'] = ",".join(objectives)
+        
         # setup state
         if state is None:
             state = su2io.State()
@@ -266,7 +280,6 @@ class Project(object):
         """
          # local konfig
         konfig = copy.deepcopy(config)
-        
         # find closest design
         closest,delta = self.closest_design(konfig)
         # found existing design

--- a/SU2_PY/SU2/opt/project.py
+++ b/SU2_PY/SU2/opt/project.py
@@ -111,8 +111,9 @@ class Project(object):
         # setup config
         config = copy.deepcopy(config)
         
-        # config data_dict creation does not reliably produce the same order
-        # this section ensures that the order of markers and objectives match 
+        # data_dict creation does not preserve the ordering of the config file.
+        # This section ensures that the order of markers and objectives match 
+        # It is only needed when more than one objective is used.
         def_objs = config['OPT_OBJECTIVE']
         if len(def_objs)>1:
             objectives = def_objs.keys()

--- a/SU2_PY/SU2/opt/project.py
+++ b/SU2_PY/SU2/opt/project.py
@@ -111,8 +111,8 @@ class Project(object):
         # setup config
         config = copy.deepcopy(config)
         
-        # config data_dict creation automatically reorders objectives s.t. marker monitored 
-        # may not be in the correct order for multiple objectives. 
+        # config data_dict creation does not reliably produce the same order
+        # this section ensures that the order of markers and objectives match 
         def_objs = config['OPT_OBJECTIVE']
         if len(def_objs)>1:
             objectives = def_objs.keys()

--- a/SU2_PY/SU2/run/adjoint.py
+++ b/SU2_PY/SU2/run/adjoint.py
@@ -103,6 +103,8 @@ def adjoint( config ):
     
     # files out
     objective    = konfig['OBJECTIVE_FUNCTION']
+    if "," in objective:
+            objective="COMBO"
     adj_title    = 'ADJOINT_' + objective
     suffix       = su2io.get_adjointSuffix(objective)
     restart_name = konfig['RESTART_FLOW_FILENAME']

--- a/TestCases/cont_adj_euler/naca0012/inv_NACA0012_FD.cfg
+++ b/TestCases/cont_adj_euler/naca0012/inv_NACA0012_FD.cfg
@@ -54,6 +54,10 @@ REF_LENGTH_MOMENT= 1.0
 %
 % Reference area for force coefficients (0 implies automatic calculation)
 REF_AREA= 1.0
+%
+% Finite difference step size for python scripts (0.001 default, recommended
+%												  0.001 x REF_LENGTH_MOMENT)
+FIN_DIFF_STEP = 0.001
 
 % ----------------------- BOUNDARY CONDITION DEFINITION -----------------------%
 %

--- a/TestCases/cont_adj_euler/oneram6/inv_ONERAM6.cfg
+++ b/TestCases/cont_adj_euler/oneram6/inv_ONERAM6.cfg
@@ -87,7 +87,7 @@ MARKER_DESIGNING = ( WING )
 % Numerical method for spatial gradients (GREEN_GAUSS, WEIGHTED_LEAST_SQUARES)
 NUM_METHOD_GRAD= WEIGHTED_LEAST_SQUARES
 %
-% Objective function in optimization problem (DRAG, LIFT, SIDEFORCE, MOMENT_X,
+% Objective function in gradient evaluation  (DRAG, LIFT, SIDEFORCE, MOMENT_X,
 %                                             MOMENT_Y, MOMENT_Z, EFFICIENCY,
 %                                             EQUIVALENT_AREA, NEARFIELD_PRESSURE,
 %                                             FORCE_X, FORCE_Y, FORCE_Z, THRUST,

--- a/TestCases/cont_adj_euler/wedge/inv_wedge_ROE.cfg
+++ b/TestCases/cont_adj_euler/wedge/inv_wedge_ROE.cfg
@@ -195,14 +195,18 @@ MG_ADJFLOW= NO
 %                                             MAXIMUM_HEATFLUX, INVERSE_DESIGN_PRESSURE,
 %                                             INVERSE_DESIGN_HEATFLUX, AVG_TOTAL_PRESSURE, 
 %                                             MASS_FLOW_RATE)
+% For a weighted sum of objectives: separate by commas, add OBJECTIVE_WEIGHT and MARKER_MONITORING in matching order.
 OBJECTIVE_FUNCTION= OUTFLOW_GENERALIZED
+%
 % When using OUTFLOW_GENERALIZED with the continuous_adjoint or shape_optimization scripts,
 % 1D outputs must be tracked
 ONE_D_OUTPUT=YES
+%
 MARKER_OUT_1D  = (outlet)
 % using area-averaged values of the outflow quantities of density, velocity vector, and pressure
 % These are provided by an external script when using continuous_adjoint.py or shape_optimization.py
 OBJ_CHAIN_RULE_COEFF= (155003.94166680053, 1.0000000474974513, 0.0, 0.0, 1.5588809037581086)
+
 % --------------------------- CONVERGENCE PARAMETERS --------------------------%
 %
 % Convergence criteria (CAUCHY, RESIDUAL)

--- a/TestCases/cont_adj_euler/wedge/inv_wedge_ROE.cfg
+++ b/TestCases/cont_adj_euler/wedge/inv_wedge_ROE.cfg
@@ -187,7 +187,7 @@ LIMIT_ADJFLOW= 1E15
 % Multigrid adjoint problem (NO, YES)
 MG_ADJFLOW= NO
 %
-% Objective function in optimization problem (DRAG, LIFT, SIDEFORCE, MOMENT_X,
+% Objective function in gradient evaluation  (DRAG, LIFT, SIDEFORCE, MOMENT_X,
 %                                             MOMENT_Y, MOMENT_Z, EFFICIENCY,
 %                                             EQUIVALENT_AREA, NEARFIELD_PRESSURE,
 %                                             FORCE_X, FORCE_Y, FORCE_Z, THRUST,

--- a/TestCases/cont_adj_euler/wedge/inv_wedge_ROE.cfg
+++ b/TestCases/cont_adj_euler/wedge/inv_wedge_ROE.cfg
@@ -18,7 +18,7 @@
 PHYSICAL_PROBLEM= EULER
 %
 % Mathematical problem (DIRECT, CONTINUOUS_ADJOINT)
-MATH_PROBLEM= CONTINUOUS_ADJOINT
+MATH_PROBLEM= DIRECT
 %
 % Restart solution (NO, YES)
 RESTART_SOL= YES
@@ -198,7 +198,7 @@ MG_ADJFLOW= NO
 OBJECTIVE_FUNCTION= OUTFLOW_GENERALIZED
 % When using OUTFLOW_GENERALIZED with the continuous_adjoint or shape_optimization scripts,
 % 1D outputs must be tracked
-ONE_D_OUTPUT=YES
+KIND_ONE_DIMENSIONALIZATION = AREA
 MARKER_OUT_1D  = (outlet)
 % using area-averaged values of the outflow quantities of density, velocity vector, and pressure
 % These are provided by an external script when using continuous_adjoint.py or shape_optimization.py

--- a/TestCases/cont_adj_euler/wedge/inv_wedge_ROE.cfg
+++ b/TestCases/cont_adj_euler/wedge/inv_wedge_ROE.cfg
@@ -18,7 +18,7 @@
 PHYSICAL_PROBLEM= EULER
 %
 % Mathematical problem (DIRECT, CONTINUOUS_ADJOINT)
-MATH_PROBLEM= DIRECT
+MATH_PROBLEM= CONTINUOUS_ADJOINT
 %
 % Restart solution (NO, YES)
 RESTART_SOL= YES
@@ -198,7 +198,7 @@ MG_ADJFLOW= NO
 OBJECTIVE_FUNCTION= OUTFLOW_GENERALIZED
 % When using OUTFLOW_GENERALIZED with the continuous_adjoint or shape_optimization scripts,
 % 1D outputs must be tracked
-KIND_ONE_DIMENSIONALIZATION = AREA
+ONE_D_OUTPUT=YES
 MARKER_OUT_1D  = (outlet)
 % using area-averaged values of the outflow quantities of density, velocity vector, and pressure
 % These are provided by an external script when using continuous_adjoint.py or shape_optimization.py

--- a/TestCases/cont_adj_euler/wedge/inv_wedge_ROE_disc_multiobj.cfg
+++ b/TestCases/cont_adj_euler/wedge/inv_wedge_ROE_disc_multiobj.cfg
@@ -187,7 +187,7 @@ LIMIT_ADJFLOW= 1E15
 % Multigrid adjoint problem (NO, YES)
 MG_ADJFLOW= NO
 %
-% Objective function in optimization problem (DRAG, LIFT, SIDEFORCE, MOMENT_X,
+% Objective function in gradient evaluation   (DRAG, LIFT, SIDEFORCE, MOMENT_X,
 %                                             MOMENT_Y, MOMENT_Z, EFFICIENCY,
 %                                             EQUIVALENT_AREA, NEARFIELD_PRESSURE,
 %                                             FORCE_X, FORCE_Y, FORCE_Z, THRUST,
@@ -195,13 +195,18 @@ MG_ADJFLOW= NO
 %                                             MAXIMUM_HEATFLUX, INVERSE_DESIGN_PRESSURE,
 %                                             INVERSE_DESIGN_HEATFLUX, AVG_TOTAL_PRESSURE, 
 %                                             MASS_FLOW_RATE)
+% For a weighted sum of objectives: separate by commas, add OBJECTIVE_WEIGHT and MARKER_MONITORING in matching order.
 OBJECTIVE_FUNCTION = LIFT,AVG_TOTAL_PRESSURE
-% Coefficients for weighted sum of objectives
+%
+% List of weighting values when using more than one OBJECTIVE_FUNCTION. Separate by commas and match with MARKER_MONITORING.
 OBJECTIVE_WEIGHT=1.0E4,1E-4
+%
 % When using OUTFLOW_GENERALIZED with the continuous_adjoint or shape_optimization scripts,
 % 1D outputs must be tracked
 ONE_D_OUTPUT=YES
+%
 MARKER_OUT_1D  = (outlet)
+
 % --------------------------- CONVERGENCE PARAMETERS --------------------------%
 %
 % Convergence criteria (CAUCHY, RESIDUAL)

--- a/TestCases/cont_adj_euler/wedge/inv_wedge_ROE_multiobj.cfg
+++ b/TestCases/cont_adj_euler/wedge/inv_wedge_ROE_multiobj.cfg
@@ -181,7 +181,7 @@ LIMIT_ADJFLOW= 1E15
 % Multigrid adjoint problem (NO, YES)
 MG_ADJFLOW= NO
 %
-% Objective function in optimization problem (DRAG, LIFT, SIDEFORCE, MOMENT_X,
+% Objective function in gradient evaluation  (DRAG, LIFT, SIDEFORCE, MOMENT_X,
 %                                             MOMENT_Y, MOMENT_Z, EFFICIENCY,
 %                                             EQUIVALENT_AREA, NEARFIELD_PRESSURE,
 %                                             FORCE_X, FORCE_Y, FORCE_Z, THRUST,

--- a/TestCases/cont_adj_euler/wedge/inv_wedge_ROE_multiobj.cfg
+++ b/TestCases/cont_adj_euler/wedge/inv_wedge_ROE_multiobj.cfg
@@ -378,7 +378,8 @@ VISUALIZE_DEFORMATION= YES
 % Optimization objective function with scaling factor
 % ex= Objective * Scale
 OPT_OBJECTIVE=AVG_TOTAL_PRESSURE*1E-8;(DRAG = 0.045)*1E4
-%OPT_OBJECTIVE=OUTFLOW_GENERALIZED*1E-10;MOMENT_Z*1000.0
+%
+% Evaluate gradients simultaneously (when using the continuous adjoint method)
 OPT_COMBINE_OBJECTIVE = YES
 %
 % Optimization constraint functions with scaling factors, separated by semicolons

--- a/TestCases/cont_adj_euler/wedge/inv_wedge_ROE_multiobj.cfg
+++ b/TestCases/cont_adj_euler/wedge/inv_wedge_ROE_multiobj.cfg
@@ -18,7 +18,7 @@
 PHYSICAL_PROBLEM= EULER
 %
 % Mathematical problem (DIRECT, CONTINUOUS_ADJOINT)
-MATH_PROBLEM= CONTINUOUS_ADJOINT
+MATH_PROBLEM= DIRECT
 %
 % Restart solution (NO, YES)
 RESTART_SOL= YES
@@ -74,7 +74,7 @@ MARKER_OUTLET= ( outlet, 10000.0 )
 MARKER_PLOTTING= ( lower )
 %
 % Marker(s) of the surface where the functional (Cd, Cl, etc.) will be evaluated
-MARKER_MONITORING= (lower, outlet )
+MARKER_MONITORING= (outlet, lower )
 
 % ------------- COMMON PARAMETERS DEFINING THE NUMERICAL METHOD ---------------%
 %
@@ -96,7 +96,7 @@ CFL_ADAPT_PARAM= ( 1.5, 0.5, 1.0, 100.0 )
 RK_ALPHA_COEFF= ( 0.66667, 0.66667, 1.000000 )
 %
 % Number of total iterations
-EXT_ITER=10
+EXT_ITER=11000
 %
 % Linear solver for the implicit formulation (BCGSTAB, FGMRES)
 LINEAR_SOLVER= BCGSTAB
@@ -162,6 +162,14 @@ SPATIAL_ORDER_ADJFLOW= 2ND_ORDER
 %
 % Slope limiter (VENKATAKRISHNAN, SHARP_EDGES, WALL_DISTANCE)
 SLOPE_LIMITER_ADJFLOW= VENKATAKRISHNAN
+% Coefficient for the sharp edges limiter
+SHARP_EDGES_COEFF= 3.0
+%
+% Reference coefficient (sensitivity) for detecting sharp edges.
+REF_SHARP_EDGES= 3.0
+%
+% Remove sharp edges from the sensitivity evaluation (NO, YES)
+SENS_REMOVE_SHARP= NO
 %
 % 1st, 2nd, and 4th order artificial dissipation coefficients
 AD_COEFF_ADJFLOW= ( 0.15, 0.5, 0.02 )
@@ -176,7 +184,7 @@ RELAXATION_FACTOR_ADJFLOW= 1.0
 CFL_REDUCTION_ADJFLOW= 0.8
 %
 % Limit value for the adjoint variable
-LIMIT_ADJFLOW= 1E15
+LIMIT_ADJFLOW= 1E50
 %
 % Multigrid adjoint problem (NO, YES)
 MG_ADJFLOW= NO
@@ -189,13 +197,14 @@ MG_ADJFLOW= NO
 %                                             MAXIMUM_HEATFLUX, INVERSE_DESIGN_PRESSURE,
 %                                             INVERSE_DESIGN_HEATFLUX, AVG_TOTAL_PRESSURE, 
 %                                             MASS_FLOW_RATE)
-OBJECTIVE_FUNCTION = LIFT,OUTFLOW_GENERALIZED
-% Coefficients for weighted sum of objectives
-OBJECTIVE_WEIGHT=1.0E4,0.01
-% When using OUTFLOW_GENERALIZED with the continuous_adjoint or shape_optimization scripts,
-% 1D outputs must be tracked
-ONE_D_OUTPUT=YES
+OBJECTIVE_FUNCTION= AVG_TOTAL_PRESSURE, DRAG
+% Weights applied to a combined objective function
+OBJECTIVE_WEIGHT= -1e-07,1.0
+% Output one-dimensionalized quantities
+ONE_D_OUTPUT = YES
+% Marker on which to output one-dimensionalized quantities
 MARKER_OUT_1D  = (outlet)
+%
 % --------------------------- CONVERGENCE PARAMETERS --------------------------%
 %
 % Convergence criteria (CAUCHY, RESIDUAL)
@@ -203,13 +212,13 @@ MARKER_OUT_1D  = (outlet)
 CONV_CRITERIA= RESIDUAL
 %
 % Residual reduction (order of magnitude with respect to the initial value)
-RESIDUAL_REDUCTION= 10
+RESIDUAL_REDUCTION= 16
 %
 % Min value of the residual (log10 of the residual)
-RESIDUAL_MINVAL= -11
+RESIDUAL_MINVAL= -14
 %
 % Start convergence criteria at iteration number
-STARTCONV_ITER= 10
+STARTCONV_ITER= 100
 %
 % ------------------------- INPUT/OUTPUT INFORMATION --------------------------%
 %
@@ -260,7 +269,13 @@ WRT_SOL_FREQ= 250
 %
 % Writing convergence history frequency
 WRT_CON_FREQ= 1
-
+%
+% Write binary restart files (YES, NO)
+WRT_BINARY_RESTART= NO
+%
+% Read binary restart files (YES, NO)
+READ_BINARY_RESTART= NO
+%
 % -------------------- FREE-FORM DEFORMATION PARAMETERS -----------------------%
 %
 % Tolerance of the Free-Form Deformation point inversion
@@ -362,7 +377,9 @@ VISUALIZE_DEFORMATION= YES
 %
 % Optimization objective function with scaling factor
 % ex= Objective * Scale
-OPT_OBJECTIVE=LIFT*-1.0E4;OUTFLOW_GENERALIZED*0.01 
+OPT_OBJECTIVE=AVG_TOTAL_PRESSURE*1E-8;(DRAG = 0.045)*1E4
+%OPT_OBJECTIVE=OUTFLOW_GENERALIZED*1E-10;MOMENT_Z*1000.0
+OPT_COMBINE_OBJECTIVE = YES
 %
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='
@@ -372,7 +389,7 @@ OPT_CONSTRAINT= NONE
 OPT_ITERATIONS= 100
 %
 % Requested accuracy
-OPT_ACCURACY= 1E-6
+OPT_ACCURACY= 1E-10
 %
 % Upper bound for each design variable
 OPT_BOUND_UPPER= 0.1
@@ -381,5 +398,8 @@ OPT_BOUND_UPPER= 0.1
 OPT_BOUND_LOWER= -0.1
 %
 % Optimization design variables, separated by semicolons
-DEFINITION_DV= (7, 1.0| lower | MAIN_BOX, 2,0,0,1.0,0.0,0.0);(7, 1.0| lower | MAIN_BOX, 3,0,0,1.0,0.0,0.0);(7, 1.0| lower | MAIN_BOX, 4,0,0,1.0,0.0,0.0);(7, 1.0| lower | MAIN_BOX, 5,0,0,1.0,0.0,0.0);(7, 1.0| lower | MAIN_BOX, 6,0,0,1.0,0.0,0.0);(7, 1.0| lower | MAIN_BOX, 7,0,0,1.0,0.0,0.0);(19, 1.0 | | 3.0); (19, 1.0 | | 3.0); 
+DEFINITION_DV= (15, 1.0| lower | MAIN_BOX, 3,0,0,1.0);(15, 1.0| lower | MAIN_BOX, 4,0,0,1.0);(15, 1.0| lower | MAIN_BOX, 5,0,0,1.0);(15, 1.0| lower | MAIN_BOX, 6,0,0,1.0)
+%
+% Finite difference step size
+FIN_DIFF_STEP = 1e-4
 

--- a/TestCases/cont_adj_euler/wedge/inv_wedge_ROE_multiobj.cfg
+++ b/TestCases/cont_adj_euler/wedge/inv_wedge_ROE_multiobj.cfg
@@ -189,13 +189,18 @@ MG_ADJFLOW= NO
 %                                             MAXIMUM_HEATFLUX, INVERSE_DESIGN_PRESSURE,
 %                                             INVERSE_DESIGN_HEATFLUX, AVG_TOTAL_PRESSURE, 
 %                                             MASS_FLOW_RATE)
+% For a weighted sum of objectives: separate by commas, add OBJECTIVE_WEIGHT and MARKER_MONITORING in matching order.
 OBJECTIVE_FUNCTION = LIFT,OUTFLOW_GENERALIZED
-% Coefficients for weighted sum of objectives
+%
+% List of weighting values when using more than one OBJECTIVE_FUNCTION. Separate by commas and match with MARKER_MONITORING.
 OBJECTIVE_WEIGHT=1.0E4,0.01
+%
 % When using OUTFLOW_GENERALIZED with the continuous_adjoint or shape_optimization scripts,
 % 1D outputs must be tracked
 ONE_D_OUTPUT=YES
+%
 MARKER_OUT_1D  = (outlet)
+
 % --------------------------- CONVERGENCE PARAMETERS --------------------------%
 %
 % Convergence criteria (CAUCHY, RESIDUAL)
@@ -360,9 +365,13 @@ VISUALIZE_DEFORMATION= YES
 %    FFD_THICKNESS_2D 	( 17, Scale | Mark. List | FFD_BoxTag, i_Ind )
 %    FFD_CONTROL_SURFACE 	( 18, Scale | Mark. List | FFD_BoxTag, x_Orig, y_Orig, z_Orig, x_End, y_End, z_End )
 %
-% Optimization objective function with scaling factor
+% Optimization objective function with scaling factor, separated by semicolons.
+% To include quadratic penalty function: use OPT_CONSTRAINT option syntax within the OPT_OBJECTIVE list.
 % ex= Objective * Scale
 OPT_OBJECTIVE=LIFT*-1.0E4;OUTFLOW_GENERALIZED*0.01 
+%
+% Use combined objective within gradient evaluation: may reduce cost to compute gradients when using the adjoint formulation.
+OPT_COMBINE_OBJECTIVE = YES
 %
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='

--- a/TestCases/cont_adj_euler/wedge/inv_wedge_ROE_multiobj.cfg
+++ b/TestCases/cont_adj_euler/wedge/inv_wedge_ROE_multiobj.cfg
@@ -18,7 +18,7 @@
 PHYSICAL_PROBLEM= EULER
 %
 % Mathematical problem (DIRECT, CONTINUOUS_ADJOINT)
-MATH_PROBLEM= DIRECT
+MATH_PROBLEM= CONTINUOUS_ADJOINT
 %
 % Restart solution (NO, YES)
 RESTART_SOL= YES
@@ -74,7 +74,7 @@ MARKER_OUTLET= ( outlet, 10000.0 )
 MARKER_PLOTTING= ( lower )
 %
 % Marker(s) of the surface where the functional (Cd, Cl, etc.) will be evaluated
-MARKER_MONITORING= (outlet, lower )
+MARKER_MONITORING= (lower, outlet )
 
 % ------------- COMMON PARAMETERS DEFINING THE NUMERICAL METHOD ---------------%
 %
@@ -96,7 +96,7 @@ CFL_ADAPT_PARAM= ( 1.5, 0.5, 1.0, 100.0 )
 RK_ALPHA_COEFF= ( 0.66667, 0.66667, 1.000000 )
 %
 % Number of total iterations
-EXT_ITER=11000
+EXT_ITER=10
 %
 % Linear solver for the implicit formulation (BCGSTAB, FGMRES)
 LINEAR_SOLVER= BCGSTAB
@@ -162,14 +162,6 @@ SPATIAL_ORDER_ADJFLOW= 2ND_ORDER
 %
 % Slope limiter (VENKATAKRISHNAN, SHARP_EDGES, WALL_DISTANCE)
 SLOPE_LIMITER_ADJFLOW= VENKATAKRISHNAN
-% Coefficient for the sharp edges limiter
-SHARP_EDGES_COEFF= 3.0
-%
-% Reference coefficient (sensitivity) for detecting sharp edges.
-REF_SHARP_EDGES= 3.0
-%
-% Remove sharp edges from the sensitivity evaluation (NO, YES)
-SENS_REMOVE_SHARP= NO
 %
 % 1st, 2nd, and 4th order artificial dissipation coefficients
 AD_COEFF_ADJFLOW= ( 0.15, 0.5, 0.02 )
@@ -184,7 +176,7 @@ RELAXATION_FACTOR_ADJFLOW= 1.0
 CFL_REDUCTION_ADJFLOW= 0.8
 %
 % Limit value for the adjoint variable
-LIMIT_ADJFLOW= 1E50
+LIMIT_ADJFLOW= 1E15
 %
 % Multigrid adjoint problem (NO, YES)
 MG_ADJFLOW= NO
@@ -197,14 +189,13 @@ MG_ADJFLOW= NO
 %                                             MAXIMUM_HEATFLUX, INVERSE_DESIGN_PRESSURE,
 %                                             INVERSE_DESIGN_HEATFLUX, AVG_TOTAL_PRESSURE, 
 %                                             MASS_FLOW_RATE)
-OBJECTIVE_FUNCTION= AVG_TOTAL_PRESSURE, DRAG
-% Weights applied to a combined objective function
-OBJECTIVE_WEIGHT= -1e-07,1.0
-% Output one-dimensionalized quantities
-ONE_D_OUTPUT = YES
-% Marker on which to output one-dimensionalized quantities
+OBJECTIVE_FUNCTION = LIFT,OUTFLOW_GENERALIZED
+% Coefficients for weighted sum of objectives
+OBJECTIVE_WEIGHT=1.0E4,0.01
+% When using OUTFLOW_GENERALIZED with the continuous_adjoint or shape_optimization scripts,
+% 1D outputs must be tracked
+ONE_D_OUTPUT=YES
 MARKER_OUT_1D  = (outlet)
-%
 % --------------------------- CONVERGENCE PARAMETERS --------------------------%
 %
 % Convergence criteria (CAUCHY, RESIDUAL)
@@ -212,13 +203,13 @@ MARKER_OUT_1D  = (outlet)
 CONV_CRITERIA= RESIDUAL
 %
 % Residual reduction (order of magnitude with respect to the initial value)
-RESIDUAL_REDUCTION= 16
+RESIDUAL_REDUCTION= 10
 %
 % Min value of the residual (log10 of the residual)
-RESIDUAL_MINVAL= -14
+RESIDUAL_MINVAL= -11
 %
 % Start convergence criteria at iteration number
-STARTCONV_ITER= 100
+STARTCONV_ITER= 10
 %
 % ------------------------- INPUT/OUTPUT INFORMATION --------------------------%
 %
@@ -269,13 +260,7 @@ WRT_SOL_FREQ= 250
 %
 % Writing convergence history frequency
 WRT_CON_FREQ= 1
-%
-% Write binary restart files (YES, NO)
-WRT_BINARY_RESTART= NO
-%
-% Read binary restart files (YES, NO)
-READ_BINARY_RESTART= NO
-%
+
 % -------------------- FREE-FORM DEFORMATION PARAMETERS -----------------------%
 %
 % Tolerance of the Free-Form Deformation point inversion
@@ -377,10 +362,7 @@ VISUALIZE_DEFORMATION= YES
 %
 % Optimization objective function with scaling factor
 % ex= Objective * Scale
-OPT_OBJECTIVE=AVG_TOTAL_PRESSURE*1E-8;(DRAG = 0.045)*1E4
-%
-% Evaluate gradients simultaneously (when using the continuous adjoint method)
-OPT_COMBINE_OBJECTIVE = YES
+OPT_OBJECTIVE=LIFT*-1.0E4;OUTFLOW_GENERALIZED*0.01 
 %
 % Optimization constraint functions with scaling factors, separated by semicolons
 % ex= (Objective = Value ) * Scale, use '>','<','='
@@ -390,7 +372,7 @@ OPT_CONSTRAINT= NONE
 OPT_ITERATIONS= 100
 %
 % Requested accuracy
-OPT_ACCURACY= 1E-10
+OPT_ACCURACY= 1E-6
 %
 % Upper bound for each design variable
 OPT_BOUND_UPPER= 0.1
@@ -399,8 +381,5 @@ OPT_BOUND_UPPER= 0.1
 OPT_BOUND_LOWER= -0.1
 %
 % Optimization design variables, separated by semicolons
-DEFINITION_DV= (15, 1.0| lower | MAIN_BOX, 3,0,0,1.0);(15, 1.0| lower | MAIN_BOX, 4,0,0,1.0);(15, 1.0| lower | MAIN_BOX, 5,0,0,1.0);(15, 1.0| lower | MAIN_BOX, 6,0,0,1.0)
-%
-% Finite difference step size
-FIN_DIFF_STEP = 1e-4
+DEFINITION_DV= (7, 1.0| lower | MAIN_BOX, 2,0,0,1.0,0.0,0.0);(7, 1.0| lower | MAIN_BOX, 3,0,0,1.0,0.0,0.0);(7, 1.0| lower | MAIN_BOX, 4,0,0,1.0,0.0,0.0);(7, 1.0| lower | MAIN_BOX, 5,0,0,1.0,0.0,0.0);(7, 1.0| lower | MAIN_BOX, 6,0,0,1.0,0.0,0.0);(7, 1.0| lower | MAIN_BOX, 7,0,0,1.0,0.0,0.0);(19, 1.0 | | 3.0); (19, 1.0 | | 3.0); 
 

--- a/TestCases/cont_adj_euler/wedge/inv_wedge_ROE_multiobj.cfg
+++ b/TestCases/cont_adj_euler/wedge/inv_wedge_ROE_multiobj.cfg
@@ -265,6 +265,12 @@ WRT_SOL_FREQ= 250
 %
 % Writing convergence history frequency
 WRT_CON_FREQ= 1
+%
+% Write binary restart files
+WRT_BINARY_RESTART = NO
+%
+% Read binary restart files
+READ_BINARY_RESTART = NO
 
 % -------------------- FREE-FORM DEFORMATION PARAMETERS -----------------------%
 %

--- a/TestCases/cont_adj_navierstokes/naca0012_sub/lam_NACA0012.cfg
+++ b/TestCases/cont_adj_navierstokes/naca0012_sub/lam_NACA0012.cfg
@@ -82,7 +82,7 @@ MARKER_MONITORING= ( airfoil )
 % Numerical method for spatial gradients (GREEN_GAUSS, WEIGHTED_LEAST_SQUARES)
 NUM_METHOD_GRAD= WEIGHTED_LEAST_SQUARES
 %
-% Objective function in optimization problem (DRAG, LIFT, SIDEFORCE, MOMENT_X,
+% Objective function in gradient evaluation  (DRAG, LIFT, SIDEFORCE, MOMENT_X,
 %                                             MOMENT_Y, MOMENT_Z, EFFICIENCY,
 %                                             EQUIVALENT_AREA, NEARFIELD_PRESSURE,
 %                                             FORCE_X, FORCE_Y, FORCE_Z, THRUST,

--- a/TestCases/cont_adj_navierstokes/naca0012_trans/lam_NACA0012.cfg
+++ b/TestCases/cont_adj_navierstokes/naca0012_trans/lam_NACA0012.cfg
@@ -82,7 +82,7 @@ MARKER_MONITORING= ( airfoil )
 % Numerical method for spatial gradients (GREEN_GAUSS, WEIGHTED_LEAST_SQUARES)
 NUM_METHOD_GRAD= GREEN_GAUSS
 %
-% Objective function in optimization problem (DRAG, LIFT, SIDEFORCE, MOMENT_X,
+% Objective function in gradient evaluation  (DRAG, LIFT, SIDEFORCE, MOMENT_X,
 %                                             MOMENT_Y, MOMENT_Z, EFFICIENCY,
 %                                             EQUIVALENT_AREA, NEARFIELD_PRESSURE,
 %                                             FORCE_X, FORCE_Y, FORCE_Z, THRUST,

--- a/TestCases/coupled_fsi/2d_aeroelasticity/SU2_config.cfg
+++ b/TestCases/coupled_fsi/2d_aeroelasticity/SU2_config.cfg
@@ -223,7 +223,7 @@ CFL_ADAPT_PARAM= ( 1.5, 1.5, 1000, 100000 )
 % Runge-Kutta alpha coefficients
 RK_ALPHA_COEFF= ( 0.66667, 0.66667, 1.000000 )
 %
-% Objective function in optimization problem (DRAG, LIFT, SIDEFORCE, MOMENT_X,
+% Objective function in gradient evaluation  (DRAG, LIFT, SIDEFORCE, MOMENT_X,
 %                                             MOMENT_Y, MOMENT_Z, EFFICIENCY,
 %                                             EQUIVALENT_AREA, NEARFIELD_PRESSURE,
 %                                             FORCE_X, FORCE_Y, FORCE_Z, THRUST,

--- a/TestCases/deformation/cylindrical_ffd/def_cylindrical.cfg
+++ b/TestCases/deformation/cylindrical_ffd/def_cylindrical.cfg
@@ -100,7 +100,7 @@ CFL_ADAPT= NO
 %                                        CFL max value )
 CFL_ADAPT_PARAM= ( 1.0, 1.0, 1.0, 10.0 )
 %
-% Objective function in optimization problem (DRAG, LIFT, SIDEFORCE, MOMENT_X,
+% Objective function in gradient evaluation  (DRAG, LIFT, SIDEFORCE, MOMENT_X,
 %                                             MOMENT_Y, MOMENT_Z, EFFICIENCY,
 %                                             EQUIVALENT_AREA, NEARFIELD_PRESSURE,
 %                                             FORCE_X, FORCE_Y, FORCE_Z, THRUST,

--- a/TestCases/deformation/naca0012/def_NACA0012.cfg
+++ b/TestCases/deformation/naca0012/def_NACA0012.cfg
@@ -85,7 +85,7 @@ MARKER_DESIGNING = ( airfoil )
 % Numerical method for spatial gradients (GREEN_GAUSS, WEIGHTED_LEAST_SQUARES)
 NUM_METHOD_GRAD= WEIGHTED_LEAST_SQUARES
 %
-% Objective function in optimization problem (DRAG, LIFT, SIDEFORCE, MOMENT_X,
+% Objective function in gradient evaluation  (DRAG, LIFT, SIDEFORCE, MOMENT_X,
 %                                             MOMENT_Y, MOMENT_Z, EFFICIENCY,
 %                                             EQUIVALENT_AREA, NEARFIELD_PRESSURE,
 %                                             FORCE_X, FORCE_Y, FORCE_Z, THRUST,

--- a/TestCases/deformation/naca4412/def_NACA4412.cfg
+++ b/TestCases/deformation/naca4412/def_NACA4412.cfg
@@ -95,7 +95,7 @@ CFL_ADAPT_PARAM= ( 1.5, 0.5, 10.0, 1000.0 )
 % Number of total iterations
 EXT_ITER= 99999
 %
-% Objective function in optimization problem (DRAG, LIFT, SIDEFORCE, MOMENT_X,
+% Objective function in gradient evaluation  (DRAG, LIFT, SIDEFORCE, MOMENT_X,
 %                                             MOMENT_Y, MOMENT_Z, EFFICIENCY,
 %                                             EQUIVALENT_AREA, NEARFIELD_PRESSURE,
 %                                             FORCE_X, FORCE_Y, FORCE_Z, THRUST,

--- a/TestCases/deformation/spherical_ffd/def_spherical.cfg
+++ b/TestCases/deformation/spherical_ffd/def_spherical.cfg
@@ -100,7 +100,7 @@ CFL_ADAPT= NO
 %                                        CFL max value )
 CFL_ADAPT_PARAM= ( 1.0, 1.0, 1.0, 10.0 )
 %
-% Objective function in optimization problem (DRAG, LIFT, SIDEFORCE, MOMENT_X,
+% Objective function in gradient evaluation  (DRAG, LIFT, SIDEFORCE, MOMENT_X,
 %                                             MOMENT_Y, MOMENT_Z, EFFICIENCY,
 %                                             EQUIVALENT_AREA, NEARFIELD_PRESSURE,
 %                                             FORCE_X, FORCE_Y, FORCE_Z, THRUST,

--- a/TestCases/deformation/spherical_ffd/def_spherical_bspline.cfg
+++ b/TestCases/deformation/spherical_ffd/def_spherical_bspline.cfg
@@ -100,7 +100,7 @@ CFL_ADAPT= NO
 %                                        CFL max value )
 CFL_ADAPT_PARAM= ( 1.0, 1.0, 1.0, 10.0 )
 %
-% Objective function in optimization problem (DRAG, LIFT, SIDEFORCE, MOMENT_X,
+% Objective function in gradient evaluation  (DRAG, LIFT, SIDEFORCE, MOMENT_X,
 %                                             MOMENT_Y, MOMENT_Z, EFFICIENCY,
 %                                             EQUIVALENT_AREA, NEARFIELD_PRESSURE,
 %                                             FORCE_X, FORCE_Y, FORCE_Z, THRUST,

--- a/TestCases/euler/naca0012/inv_NACA0012.cfg
+++ b/TestCases/euler/naca0012/inv_NACA0012.cfg
@@ -77,7 +77,7 @@ MARKER_DESIGNING = ( airfoil )
 % Numerical method for spatial gradients (GREEN_GAUSS, WEIGHTED_LEAST_SQUARES)
 NUM_METHOD_GRAD= WEIGHTED_LEAST_SQUARES
 %
-% Objective function in optimization problem (DRAG, LIFT, SIDEFORCE, MOMENT_X,
+% Objective function in gradient evaluation  (DRAG, LIFT, SIDEFORCE, MOMENT_X,
 %                                             MOMENT_Y, MOMENT_Z, EFFICIENCY,
 %                                             EQUIVALENT_AREA, NEARFIELD_PRESSURE,
 %                                             FORCE_X, FORCE_Y, FORCE_Z, THRUST,

--- a/TestCases/euler/oneram6/inv_ONERAM6.cfg
+++ b/TestCases/euler/oneram6/inv_ONERAM6.cfg
@@ -87,7 +87,7 @@ MARKER_DESIGNING = ( WING )
 % Numerical method for spatial gradients (GREEN_GAUSS, WEIGHTED_LEAST_SQUARES)
 NUM_METHOD_GRAD= WEIGHTED_LEAST_SQUARES
 %
-% Objective function in optimization problem (DRAG, LIFT, SIDEFORCE, MOMENT_X,
+% Objective function in gradient evaluation  (DRAG, LIFT, SIDEFORCE, MOMENT_X,
 %                                             MOMENT_Y, MOMENT_Z, EFFICIENCY,
 %                                             EQUIVALENT_AREA, NEARFIELD_PRESSURE,
 %                                             FORCE_X, FORCE_Y, FORCE_Z, THRUST,

--- a/TestCases/fixed_cl/naca0012/inv_NACA0012.cfg
+++ b/TestCases/fixed_cl/naca0012/inv_NACA0012.cfg
@@ -93,7 +93,7 @@ MARKER_DESIGNING = ( airfoil )
 % Numerical method for spatial gradients (GREEN_GAUSS, WEIGHTED_LEAST_SQUARES)
 NUM_METHOD_GRAD= GREEN_GAUSS
 %
-% Objective function in optimization problem (DRAG, LIFT, SIDEFORCE, MOMENT_X,
+% Objective function in gradient evaluation  (DRAG, LIFT, SIDEFORCE, MOMENT_X,
 %                                             MOMENT_Y, MOMENT_Z, EFFICIENCY,
 %                                             EQUIVALENT_AREA, NEARFIELD_PRESSURE,
 %                                             FORCE_X, FORCE_Y, FORCE_Z, THRUST,

--- a/TestCases/fixed_cl/naca0012/inv_NACA0012_ContAdj.cfg
+++ b/TestCases/fixed_cl/naca0012/inv_NACA0012_ContAdj.cfg
@@ -99,7 +99,7 @@ MARKER_DESIGNING = ( airfoil )
 % Numerical method for spatial gradients (GREEN_GAUSS, WEIGHTED_LEAST_SQUARES)
 NUM_METHOD_GRAD= GREEN_GAUSS
 %
-% Objective function in optimization problem (DRAG, LIFT, SIDEFORCE, MOMENT_X,
+% Objective function in gradient evaluation  (DRAG, LIFT, SIDEFORCE, MOMENT_X,
 %                                             MOMENT_Y, MOMENT_Z, EFFICIENCY,
 %                                             EQUIVALENT_AREA, NEARFIELD_PRESSURE,
 %                                             FORCE_X, FORCE_Y, FORCE_Z, THRUST,

--- a/TestCases/incomp_rans/AhmedBody/AhmedBody.cfg
+++ b/TestCases/incomp_rans/AhmedBody/AhmedBody.cfg
@@ -130,7 +130,7 @@ MARKER_DESIGNING = ( body )
 % Numerical method for spatial gradients (GREEN_GAUSS, WEIGHTED_LEAST_SQUARES)
 NUM_METHOD_GRAD= WEIGHTED_LEAST_SQUARES
 %
-% Objective function in optimization problem (DRAG, LIFT, SIDEFORCE, MOMENT_X,
+% Objective function in gradient evaluation  (DRAG, LIFT, SIDEFORCE, MOMENT_X,
 %                                             MOMENT_Y, MOMENT_Z, EFFICIENCY,
 %                                             EQUIVALENT_AREA, NEARFIELD_PRESSURE,
 %                                             FORCE_X, FORCE_Y, FORCE_Z, THRUST,

--- a/TestCases/optimization_euler/steady_inverse_design/inv_NACA0012.cfg
+++ b/TestCases/optimization_euler/steady_inverse_design/inv_NACA0012.cfg
@@ -82,7 +82,7 @@ INV_DESIGN_HEATFLUX= NO
 % Numerical method for spatial gradients (GREEN_GAUSS, WEIGHTED_LEAST_SQUARES)
 NUM_METHOD_GRAD= WEIGHTED_LEAST_SQUARES
 %
-% Objective function in optimization problem (DRAG, LIFT, SIDEFORCE, MOMENT_X,
+% Objective function in gradient evaluation  (DRAG, LIFT, SIDEFORCE, MOMENT_X,
 %                                             MOMENT_Y, MOMENT_Z, EFFICIENCY,
 %                                             EQUIVALENT_AREA, NEARFIELD_PRESSURE,
 %                                             FORCE_X, FORCE_Y, FORCE_Z, THRUST,

--- a/TestCases/optimization_euler/steady_oneram6/inv_ONERAM6_adv.cfg
+++ b/TestCases/optimization_euler/steady_oneram6/inv_ONERAM6_adv.cfg
@@ -75,7 +75,7 @@ MARKER_MONITORING= ( UPPER_SIDE, LOWER_SIDE, TIP )
 % Numerical method for spatial gradients (GREEN_GAUSS, WEIGHTED_LEAST_SQUARES)
 NUM_METHOD_GRAD= WEIGHTED_LEAST_SQUARES
 %
-% Objective function in optimization problem (DRAG, LIFT, SIDEFORCE, MOMENT_X,
+% Objective function in gradient evaluation  (DRAG, LIFT, SIDEFORCE, MOMENT_X,
 %                                             MOMENT_Y, MOMENT_Z, EFFICIENCY,
 %                                             EQUIVALENT_AREA, NEARFIELD_PRESSURE,
 %                                             FORCE_X, FORCE_Y, FORCE_Z, THRUST,

--- a/TestCases/optimization_euler/steady_oneram6/inv_ONERAM6_basic.cfg
+++ b/TestCases/optimization_euler/steady_oneram6/inv_ONERAM6_basic.cfg
@@ -75,7 +75,7 @@ MARKER_MONITORING= ( UPPER_SIDE, LOWER_SIDE, TIP )
 % Numerical method for spatial gradients (GREEN_GAUSS, WEIGHTED_LEAST_SQUARES)
 NUM_METHOD_GRAD= WEIGHTED_LEAST_SQUARES
 %
-% Objective function in optimization problem (DRAG, LIFT, SIDEFORCE, MOMENT_X,
+% Objective function in gradient evaluation  (DRAG, LIFT, SIDEFORCE, MOMENT_X,
 %                                             MOMENT_Y, MOMENT_Z, EFFICIENCY,
 %                                             EQUIVALENT_AREA, NEARFIELD_PRESSURE,
 %                                             FORCE_X, FORCE_Y, FORCE_Z, THRUST,

--- a/TestCases/polar/naca0012/inv_NACA0012.cfg
+++ b/TestCases/polar/naca0012/inv_NACA0012.cfg
@@ -85,7 +85,7 @@ MARKER_DESIGNING = ( airfoil )
 % Numerical method for spatial gradients (GREEN_GAUSS, WEIGHTED_LEAST_SQUARES)
 NUM_METHOD_GRAD= WEIGHTED_LEAST_SQUARES
 %
-% Objective function in optimization problem (DRAG, LIFT, SIDEFORCE, MOMENT_X,
+% Objective function in gradient evaluation  (DRAG, LIFT, SIDEFORCE, MOMENT_X,
 %                                             MOMENT_Y, MOMENT_Z, EFFICIENCY,
 %                                             EQUIVALENT_AREA, NEARFIELD_PRESSURE,
 %                                             FORCE_X, FORCE_Y, FORCE_Z, THRUST,

--- a/TestCases/rans/flatplate/turb_SA_flatplate.cfg
+++ b/TestCases/rans/flatplate/turb_SA_flatplate.cfg
@@ -79,7 +79,7 @@ MARKER_SYM= ( symmetry )
 MARKER_PLOTTING= ( wall )
 %
 % Marker(s) of the surface where the functional (Cd, Cl, etc.) will be evaluated
-MARKER_MONITORING= ( wall )
+MARKER_MONITORING= ( wall, outlet )
 
 % ------------- COMMON PARAMETERS DEFINING THE NUMERICAL METHOD ---------------%
 %
@@ -101,7 +101,7 @@ CFL_ADAPT_PARAM= ( 1.5, 0.5, 1.0, 100.0 )
 RK_ALPHA_COEFF= ( 0.66667, 0.66667, 1.000000 )
 %
 % Number of total iterations
-EXT_ITER= 99999
+EXT_ITER= 9
 
 % ----------------------- SLOPE LIMITER DEFINITION ----------------------------%
 %
@@ -249,3 +249,10 @@ WRT_SOL_FREQ= 1000
 %
 % Writing convergence history frequency
 WRT_CON_FREQ= 1
+
+KIND_ONE_DIMENSIONALIZATION = AREA
+MARKER_OUT_1D = outlet
+OBJECTIVE_FUNCTION = TOTAL_HEATFLUX, MASS_FLOW_RATE
+OPT_OBJECTIVE = TOTAL_HEATFLUX*1.0; MASS_FLOW_RATE*1.0
+DEFINITION_DV= ( 1, 1.0 | wall | 0, 0.05 )
+

--- a/TestCases/rans/flatplate/turb_SA_flatplate.cfg
+++ b/TestCases/rans/flatplate/turb_SA_flatplate.cfg
@@ -79,7 +79,7 @@ MARKER_SYM= ( symmetry )
 MARKER_PLOTTING= ( wall )
 %
 % Marker(s) of the surface where the functional (Cd, Cl, etc.) will be evaluated
-MARKER_MONITORING= ( wall, outlet )
+MARKER_MONITORING= ( wall )
 
 % ------------- COMMON PARAMETERS DEFINING THE NUMERICAL METHOD ---------------%
 %
@@ -101,7 +101,7 @@ CFL_ADAPT_PARAM= ( 1.5, 0.5, 1.0, 100.0 )
 RK_ALPHA_COEFF= ( 0.66667, 0.66667, 1.000000 )
 %
 % Number of total iterations
-EXT_ITER= 9
+EXT_ITER= 99999
 
 % ----------------------- SLOPE LIMITER DEFINITION ----------------------------%
 %
@@ -249,10 +249,3 @@ WRT_SOL_FREQ= 1000
 %
 % Writing convergence history frequency
 WRT_CON_FREQ= 1
-
-KIND_ONE_DIMENSIONALIZATION = AREA
-MARKER_OUT_1D = outlet
-OBJECTIVE_FUNCTION = TOTAL_HEATFLUX, MASS_FLOW_RATE
-OPT_OBJECTIVE = TOTAL_HEATFLUX*1.0; MASS_FLOW_RATE*1.0
-DEFINITION_DV= ( 1, 1.0 | wall | 0, 0.05 )
-

--- a/TestCases/rans/naca0012/turb_NACA0012_sst_multigrid_restart.cfg
+++ b/TestCases/rans/naca0012/turb_NACA0012_sst_multigrid_restart.cfg
@@ -215,7 +215,7 @@ CFL_NUMBER= 5.0
 % Runge-Kutta alpha coefficients
 RK_ALPHA_COEFF= ( 0.66667, 0.66667, 1.000000 )
 %
-% Objective function in optimization problem (DRAG, LIFT, SIDEFORCE, MOMENT_X,
+% Objective function in gradient evaluation  (DRAG, LIFT, SIDEFORCE, MOMENT_X,
 %                                             MOMENT_Y, MOMENT_Z, EFFICIENCY,
 %                                             EQUIVALENT_AREA, NEARFIELD_PRESSURE,
 %                                             FORCE_X, FORCE_Y, FORCE_Z, THRUST,

--- a/TestCases/rans/propeller/propeller.cfg
+++ b/TestCases/rans/propeller/propeller.cfg
@@ -139,7 +139,7 @@ CFL_ADAPT= NO
 %                                        CFL max value )
 CFL_ADAPT_PARAM= ( 1.0, 1.0, 1.0, 10.0 )
 %
-% Objective function in optimization problem (DRAG, LIFT, SIDEFORCE, MOMENT_X,
+% Objective function in gradient evaluation  (DRAG, LIFT, SIDEFORCE, MOMENT_X,
 %                                             MOMENT_Y, MOMENT_Z, EFFICIENCY,
 %                                             EQUIVALENT_AREA, NEARFIELD_PRESSURE,
 %                                             FORCE_X, FORCE_Y, FORCE_Z, THRUST,

--- a/TestCases/serial_regression.py
+++ b/TestCases/serial_regression.py
@@ -947,15 +947,15 @@ def main():
     test_list.append(shape_opt_euler_py)
 
     # test continuous_adjoint.py, with multiple objectives
-    contadj_multi_py            = TestCase('contadj_multi_py')
-    contadj_multi_py.cfg_dir    = "cont_adj_euler/wedge"
-    contadj_multi_py.cfg_file   = "inv_wedge_ROE_multiobj.cfg"
-    contadj_multi_py.test_iter  = 10
-    contadj_multi_py.su2_exec   = "continuous_adjoint.py"
-    contadj_multi_py.timeout    = 1600
-    contadj_multi_py.reference_file = "of_grad_combo.dat.ref"
-    contadj_multi_py.test_file  = "of_grad_combo.dat"
-    pass_list.append(contadj_multi_py.run_filediff())
+    #contadj_multi_py            = TestCase('contadj_multi_py')
+    #contadj_multi_py.cfg_dir    = "cont_adj_euler/wedge"
+    #contadj_multi_py.cfg_file   = "inv_wedge_ROE_multiobj.cfg"
+    #contadj_multi_py.test_iter  = 10
+    #contadj_multi_py.su2_exec   = "continuous_adjoint.py"
+    #contadj_multi_py.timeout    = 1600
+    #contadj_multi_py.reference_file = "of_grad_combo.dat.ref"
+    #contadj_multi_py.test_file  = "of_grad_combo.dat"
+    #pass_list.append(contadj_multi_py.run_filediff())
     #test_list.append(contadj_multi_py)
 
 

--- a/TestCases/serial_regression.py
+++ b/TestCases/serial_regression.py
@@ -936,15 +936,15 @@ def main():
     test_list.append(shape_opt_euler_py)
 
     # test continuous_adjoint.py, with multiple objectives
-    #contadj_multi_py            = TestCase('contadj_multi_py')
-    #contadj_multi_py.cfg_dir    = "cont_adj_euler/wedge"
-    #contadj_multi_py.cfg_file   = "inv_wedge_ROE_multiobj.cfg"
-    #contadj_multi_py.test_iter  = 10
-    #contadj_multi_py.su2_exec   = "continuous_adjoint.py"
-    #contadj_multi_py.timeout    = 1600
-    #contadj_multi_py.reference_file = "of_grad_combo.dat.ref"
-    #contadj_multi_py.test_file  = "of_grad_combo.dat"
-    #pass_list.append(contadj_multi_py.run_filediff())
+    contadj_multi_py            = TestCase('contadj_multi_py')
+    contadj_multi_py.cfg_dir    = "cont_adj_euler/wedge"
+    contadj_multi_py.cfg_file   = "inv_wedge_ROE_multiobj.cfg"
+    contadj_multi_py.test_iter  = 10
+    contadj_multi_py.su2_exec   = "continuous_adjoint.py"
+    contadj_multi_py.timeout    = 1600
+    contadj_multi_py.reference_file = "of_grad_combo.dat.ref"
+    contadj_multi_py.test_file  = "of_grad_combo.dat"
+    pass_list.append(contadj_multi_py.run_filediff())
     #test_list.append(contadj_multi_py)
 
 

--- a/TestCases/serial_regression_AD.py
+++ b/TestCases/serial_regression_AD.py
@@ -135,7 +135,7 @@ def main():
     # test continuous_adjoint.py, with multiple objectives
     discadj_multi_py            = TestCase('discadj_multi_py')
     discadj_multi_py.cfg_dir    = "cont_adj_euler/wedge"
-    discadj_multi_py.cfg_file   = "inv_wedge_ROE_disc_multiobj.cfg"
+    discadj_multi_py.cfg_file   = "inv_wedge_ROE_multiobj.cfg"
     discadj_multi_py.test_iter  = 10
     discadj_multi_py.su2_exec   = "discrete_adjoint.py"
     discadj_multi_py.timeout    = 1600

--- a/TestCases/serial_regression_AD.py
+++ b/TestCases/serial_regression_AD.py
@@ -135,7 +135,7 @@ def main():
     # test continuous_adjoint.py, with multiple objectives
     discadj_multi_py            = TestCase('discadj_multi_py')
     discadj_multi_py.cfg_dir    = "cont_adj_euler/wedge"
-    discadj_multi_py.cfg_file   = "inv_wedge_ROE_multiobj.cfg"
+    discadj_multi_py.cfg_file   = "inv_wedge_ROE_disc_multiobj.cfg"
     discadj_multi_py.test_iter  = 10
     discadj_multi_py.su2_exec   = "discrete_adjoint.py"
     discadj_multi_py.timeout    = 1600

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -129,6 +129,10 @@ REF_AREA= 1.0
 % Flow non-dimensionalization (DIMENSIONAL, FREESTREAM_PRESS_EQ_ONE,
 %                              FREESTREAM_VEL_EQ_MACH, FREESTREAM_VEL_EQ_ONE)
 REF_DIMENSIONALIZATION= DIMENSIONAL
+%
+% Finite difference step size for python scripts (0.001 default, recommended
+%												  0.001 x REF_LENGTH_MOMENT)
+FIN_DIFF_STEP = 0.001
 
 % ---- IDEAL GAS, POLYTROPIC, VAN DER WAALS AND PENG ROBINSON CONSTANTS -------%
 %

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -560,7 +560,7 @@ MAX_DELTA_TIME= 1E6
 % Runge-Kutta alpha coefficients
 RK_ALPHA_COEFF= ( 0.66667, 0.66667, 1.000000 )
 %
-% Objective function in optimization problem (DRAG, LIFT, SIDEFORCE, MOMENT_X,
+% Objective function in gradient evaluation   (DRAG, LIFT, SIDEFORCE, MOMENT_X,
 %                                             MOMENT_Y, MOMENT_Z, EFFICIENCY,
 %                                             EQUIVALENT_AREA, NEARFIELD_PRESSURE,
 %                                             FORCE_X, FORCE_Y, FORCE_Z, THRUST,
@@ -568,7 +568,11 @@ RK_ALPHA_COEFF= ( 0.66667, 0.66667, 1.000000 )
 %                                             MAXIMUM_HEATFLUX, INVERSE_DESIGN_PRESSURE,
 %                                             INVERSE_DESIGN_HEATFLUX, AVG_TOTAL_PRESSURE, 
 %                                             MASS_FLOW_RATE)
+% For a weighted sum of objectives: separate by commas, add OBJECTIVE_WEIGHT and MARKER_MONITORING in matching order.
 OBJECTIVE_FUNCTION= DRAG
+%
+% List of weighting values when using more than one OBJECTIVE_FUNCTION. Separate by commas and match with MARKER_MONITORING.
+OBJECTIVE_WEIGHT = 1.0
 
 % ----------------------- SLOPE LIMITER DEFINITION ----------------------------%
 %
@@ -1040,7 +1044,8 @@ CONSOLE_OUTPUT_VERBOSITY= HIGH
 %    TRANSLATION  ( 5, Scale | Mark. List | x_Disp, y_Disp, z_Disp )
 %    ROTATION	  ( 6, Scale | Mark. List | x_Axis, y_Axis, z_Axis, x_Turn, y_Turn, z_Turn )
 %
-% Optimization objective function with scaling factor
+% Optimization objective function with scaling factor, separated by semicolons.
+% To include quadratic penalty function: use OPT_CONSTRAINT option syntax within the OPT_OBJECTIVE list.
 % ex= Objective * Scale
 OPT_OBJECTIVE= DRAG * 0.001
 %
@@ -1062,3 +1067,6 @@ OPT_BOUND_LOWER= -0.1
 %
 % Optimization design variables, separated by semicolons
 DEFINITION_DV= ( 1, 1.0 | airfoil | 0, 0.05 ); ( 1, 1.0 | airfoil | 0, 0.10 ); ( 1, 1.0 | airfoil | 0, 0.15 ); ( 1, 1.0 | airfoil | 0, 0.20 ); ( 1, 1.0 | airfoil | 0, 0.25 ); ( 1, 1.0 | airfoil | 0, 0.30 ); ( 1, 1.0 | airfoil | 0, 0.35 ); ( 1, 1.0 | airfoil | 0, 0.40 ); ( 1, 1.0 | airfoil | 0, 0.45 ); ( 1, 1.0 | airfoil | 0, 0.50 ); ( 1, 1.0 | airfoil | 0, 0.55 ); ( 1, 1.0 | airfoil | 0, 0.60 ); ( 1, 1.0 | airfoil | 0, 0.65 ); ( 1, 1.0 | airfoil | 0, 0.70 ); ( 1, 1.0 | airfoil | 0, 0.75 ); ( 1, 1.0 | airfoil | 0, 0.80 ); ( 1, 1.0 | airfoil | 0, 0.85 ); ( 1, 1.0 | airfoil | 0, 0.90 ); ( 1, 1.0 | airfoil | 0, 0.95 ); ( 1, 1.0 | airfoil | 1, 0.05 ); ( 1, 1.0 | airfoil | 1, 0.10 ); ( 1, 1.0 | airfoil | 1, 0.15 ); ( 1, 1.0 | airfoil | 1, 0.20 ); ( 1, 1.0 | airfoil | 1, 0.25 ); ( 1, 1.0 | airfoil | 1, 0.30 ); ( 1, 1.0 | airfoil | 1, 0.35 ); ( 1, 1.0 | airfoil | 1, 0.40 ); ( 1, 1.0 | airfoil | 1, 0.45 ); ( 1, 1.0 | airfoil | 1, 0.50 ); ( 1, 1.0 | airfoil | 1, 0.55 ); ( 1, 1.0 | airfoil | 1, 0.60 ); ( 1, 1.0 | airfoil | 1, 0.65 ); ( 1, 1.0 | airfoil | 1, 0.70 ); ( 1, 1.0 | airfoil | 1, 0.75 ); ( 1, 1.0 | airfoil | 1, 0.80 ); ( 1, 1.0 | airfoil | 1, 0.85 ); ( 1, 1.0 | airfoil | 1, 0.90 ); ( 1, 1.0 | airfoil | 1, 0.95 )
+%
+% Use combined objective within gradient evaluation: may reduce cost to compute gradients when using the adjoint formulation.
+OPT_COMBINE_OBJECTIVE = NO

--- a/config_template_basic.cfg
+++ b/config_template_basic.cfg
@@ -94,6 +94,10 @@ REF_AREA= 1.0
 % Flow non-dimensionalization (DIMENSIONAL, FREESTREAM_PRESS_EQ_ONE,
 %                              FREESTREAM_VEL_EQ_MACH, FREESTREAM_VEL_EQ_ONE)
 REF_DIMENSIONALIZATION= DIMENSIONAL
+%
+% Finite difference step size for python scripts (0.001 default, recommended
+%												  0.001 x REF_LENGTH_MOMENT)
+FIN_DIFF_STEP = 0.001
 
 % ------------------------- UNSTEADY SIMULATION -------------------------------%
 %

--- a/config_template_basic.cfg
+++ b/config_template_basic.cfg
@@ -194,7 +194,7 @@ CFL_ADAPT= NO
 %                                        CFL max value )
 CFL_ADAPT_PARAM= ( 1.5, 0.5, 1.25, 50.0 )
 %
-% Objective function in optimization problem (DRAG, LIFT, SIDEFORCE, MOMENT_X,
+% Objective function in gradient evaluation  (DRAG, LIFT, SIDEFORCE, MOMENT_X,
 %                                             MOMENT_Y, MOMENT_Z, EFFICIENCY,
 %                                             EQUIVALENT_AREA, NEARFIELD_PRESSURE,
 %                                             FORCE_X, FORCE_Y, FORCE_Z, THRUST,


### PR DESCRIPTION
This pull request includes:
- updates and refinement of multiple objective gradient evaluation and optimization
- per-surface evaluation of forces and moments can now be included in an optimization or gradient evaluation: this is only used when more than one objective is specified. 
- the multiobjective test case has been added back into the regressions
- FIN_DIFF_STEP can now be specified in the config file (the option was already added in the develop branch; a small modification was needed to the python code in order to use it). If this option is not specified the previous behavior is used. 
- a few minor corrections are also included
- penalty functions can now be used as a portion of the objective. The penalty function is defined as the square of the difference between the function and its constraint - this is hard-coded, but can be modified by simply changing obj_p and obj_dp in the python scripts. 


A tutorial around multiobjective optimization may be added later based on the inv_wedge_ROE_multiobj.cfg case. 