### PR TITLE
Fix duplicated entry of CFL_ADAPT_PARAM on .cfg file

### DIFF
--- a/TestCases/optimization_rans/pitching_oneram6/turb_ONERAM6.cfg
+++ b/TestCases/optimization_rans/pitching_oneram6/turb_ONERAM6.cfg
@@ -135,9 +135,6 @@ NUM_METHOD_GRAD= GREEN_GAUSS
 % Adaptive CFL number (NO, YES)
 CFL_ADAPT= NO
 %
-% Parameters of the adaptive CFL number (factor down, factor up, CFL limit)
-CFL_ADAPT_PARAM= ( 1.5, 0.5, 100.0 )
-%
 % Parameters of the adaptive CFL number (factor down, factor up, CFL min value,
 %                                        CFL max value )
 CFL_ADAPT_PARAM= ( 1.5, 0.5, 1.0, 100.0 )


### PR DESCRIPTION
Test Case was not running due to AssertionError: Config file has multiple specifications of CFL_ADAPT_PARAM
Duplicated entry of CFL_ADAPT_PARAM removed