### PR TITLE
Removed invalid options from TestCase cfg file

### DIFF
--- a/TestCases/optimization_rans/pitching_oneram6/turb_ONERAM6.cfg
+++ b/TestCases/optimization_rans/pitching_oneram6/turb_ONERAM6.cfg
@@ -351,9 +351,6 @@ MESH_OUT_FILENAME= mesh_out.su2
 % Restart flow input file
 SOLUTION_FLOW_FILENAME= restart_flow.dat
 %
-% Restart linear flow input file
-SOLUTION_LIN_FILENAME= solution_lin.dat
-%
 % Restart adjoint input file
 SOLUTION_ADJ_FILENAME= solution_adj.dat
 %
@@ -369,9 +366,6 @@ RESTART_FLOW_FILENAME= restart_flow.dat
 % Output file restart adjoint
 RESTART_ADJ_FILENAME= restart_adj.dat
 %
-% Output file linear flow
-RESTART_LIN_FILENAME= restart_lin.dat
-%
 % Output file flow (w/o extension) variables
 VOLUME_FLOW_FILENAME= flow
 %
@@ -386,9 +380,6 @@ SURFACE_FLOW_FILENAME= surface_flow
 %
 % Output file surface adjoint coefficient (w/o extension)
 SURFACE_ADJ_FILENAME= surface_adjoint
-%
-% Output file surface linear coefficient (w/o extension)
-SURFACE_LIN_FILENAME= surface_linear
 %
 % Writing solution file frequency
 WRT_SOL_FREQ= 1000


### PR DESCRIPTION
Remove three outdated option parameters, which were causing the example not to run. These are: 

```
SOLUTION_LIN_FILENAME: invalid option name. Check current SU2 options in config_template.cfg.
RESTART_LIN_FILENAME: invalid option name. Check current SU2 options in config_template.cfg.
SURFACE_LIN_FILENAME: invalid option name. Check current SU2 options in config_template.cfg.
```