### PR TITLE
New Repo for SU2 Website

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ SU2 is a suite of open-source software tools written in C++ for the numerical so
 The primary applications are computational fluid dynamics and aerodynamic shape optimization, but has been extended to treat more general equations such as electrodynamics and chemically reacting flows. 
 
 You will find more information and the latest news in:
-   - GitHub:    https://github.com/su2code
-   - CFD-online http://www.cfd-online.com/Forums/su2/
-   - Twitter:   https://twitter.com/su2code
+   - SU2 Home Page: https://github.com/su2code/su2code.github.io
+   - GitHub:        https://github.com/su2code
+   - CFD Online:    http://www.cfd-online.com/Forums/su2/
+   - Twitter:       https://twitter.com/su2code
 
 ---------------------------------------------------
   SU2 INSTALLATION

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ SU2 is a suite of open-source software tools written in C++ for the numerical so
 The primary applications are computational fluid dynamics and aerodynamic shape optimization, but has been extended to treat more general equations such as electrodynamics and chemically reacting flows. 
 
 You will find more information and the latest news in:
-   - SU2 Home Page: https://github.com/su2code/su2code.github.io
+   - SU2 Home Page: https://su2code.github.io
    - GitHub:        https://github.com/su2code
    - CFD Online:    http://www.cfd-online.com/Forums/su2/
    - Twitter:       https://twitter.com/su2code


### PR DESCRIPTION
In keeping with our open-source philosophy, the SU2 webpage should be open and modifiable by all members of the community, just like the rest of the code. This will make it much easier to manage and improve in the long run with distributed effort.

As a first step to accomplish this, we are taking advantage of GitHub Pages (https://pages.github.com) in order to host our current SU2 page. A new repository has been created within the SU2 GitHub organization here:

https://github.com/su2code/su2code.github.io

and it contains a copy of the current webpage located at http://su2.stanford.edu with all necessary modifications to links, data, etc. so that it functions correctly and independently. The files on the master branch of that new repository are automatically hosted for us by GitHub here (for free):

https://su2code.github.io

All developers now have access to this repository, and in the future, we can all collaborate together to keep it updated and modernize it. An important note is that GitHub allows for custom domain names to be applied to this website, allowing us to use a ".org" domain name instead of https://su2code.github.io in the future, once available (https://help.github.com/articles/using-a-custom-domain-with-github-pages/).

As for next steps, I would like to use this PR to invite discussion about this. If we are in agreement to approve this PR, then we will add an automatic redirect from http://su2.stanford.edu to https://su2code.github.io and focus solely on the version of the website in the new repo going forward. Please do share any comments or thoughts.