### PR TITLE
Feature ILU(n)

### DIFF
--- a/Common/include/config_structure.hpp
+++ b/Common/include/config_structure.hpp
@@ -481,6 +481,7 @@ private:
   unsigned long Linear_Solver_Iter;		/*!< \brief Max iterations of the linear solver for the implicit formulation. */
   unsigned long Linear_Solver_Iter_FSI_Struc;		/*!< \brief Max iterations of the linear solver for FSI applications and structural solver. */
   unsigned long Linear_Solver_Restart_Frequency;   /*!< \brief Restart frequency of the linear solver for the implicit formulation. */
+  unsigned short Linear_Solver_ILU_n;		/*!< \brief ILU fill=in level. */
   su2double SemiSpan;		/*!< \brief Wing Semi span. */
   su2double Roe_Kappa;		/*!< \brief Relaxation of the Roe scheme. */
   su2double Relaxation_Factor_Flow;		/*!< \brief Relaxation coefficient of the linear solver mean flow. */
@@ -3171,6 +3172,12 @@ public:
    */
   unsigned long GetLinear_Solver_Iter(void);
   
+  /*!
+   * \brief Get the ILU fill-in level for the linear solver.
+   * \return Fill in level of the ILU preconditioner for the linear solver.
+   */
+  unsigned short GetLinear_Solver_ILU_n(void);
+
   /*!
    * \brief Get restart frequency of the linear solver for the implicit formulation.
    * \return Restart frequency of the linear solver for the implicit formulation.

--- a/Common/include/config_structure.inl
+++ b/Common/include/config_structure.inl
@@ -825,6 +825,8 @@ inline su2double CConfig::GetLinear_Solver_Error(void) { return Linear_Solver_Er
 
 inline unsigned long CConfig::GetLinear_Solver_Iter(void) { return Linear_Solver_Iter; }
 
+inline unsigned short CConfig::GetLinear_Solver_ILU_n(void) { return Linear_Solver_ILU_n; }
+
 inline unsigned long CConfig::GetLinear_Solver_Restart_Frequency(void) { return Linear_Solver_Restart_Frequency; }
 
 inline su2double CConfig::GetRelaxation_Factor_Flow(void) { return Relaxation_Factor_Flow; }

--- a/Common/include/matrix_structure.hpp
+++ b/Common/include/matrix_structure.hpp
@@ -70,6 +70,8 @@ private:
   unsigned long nnz_ilu;             /*!< \brief Number of possible nonzero entries in the matrix (ILU). */
   unsigned long *row_ptr_ilu;        /*!< \brief Pointers to the first element in each row (ILU). */
   unsigned long *col_ind_ilu;        /*!< \brief Column index for each of the elements in val() (ILU). */
+  unsigned short ilu_fill_in;        /*!< \brief Fill in level for the ILU preconditioner. */
+  
   su2double *block;             /*!< \brief Internal array to store a subblock of the matrix. */
   su2double *block_inverse;             /*!< \brief Internal array to store a subblock of the matrix. */
   su2double *block_weight;             /*!< \brief Internal array to store a subblock of the matrix. */
@@ -127,8 +129,10 @@ public:
    * \param[in] iPoint - Base point to compute neighbours.
    * \param[in] deep_level - Deep level for the recursive algorithm.
    * \param[in] fill_level - ILU fill in level.
+   * \param[in] EdgeConnect - There is (or not) an edge structure).
+   * \param[in] vneighs - Storage the neighbours points to iPoint.
    */
-  void SetNeighbours(CGeometry *geometry, unsigned long iPoint, unsigned short deep_level, unsigned short fill_level, vector<unsigned long> & vneighs);
+  void SetNeighbours(CGeometry *geometry, unsigned long iPoint, unsigned short deep_level, unsigned short fill_level, bool EdgeConnect, vector<unsigned long> & vneighs);
   
   /*!
    * \brief Sets to zero all the entries of the sparse matrix.
@@ -454,7 +458,7 @@ public:
   unsigned long Jacobi_Smoother(const CSysVector & b, CSysVector & x, CMatrixVectorProduct & mat_vec, su2double tol, unsigned long m, su2double *residual, bool monitoring, CGeometry *geometry, CConfig *config);
   
   /*!
-   * \brief Build the ILU0 preconditioner.
+   * \brief Build the ILU preconditioner.
    * \param[in] transposed - Flag to use the transposed matrix to construct the preconditioner.
    */
   void BuildILUPreconditioner(bool transposed = false);
@@ -469,7 +473,7 @@ public:
   void ComputeILUPreconditioner(const CSysVector & vec, CSysVector & prod, CGeometry *geometry, CConfig *config);
   
   /*!
-   * \brief Apply ILU0 as a classical iterative smoother
+   * \brief Apply ILU as a classical iterative smoother
    * \param[in] b - CSysVector containing the residual (b)
    * \param[in] x - CSysVector containing the solution (x^k)
    * \param[in] mat_vec - object that defines matrix-vector product
@@ -481,7 +485,7 @@ public:
    * \param[in] config - Definition of the particular problem.
    * \param[out] x - CSysVector containing the result of the smoothing (x^k+1 = x^k + M^-1*(b - A*x^k).
    */
-  unsigned long ILU0_Smoother(const CSysVector & b, CSysVector & x, CMatrixVectorProduct & mat_vec, su2double tol, unsigned long m, su2double *residual, bool monitoring, CGeometry *geometry, CConfig *config);
+  unsigned long ILU_Smoother(const CSysVector & b, CSysVector & x, CMatrixVectorProduct & mat_vec, su2double tol, unsigned long m, su2double *residual, bool monitoring, CGeometry *geometry, CConfig *config);
   
   /*!
    * \brief Multiply CSysVector by the preconditioner

--- a/Common/include/matrix_structure.hpp
+++ b/Common/include/matrix_structure.hpp
@@ -58,27 +58,30 @@ const su2double eps = numeric_limits<su2double>::epsilon(); /*!< \brief machine 
  */
 class CSysMatrix {
 private:
-	unsigned long nPoint,   /*!< \brief Number of points in the grid. */
-	nPointDomain,           /*!< \brief Number of points in the grid. */
-	nVar,                   /*!< \brief Number of variables. */
-	nEqn;                   /*!< \brief Number of equations. */
-	su2double *matrix;            /*!< \brief Entries of the sparse matrix. */
-	su2double *ILU_matrix;         /*!< \brief Entries of the ILU sparse matrix. */
-	unsigned long *row_ptr;    /*!< \brief Pointers to the first element in each row. */
-	unsigned long *col_ind;    /*!< \brief Column index for each of the elements in val(). */
-	unsigned long nnz;         /*!< \brief Number of possible nonzero entries in the matrix. */
-	su2double *block;             /*!< \brief Internal array to store a subblock of the matrix. */
-	su2double *block_inverse;             /*!< \brief Internal array to store a subblock of the matrix. */
-	su2double *block_weight;             /*!< \brief Internal array to store a subblock of the matrix. */
+  unsigned long nPoint,   /*!< \brief Number of points in the grid. */
+  nPointDomain,           /*!< \brief Number of points in the grid. */
+  nVar,                   /*!< \brief Number of variables. */
+  nEqn;                   /*!< \brief Number of equations. */
+  su2double *matrix;            /*!< \brief Entries of the sparse matrix. */
+  su2double *ILU_matrix;         /*!< \brief Entries of the ILU sparse matrix. */
+  unsigned long nnz;                 /*!< \brief Number of possible nonzero entries in the matrix. */
+  unsigned long *row_ptr;            /*!< \brief Pointers to the first element in each row. */
+  unsigned long *col_ind;            /*!< \brief Column index for each of the elements in val(). */
+  unsigned long nnz_ilu;             /*!< \brief Number of possible nonzero entries in the matrix (ILU). */
+  unsigned long *row_ptr_ilu;        /*!< \brief Pointers to the first element in each row (ILU). */
+  unsigned long *col_ind_ilu;        /*!< \brief Column index for each of the elements in val() (ILU). */
+  su2double *block;             /*!< \brief Internal array to store a subblock of the matrix. */
+  su2double *block_inverse;             /*!< \brief Internal array to store a subblock of the matrix. */
+  su2double *block_weight;             /*!< \brief Internal array to store a subblock of the matrix. */
   su2double *prod_block_vector; /*!< \brief Internal array to store the product of a subblock with a vector. */
-	su2double *prod_row_vector;   /*!< \brief Internal array to store the product of a matrix-by-blocks "row" with a vector. */
-	su2double *aux_vector;         /*!< \brief Auxiliary array to store intermediate results. */
+  su2double *prod_row_vector;   /*!< \brief Internal array to store the product of a matrix-by-blocks "row" with a vector. */
+  su2double *aux_vector;         /*!< \brief Auxiliary array to store intermediate results. */
   su2double *sum_vector;         /*!< \brief Auxiliary array to store intermediate results. */
-	su2double *invM;              /*!< \brief Inverse of (Jacobi) preconditioner. */
-
-	bool *LineletBool;                          /*!< \brief Identify if a point belong to a linelet. */
-	vector<unsigned long> *LineletPoint;        /*!< \brief Linelet structure. */
-	unsigned long nLinelet;                     /*!< \brief Number of Linelets in the system. */
+  su2double *invM;              /*!< \brief Inverse of (Jacobi) preconditioner. */
+  
+  bool *LineletBool;                          /*!< \brief Identify if a point belong to a linelet. */
+  vector<unsigned long> *LineletPoint;        /*!< \brief Linelet structure. */
+  unsigned long nLinelet;                     /*!< \brief Number of Linelets in the system. */
   su2double **UBlock, **invUBlock, **LBlock,
   **yVector, **zVector, **rVector, *LFBlock,
   *LyVector, *FzVector;           /*!< \brief Arrays of the Linelet preconditioner methodology. */
@@ -86,105 +89,114 @@ private:
   
 public:
   
-	/*!
-	 * \brief Constructor of the class.
-	 */
-	CSysMatrix(void);
-  
-	/*!
-	 * \brief Destructor of the class.
-	 */
-	~CSysMatrix(void);
+  /*!
+   * \brief Constructor of the class.
+   */
+  CSysMatrix(void);
   
   /*!
-	 * \brief Initializes space matrix system.
-	 * \param[in] nVar - Number of variables.
-	 * \param[in] nEqn - Number of equations.
+   * \brief Destructor of the class.
+   */
+  ~CSysMatrix(void);
+  
+  /*!
+   * \brief Initializes space matrix system.
+   * \param[in] nVar - Number of variables.
+   * \param[in] nEqn - Number of equations.
    * \param[in] geometry - Geometrical definition of the problem.
-	 * \param[in] config - Definition of the particular problem.
-	 */
+   * \param[in] config - Definition of the particular problem.
+   */
   void Initialize(unsigned long nPoint, unsigned long nPointDomain, unsigned short nVar, unsigned short nEqn,
                   bool EdgeConnect, CGeometry *geometry, CConfig *config);
   
   /*!
-	 * \brief Assigns values to the sparse-matrix structure.
-	 * \param[in] val_nPoint - Number of points in the nPoint x nPoint block structure
-	 * \param[in] val_nVar - Number of nVar x nVar variables in each subblock of the matrix-by-block structure.
+   * \brief Assigns values to the sparse-matrix structure.
+   * \param[in] val_nPoint - Number of points in the nPoint x nPoint block structure
+   * \param[in] val_nVar - Number of nVar x nVar variables in each subblock of the matrix-by-block structure.
    * \param[in] val_nEq - Number of nEqn x nVar variables in each subblock of the matrix-by-block structure.
-	 * \param[in] val_row_ptr - Pointers to the first element in each row.
-	 * \param[in] val_col_ind - Column index for each of the elements in val().
-	 * \param[in] val_nnz - Number of possible nonzero entries in the matrix.
-	 * \param[in] config - Definition of the particular problem.
-	 */
-	void SetIndexes(unsigned long val_nPoint, unsigned long val_nPointDomain, unsigned short val_nVar, unsigned short val_nEq, unsigned long* val_row_ptr, unsigned long* val_col_ind, unsigned long val_nnz, CConfig *config);
-  
-	/*!
-	 * \brief Sets to zero all the entries of the sparse matrix.
-	 */
-	void SetValZero(void);
+   * \param[in] val_row_ptr - Pointers to the first element in each row.
+   * \param[in] val_col_ind - Column index for each of the elements in val().
+   * \param[in] val_nnz - Number of possible nonzero entries in the matrix.
+   * \param[in] config - Definition of the particular problem.
+   */
+  void SetIndexes(unsigned long val_nPoint, unsigned long val_nPointDomain, unsigned short val_nVar, unsigned short val_nEq, unsigned long* val_row_ptr, unsigned long* val_col_ind, unsigned long val_nnz, CConfig *config);
   
   /*!
-	 * \brief Copies the block (i, j) of the matrix-by-blocks structure in the internal variable *block.
-	 * \param[in] block_i - Indexes of the block in the matrix-by-blocks structure.
-	 * \param[in] block_j - Indexes of the block in the matrix-by-blocks structure.
-	 */
-	su2double *GetBlock(unsigned long block_i, unsigned long block_j);
+   * \brief Assigns values to the sparse-matrix structure.
+   * \param[in] geometry - Geometrical definition of the problem.
+   * \param[in] iPoint - Base point to compute neighbours.
+   * \param[in] deep_level - Deep level for the recursive algorithm.
+   * \param[in] fill_level - ILU fill in level.
+   */
+  void SetNeighbours(CGeometry *geometry, unsigned long iPoint, unsigned short deep_level, unsigned short fill_level, vector<unsigned long> & vneighs);
   
   /*!
-	 * \brief Copies the block (i, j) of the matrix-by-blocks structure in the internal variable *block.
-	 * \param[in] block_i - Indexes of the block in the matrix-by-blocks structure.
-	 * \param[in] block_j - Indexes of the block in the matrix-by-blocks structure.
-	 */
-	su2double GetBlock(unsigned long block_i, unsigned long block_j, unsigned short iVar, unsigned short jVar);
+   * \brief Sets to zero all the entries of the sparse matrix.
+   */
+  void SetValZero(void);
   
   /*!
-	 * \brief Set the value of a block in the sparse matrix.
-	 * \param[in] block_i - Indexes of the block in the matrix-by-blocks structure.
-	 * \param[in] block_j - Indexes of the block in the matrix-by-blocks structure.
-	 * \param[in] **val_block - Block to set to A(i, j).
-	 */
-	void SetBlock(unsigned long block_i, unsigned long block_j, su2double **val_block);
+   * \brief Copies the block (i, j) of the matrix-by-blocks structure in the internal variable *block.
+   * \param[in] block_i - Indexes of the block in the matrix-by-blocks structure.
+   * \param[in] block_j - Indexes of the block in the matrix-by-blocks structure.
+   */
+  su2double *GetBlock(unsigned long block_i, unsigned long block_j);
   
   /*!
-	 * \brief Set the value of a block in the sparse matrix.
-	 * \param[in] block_i - Indexes of the block in the matrix-by-blocks structure.
-	 * \param[in] block_j - Indexes of the block in the matrix-by-blocks structure.
-	 * \param[in] **val_block - Block to set to A(i, j).
-	 */
-	void SetBlock(unsigned long block_i, unsigned long block_j, su2double *val_block);
-  
-	/*!
-	 * \brief Adds the specified block to the sparse matrix.
-	 * \param[in] block_i - Indexes of the block in the matrix-by-blocks structure.
-	 * \param[in] block_j - Indexes of the block in the matrix-by-blocks structure.
-	 * \param[in] **val_block - Block to add to A(i, j).
-	 */
-	void AddBlock(unsigned long block_i, unsigned long block_j, su2double **val_block);
-  
-	/*!
-	 * \brief Subtracts the specified block to the sparse matrix.
-	 * \param[in] block_i - Indexes of the block in the matrix-by-blocks structure.
-	 * \param[in] block_j - Indexes of the block in the matrix-by-blocks structure.
-	 * \param[in] **val_block - Block to subtract to A(i, j).
-	 */
-	void SubtractBlock(unsigned long block_i, unsigned long block_j, su2double **val_block);
+   * \brief Copies the block (i, j) of the matrix-by-blocks structure in the internal variable *block.
+   * \param[in] block_i - Indexes of the block in the matrix-by-blocks structure.
+   * \param[in] block_j - Indexes of the block in the matrix-by-blocks structure.
+   */
+  su2double GetBlock(unsigned long block_i, unsigned long block_j, unsigned short iVar, unsigned short jVar);
   
   /*!
-	 * \brief Copies the block (i, j) of the matrix-by-blocks structure in the internal variable *block.
-	 * \param[in] block_i - Indexes of the block in the matrix-by-blocks structure.
-	 * \param[in] block_j - Indexes of the block in the matrix-by-blocks structure.
-	 */
-	su2double *GetBlock_ILUMatrix(unsigned long block_i, unsigned long block_j);
+   * \brief Set the value of a block in the sparse matrix.
+   * \param[in] block_i - Indexes of the block in the matrix-by-blocks structure.
+   * \param[in] block_j - Indexes of the block in the matrix-by-blocks structure.
+   * \param[in] **val_block - Block to set to A(i, j).
+   */
+  void SetBlock(unsigned long block_i, unsigned long block_j, su2double **val_block);
   
   /*!
-	 * \brief Set the value of a block in the sparse matrix.
-	 * \param[in] block_i - Indexes of the block in the matrix-by-blocks structure.
-	 * \param[in] block_j - Indexes of the block in the matrix-by-blocks structure.
-	 * \param[in] **val_block - Block to set to A(i, j).
-	 */
-	void SetBlock_ILUMatrix(unsigned long block_i, unsigned long block_j, su2double *val_block);
+   * \brief Set the value of a block in the sparse matrix.
+   * \param[in] block_i - Indexes of the block in the matrix-by-blocks structure.
+   * \param[in] block_j - Indexes of the block in the matrix-by-blocks structure.
+   * \param[in] **val_block - Block to set to A(i, j).
+   */
+  void SetBlock(unsigned long block_i, unsigned long block_j, su2double *val_block);
   
-
+  /*!
+   * \brief Adds the specified block to the sparse matrix.
+   * \param[in] block_i - Indexes of the block in the matrix-by-blocks structure.
+   * \param[in] block_j - Indexes of the block in the matrix-by-blocks structure.
+   * \param[in] **val_block - Block to add to A(i, j).
+   */
+  void AddBlock(unsigned long block_i, unsigned long block_j, su2double **val_block);
+  
+  /*!
+   * \brief Subtracts the specified block to the sparse matrix.
+   * \param[in] block_i - Indexes of the block in the matrix-by-blocks structure.
+   * \param[in] block_j - Indexes of the block in the matrix-by-blocks structure.
+   * \param[in] **val_block - Block to subtract to A(i, j).
+   */
+  void SubtractBlock(unsigned long block_i, unsigned long block_j, su2double **val_block);
+  
+  /*!
+   * \brief Copies the block (i, j) of the matrix-by-blocks structure in the internal variable *block.
+   * \param[in] block_i - Indexes of the block in the matrix-by-blocks structure.
+   * \param[in] block_j - Indexes of the block in the matrix-by-blocks structure.
+   */
+  su2double *GetBlock_ILUMatrix(unsigned long block_i, unsigned long block_j);
+  
+  /*!
+   * \brief Set the value of a block in the sparse matrix.
+   * \param[in] block_i - Indexes of the block in the matrix-by-blocks structure.
+   * \param[in] block_j - Indexes of the block in the matrix-by-blocks structure.
+   * \param[in] **val_block - Block to set to A(i, j).
+   */
+  void SetBlock_ILUMatrix(unsigned long block_i, unsigned long block_j, su2double *val_block);
+  
+  
   /*!
    * \brief Set the transposed value of a block in the sparse matrix.
    * \param[in] block_i - Indexes of the block in the matrix-by-blocks structure.
@@ -192,22 +204,22 @@ public:
    * \param[in] **val_block - Block to set to A(i, j).
    */
   void SetBlockTransposed_ILUMatrix(unsigned long block_i, unsigned long block_j, su2double *val_block);
-
-	/*!
-	 * \brief Subtracts the specified block to the sparse matrix.
-	 * \param[in] block_i - Indexes of the block in the matrix-by-blocks structure.
-	 * \param[in] block_j - Indexes of the block in the matrix-by-blocks structure.
-	 * \param[in] **val_block - Block to subtract to A(i, j).
-	 */
-	void SubtractBlock_ILUMatrix(unsigned long block_i, unsigned long block_j, su2double *val_block);
   
-	/*!
-	 * \brief Adds the specified value to the diagonal of the (i, i) subblock
-	 *        of the matrix-by-blocks structure.
-	 * \param[in] block_i - Index of the block in the matrix-by-blocks structure.
-	 * \param[in] val_matrix - Value to add to the diagonal elements of A(i, i).
-	 */
-	void AddVal2Diag(unsigned long block_i, su2double val_matrix);
+  /*!
+   * \brief Subtracts the specified block to the sparse matrix.
+   * \param[in] block_i - Indexes of the block in the matrix-by-blocks structure.
+   * \param[in] block_j - Indexes of the block in the matrix-by-blocks structure.
+   * \param[in] **val_block - Block to subtract to A(i, j).
+   */
+  void SubtractBlock_ILUMatrix(unsigned long block_i, unsigned long block_j, su2double *val_block);
+  
+  /*!
+   * \brief Adds the specified value to the diagonal of the (i, i) subblock
+   *        of the matrix-by-blocks structure.
+   * \param[in] block_i - Index of the block in the matrix-by-blocks structure.
+   * \param[in] val_matrix - Value to add to the diagonal elements of A(i, i).
+   */
+  void AddVal2Diag(unsigned long block_i, su2double val_matrix);
   
   /*!
    * \brief Sets the specified value to the diagonal of the (i, i) subblock
@@ -216,28 +228,28 @@ public:
    * \param[in] val_matrix - Value to add to the diagonal elements of A(i, i).
    */
   void SetVal2Diag(unsigned long block_i, su2double val_matrix);
-
+  
   /*!
-	 * \brief Calculates the matrix-vector product
-	 * \param[in] matrix
-	 * \param[in] vector
-	 * \param[out] product
-	 */
+   * \brief Calculates the matrix-vector product
+   * \param[in] matrix
+   * \param[in] vector
+   * \param[out] product
+   */
   void MatrixVectorProduct(su2double *matrix, su2double *vector, su2double *product);
   
-	/*!
-	 * \brief Calculates the matrix-matrix product
-	 * \param[in] matrix_a
-	 * \param[in] matrix_b
-	 * \param[out] product
-	 */
+  /*!
+   * \brief Calculates the matrix-matrix product
+   * \param[in] matrix_a
+   * \param[in] matrix_b
+   * \param[out] product
+   */
   void MatrixMatrixProduct(su2double *matrix_a, su2double *matrix_b, su2double *product);
   
-	/*!
-	 * \brief Deletes the values of the row i of the sparse matrix.
-	 * \param[in] i - Index of the row.
-	 */
-	void DeleteValsRowi(unsigned long i);
+  /*!
+   * \brief Deletes the values of the row i of the sparse matrix.
+   * \param[in] i - Index of the row.
+   */
+  void DeleteValsRowi(unsigned long i);
   
   /*!
    * \brief Recursive definition of determinate using expansion by minors. Written by Paul Bourke
@@ -246,7 +258,7 @@ public:
    * \return Value of the determinant.
    */
   su2double MatrixDeterminant(su2double **a, unsigned long n);
-
+  
   /*!
    * \brief Find the cofactor matrix of a square matrix. Written by Paul Bourke
    * \param[in] a - Matrix to compute the determinant.
@@ -254,7 +266,7 @@ public:
    * \param[out] b - cofactor matrix
    */
   void MatrixCoFactor(su2double **a, unsigned long n, su2double **b) ;
-
+  
   /*!
    * \brief Transpose of a square matrix, do it in place. Written by Paul Bourke
    * \param[in] a - Matrix to compute the determinant.
@@ -262,73 +274,73 @@ public:
    */
   void MatrixTranspose(su2double **a, unsigned long n) ;
   
-	/*!
-	 * \brief Performs the Gauss Elimination algorithm to solve the linear subsystem of the (i, i) subblock and rhs.
-	 * \param[in] block_i - Index of the (i, i) subblock in the matrix-by-blocks structure.
-	 * \param[in] rhs - Right-hand-side of the linear system.
+  /*!
+   * \brief Performs the Gauss Elimination algorithm to solve the linear subsystem of the (i, i) subblock and rhs.
+   * \param[in] block_i - Index of the (i, i) subblock in the matrix-by-blocks structure.
+   * \param[in] rhs - Right-hand-side of the linear system.
    * \param[in] transposed - If true the transposed of the block is used (default = false).
-	 * \return Solution of the linear system (overwritten on rhs).
-	 */
+   * \return Solution of the linear system (overwritten on rhs).
+   */
   void Gauss_Elimination(unsigned long block_i, su2double* rhs, bool transposed = false);
   
-	/*!
-	 * \brief Performs the Gauss Elimination algorithm to solve the linear subsystem of the (i, i) subblock and rhs.
-	 * \param[in] Block - matrix-by-blocks structure.
-	 * \param[in] rhs - Right-hand-side of the linear system.
-	 * \return Solution of the linear system (overwritten on rhs).
-	 */
-	void Gauss_Elimination(su2double* Block, su2double* rhs);
-
   /*!
-	 * \brief Performs the Gauss Elimination algorithm to solve the linear subsystem of the (i, i) subblock and rhs.
-	 * \param[in] block_i - Index of the (i, i) subblock in the matrix-by-blocks structure.
-	 * \param[in] rhs - Right-hand-side of the linear system.
-	 * \return Solution of the linear system (overwritten on rhs).
-	 */
-	void Gauss_Elimination_ILUMatrix(unsigned long block_i, su2double* rhs);
+   * \brief Performs the Gauss Elimination algorithm to solve the linear subsystem of the (i, i) subblock and rhs.
+   * \param[in] Block - matrix-by-blocks structure.
+   * \param[in] rhs - Right-hand-side of the linear system.
+   * \return Solution of the linear system (overwritten on rhs).
+   */
+  void Gauss_Elimination(su2double* Block, su2double* rhs);
   
   /*!
-	 * \fn void CSysMatrix::ProdBlockVector(unsigned long block_i, unsigned long block_j, su2double* vec);
-	 * \brief Performs the product of the block (i, j) by vector vec.
-	 * \param[in] block_i - Indexes of the block in the matrix-by-blocks structure.
-	 * \param[in] block_j - Indexes of the block in the matrix-by-blocks structure.
-	 * \param[in] vec - Vector to be multiplied by the block (i, j) of the sparse matrix A.
-	 * \return Product of A(i, j) by vector *vec (stored at *prod_block_vector).
-	 */
-	void ProdBlockVector(unsigned long block_i, unsigned long block_j, const CSysVector & vec);
+   * \brief Performs the Gauss Elimination algorithm to solve the linear subsystem of the (i, i) subblock and rhs.
+   * \param[in] block_i - Index of the (i, i) subblock in the matrix-by-blocks structure.
+   * \param[in] rhs - Right-hand-side of the linear system.
+   * \return Solution of the linear system (overwritten on rhs).
+   */
+  void Gauss_Elimination_ILUMatrix(unsigned long block_i, su2double* rhs);
   
   /*!
-	 * \brief Performs the product of i-th row of the upper part of a sparse matrix by a vector.
-	 * \param[in] vec - Vector to be multiplied by the upper part of the sparse matrix A.
-	 * \param[in] row_i - Row of the matrix to be multiplied by vector vec.
-	 * \return prod Result of the product U(A)*vec (stored at *prod_row_vector).
-	 */
-	void UpperProduct(CSysVector & vec, unsigned long row_i);
+   * \fn void CSysMatrix::ProdBlockVector(unsigned long block_i, unsigned long block_j, su2double* vec);
+   * \brief Performs the product of the block (i, j) by vector vec.
+   * \param[in] block_i - Indexes of the block in the matrix-by-blocks structure.
+   * \param[in] block_j - Indexes of the block in the matrix-by-blocks structure.
+   * \param[in] vec - Vector to be multiplied by the block (i, j) of the sparse matrix A.
+   * \return Product of A(i, j) by vector *vec (stored at *prod_block_vector).
+   */
+  void ProdBlockVector(unsigned long block_i, unsigned long block_j, const CSysVector & vec);
   
   /*!
-	 * \brief Performs the product of i-th row of the lower part of a sparse matrix by a vector.
-	 * \param[in] vec - Vector to be multiplied by the lower part of the sparse matrix A.
-	 * \param[in] row_i - Row of the matrix to be multiplied by vector vec.
-	 * \return prod Result of the product L(A)*vec (stored at *prod_row_vector).
-	 */
-	void LowerProduct(CSysVector & vec, unsigned long row_i);
+   * \brief Performs the product of i-th row of the upper part of a sparse matrix by a vector.
+   * \param[in] vec - Vector to be multiplied by the upper part of the sparse matrix A.
+   * \param[in] row_i - Row of the matrix to be multiplied by vector vec.
+   * \return prod Result of the product U(A)*vec (stored at *prod_row_vector).
+   */
+  void UpperProduct(CSysVector & vec, unsigned long row_i);
   
   /*!
-	 * \brief Performs the product of i-th row of the diagonal part of a sparse matrix by a vector.
-	 * \param[in] vec - Vector to be multiplied by the diagonal part of the sparse matrix A.
-	 * \param[in] row_i - Row of the matrix to be multiplied by vector vec.
-	 * \return prod Result of the product D(A)*vec (stored at *prod_row_vector).
-	 */
-	void DiagonalProduct(CSysVector & vec, unsigned long row_i);
-
+   * \brief Performs the product of i-th row of the lower part of a sparse matrix by a vector.
+   * \param[in] vec - Vector to be multiplied by the lower part of the sparse matrix A.
+   * \param[in] row_i - Row of the matrix to be multiplied by vector vec.
+   * \return prod Result of the product L(A)*vec (stored at *prod_row_vector).
+   */
+  void LowerProduct(CSysVector & vec, unsigned long row_i);
+  
   /*!
-	 * \brief Send receive the solution using MPI.
-	 * \param[in] x - Solution..
-	 * \param[in] geometry - Geometrical definition of the problem.
-	 * \param[in] config - Definition of the particular problem.
-	 */
-	void SendReceive_Solution(CSysVector & x, CGeometry *geometry, CConfig *config);
-
+   * \brief Performs the product of i-th row of the diagonal part of a sparse matrix by a vector.
+   * \param[in] vec - Vector to be multiplied by the diagonal part of the sparse matrix A.
+   * \param[in] row_i - Row of the matrix to be multiplied by vector vec.
+   * \return prod Result of the product D(A)*vec (stored at *prod_row_vector).
+   */
+  void DiagonalProduct(CSysVector & vec, unsigned long row_i);
+  
+  /*!
+   * \brief Send receive the solution using MPI.
+   * \param[in] x - Solution..
+   * \param[in] geometry - Geometrical definition of the problem.
+   * \param[in] config - Definition of the particular problem.
+   */
+  void SendReceive_Solution(CSysVector & x, CGeometry *geometry, CConfig *config);
+  
   /*!
    * \brief Send receive the solution using MPI and the transposed structure of the matrix.
    * \param[in] x - Solution..
@@ -336,32 +348,32 @@ public:
    * \param[in] config - Definition of the particular problem.
    */
   void SendReceive_SolutionTransposed(CSysVector & x, CGeometry *geometry, CConfig *config);
-
-  /*!
-	 * \brief Performs the product of i-th row of a sparse matrix by a vector.
-	 * \param[in] vec - Vector to be multiplied by the row of the sparse matrix A.
-	 * \param[in] row_i - Row of the matrix to be multiplied by vector vec.
-	 * \return Result of the product (stored at *prod_row_vector).
-	 */
-	void RowProduct(const CSysVector & vec, unsigned long row_i);
   
   /*!
-	 * \brief Performs the product of a sparse matrix by a vector.
-	 * \param[in] vec - Vector to be multiplied by the sparse matrix A.
-	 * \param[out] prod - Result of the product.
-	 * \return Result of the product A*vec.
-	 */
-	void MatrixVectorProduct(const CSysVector & vec, CSysVector & prod);
+   * \brief Performs the product of i-th row of a sparse matrix by a vector.
+   * \param[in] vec - Vector to be multiplied by the row of the sparse matrix A.
+   * \param[in] row_i - Row of the matrix to be multiplied by vector vec.
+   * \return Result of the product (stored at *prod_row_vector).
+   */
+  void RowProduct(const CSysVector & vec, unsigned long row_i);
   
-	/*!
-	 * \brief Performs the product of a sparse matrix by a CSysVector.
-	 * \param[in] vec - CSysVector to be multiplied by the sparse matrix A.
-	 * \param[in] geometry - Geometrical definition of the problem.
+  /*!
+   * \brief Performs the product of a sparse matrix by a vector.
+   * \param[in] vec - Vector to be multiplied by the sparse matrix A.
+   * \param[out] prod - Result of the product.
+   * \return Result of the product A*vec.
+   */
+  void MatrixVectorProduct(const CSysVector & vec, CSysVector & prod);
+  
+  /*!
+   * \brief Performs the product of a sparse matrix by a CSysVector.
+   * \param[in] vec - CSysVector to be multiplied by the sparse matrix A.
+   * \param[in] geometry - Geometrical definition of the problem.
    * \param[in] config - Definition of the particular problem.
-	 * \param[out] prod - Result of the product.
-	 */
-	void MatrixVectorProduct(const CSysVector & vec, CSysVector & prod, CGeometry *geometry, CConfig *config);
-	
+   * \param[out] prod - Result of the product.
+   */
+  void MatrixVectorProduct(const CSysVector & vec, CSysVector & prod, CGeometry *geometry, CConfig *config);
+  
   /*!
    * \brief Performs the product of a sparse matrix by a CSysVector.
    * \param[in] vec - CSysVector to be multiplied by the sparse matrix A.
@@ -370,61 +382,61 @@ public:
    * \param[out] prod - Result of the product.
    */
   void MatrixVectorProductTransposed(const CSysVector & vec, CSysVector & prod, CGeometry *geometry, CConfig *config);
-
-	/*!
-	 * \brief Performs the product of two block matrices.
-	 */
-	void GetMultBlockBlock(su2double *c, su2double *a, su2double *b);
-	
-	/*!
-	 * \brief Performs the product of a block matrices by a vector.
-	 */
-	void GetMultBlockVector(su2double *c, su2double *a, su2double *b);
-	
-	/*!
-	 * \brief Performs the subtraction of two matrices.
-	 */
-	void GetSubsBlock(su2double *c, su2double *a, su2double *b);
-	
-	/*!
-	 * \brief Performs the subtraction of two vectors.
-	 */
-	void GetSubsVector(su2double *c, su2double *a, su2double *b);
   
-	/*!
-	 * \brief Inverse diagonal block.
+  /*!
+   * \brief Performs the product of two block matrices.
+   */
+  void GetMultBlockBlock(su2double *c, su2double *a, su2double *b);
+  
+  /*!
+   * \brief Performs the product of a block matrices by a vector.
+   */
+  void GetMultBlockVector(su2double *c, su2double *a, su2double *b);
+  
+  /*!
+   * \brief Performs the subtraction of two matrices.
+   */
+  void GetSubsBlock(su2double *c, su2double *a, su2double *b);
+  
+  /*!
+   * \brief Performs the subtraction of two vectors.
+   */
+  void GetSubsVector(su2double *c, su2double *a, su2double *b);
+  
+  /*!
+   * \brief Inverse diagonal block.
    * \param[in] block_i - Indexes of the block in the matrix-by-blocks structure.
-	 * \param[out] invBlock - Inverse block.
-	 */
+   * \param[out] invBlock - Inverse block.
+   */
   void InverseDiagonalBlock(unsigned long block_i, su2double *invBlock, bool transpose = false);
   
  	/*!
-	 * \brief Inverse diagonal block.
-	 * \param[in] block_i - Indexes of the block in the matrix-by-blocks structure.
-	 * \param[out] invBlock - Inverse block.
-	 */
-	void InverseDiagonalBlock_ILUMatrix(unsigned long block_i, su2double *invBlock);
- 
-	/*!
-	 * \brief Inverse a block.
-	 * \param[in] Block - block matrix.
-	 * \param[out] invBlock - Inverse block.
-	 */
-	void InverseBlock(su2double *Block, su2double *invBlock);
+   * \brief Inverse diagonal block.
+   * \param[in] block_i - Indexes of the block in the matrix-by-blocks structure.
+   * \param[out] invBlock - Inverse block.
+   */
+  void InverseDiagonalBlock_ILUMatrix(unsigned long block_i, su2double *invBlock);
   
-	/*!
-	 * \brief Build the Jacobi preconditioner.
-	 */
+  /*!
+   * \brief Inverse a block.
+   * \param[in] Block - block matrix.
+   * \param[out] invBlock - Inverse block.
+   */
+  void InverseBlock(su2double *Block, su2double *invBlock);
+  
+  /*!
+   * \brief Build the Jacobi preconditioner.
+   */
   void BuildJacobiPreconditioner(bool transpose = false);
-	
-	/*!
-	 * \brief Multiply CSysVector by the preconditioner
-	 * \param[in] vec - CSysVector to be multiplied by the preconditioner.
-	 * \param[out] prod - Result of the product A*vec.
+  
+  /*!
+   * \brief Multiply CSysVector by the preconditioner
+   * \param[in] vec - CSysVector to be multiplied by the preconditioner.
+   * \param[out] prod - Result of the product A*vec.
    * \param[in] geometry - Geometrical definition of the problem.
    * \param[in] config - Definition of the particular problem.
-	 */
-	void ComputeJacobiPreconditioner(const CSysVector & vec, CSysVector & prod, CGeometry *geometry, CConfig *config);
+   */
+  void ComputeJacobiPreconditioner(const CSysVector & vec, CSysVector & prod, CGeometry *geometry, CConfig *config);
   
   /*!
    * \brief Apply Jacobi as a classical iterative smoother
@@ -447,14 +459,14 @@ public:
    */
   void BuildILUPreconditioner(bool transposed = false);
   
-	/*!
-	 * \brief Multiply CSysVector by the preconditioner
-	 * \param[in] vec - CSysVector to be multiplied by the preconditioner.
-	 * \param[out] prod - Result of the product A*vec.
+  /*!
+   * \brief Multiply CSysVector by the preconditioner
+   * \param[in] vec - CSysVector to be multiplied by the preconditioner.
+   * \param[out] prod - Result of the product A*vec.
    * \param[in] geometry - Geometrical definition of the problem.
    * \param[in] config - Definition of the particular problem.
-	 */
-	void ComputeILUPreconditioner(const CSysVector & vec, CSysVector & prod, CGeometry *geometry, CConfig *config);
+   */
+  void ComputeILUPreconditioner(const CSysVector & vec, CSysVector & prod, CGeometry *geometry, CConfig *config);
   
   /*!
    * \brief Apply ILU0 as a classical iterative smoother
@@ -470,15 +482,15 @@ public:
    * \param[out] x - CSysVector containing the result of the smoothing (x^k+1 = x^k + M^-1*(b - A*x^k).
    */
   unsigned long ILU0_Smoother(const CSysVector & b, CSysVector & x, CMatrixVectorProduct & mat_vec, su2double tol, unsigned long m, su2double *residual, bool monitoring, CGeometry *geometry, CConfig *config);
-
-  /*!
-	 * \brief Multiply CSysVector by the preconditioner
-	 * \param[in] vec - CSysVector to be multiplied by the preconditioner.
-	 * \param[out] prod - Result of the product A*vec.
-	 */
-	void ComputeLU_SGSPreconditioner(const CSysVector & vec, CSysVector & prod, CGeometry *geometry, CConfig *config);
   
-/*!
+  /*!
+   * \brief Multiply CSysVector by the preconditioner
+   * \param[in] vec - CSysVector to be multiplied by the preconditioner.
+   * \param[out] prod - Result of the product A*vec.
+   */
+  void ComputeLU_SGSPreconditioner(const CSysVector & vec, CSysVector & prod, CGeometry *geometry, CConfig *config);
+  
+  /*!
    * \brief Apply LU_SGS as a classical iterative smoother
    * \param[in] b - CSysVector containing the residual (b)
    * \param[in] x - CSysVector containing the solution (x^k)
@@ -499,22 +511,22 @@ public:
    * \param[in] config - Definition of the particular problem.
    */
   unsigned short BuildLineletPreconditioner(CGeometry *geometry, CConfig *config);
-
-	/*!
-	 * \brief Multiply CSysVector by the preconditioner
-	 * \param[in] vec - CSysVector to be multiplied by the preconditioner.
-	 * \param[out] prod - Result of the product A*vec.
-	 */
-	void ComputeLineletPreconditioner(const CSysVector & vec, CSysVector & prod, CGeometry *geometry, CConfig *config);
-
+  
   /*!
-	 * \brief Compute the residual Ax-b
-	 * \param[in] sol - CSysVector to be multiplied by the preconditioner.
-	 * \param[in] f - Result of the product A*vec.
+   * \brief Multiply CSysVector by the preconditioner
+   * \param[in] vec - CSysVector to be multiplied by the preconditioner.
+   * \param[out] prod - Result of the product A*vec.
+   */
+  void ComputeLineletPreconditioner(const CSysVector & vec, CSysVector & prod, CGeometry *geometry, CConfig *config);
+  
+  /*!
+   * \brief Compute the residual Ax-b
+   * \param[in] sol - CSysVector to be multiplied by the preconditioner.
+   * \param[in] f - Result of the product A*vec.
    * \param[out] res - Result of the product A*vec.
-	 */
+   */
   void ComputeResidual(const CSysVector & sol, const CSysVector & f, CSysVector & res);
-
+  
 };
 
 /*!
@@ -523,31 +535,31 @@ public:
  */
 class CSysMatrixVectorProduct : public CMatrixVectorProduct {
 private:
-	CSysMatrix* sparse_matrix; /*!< \brief pointer to matrix that defines the product. */
-	CGeometry* geometry; /*!< \brief pointer to matrix that defines the geometry. */
-	CConfig* config; /*!< \brief pointer to matrix that defines the config. */
+  CSysMatrix* sparse_matrix; /*!< \brief pointer to matrix that defines the product. */
+  CGeometry* geometry; /*!< \brief pointer to matrix that defines the geometry. */
+  CConfig* config; /*!< \brief pointer to matrix that defines the config. */
   
 public:
   
-	/*!
-	 * \brief constructor of the class
-	 * \param[in] matrix_ref - matrix reference that will be used to define the products
-	 * \param[in] geometry_ref -
+  /*!
+   * \brief constructor of the class
+   * \param[in] matrix_ref - matrix reference that will be used to define the products
+   * \param[in] geometry_ref -
    * \param[in] config_ref -
-	 */
-	CSysMatrixVectorProduct(CSysMatrix & matrix_ref, CGeometry *geometry_ref, CConfig *config_ref);
+   */
+  CSysMatrixVectorProduct(CSysMatrix & matrix_ref, CGeometry *geometry_ref, CConfig *config_ref);
   
-	/*!
-	 * \brief destructor of the class
-	 */
-	~CSysMatrixVectorProduct() {}
+  /*!
+   * \brief destructor of the class
+   */
+  ~CSysMatrixVectorProduct() {}
   
-	/*!
-	 * \brief operator that defines the CSysMatrix-CSysVector product
-	 * \param[in] u - CSysVector that is being multiplied by the sparse matrix
-	 * \param[out] v - CSysVector that is the result of the product
-	 */
-	void operator()(const CSysVector & u, CSysVector & v) const;
+  /*!
+   * \brief operator that defines the CSysMatrix-CSysVector product
+   * \param[in] u - CSysVector that is being multiplied by the sparse matrix
+   * \param[out] v - CSysVector that is the result of the product
+   */
+  void operator()(const CSysVector & u, CSysVector & v) const;
 };
 
 /*!
@@ -559,9 +571,9 @@ private:
   CSysMatrix* sparse_matrix; /*!< \brief pointer to matrix that defines the product. */
   CGeometry* geometry; /*!< \brief pointer to matrix that defines the geometry. */
   CConfig* config; /*!< \brief pointer to matrix that defines the config. */
-
+  
 public:
-
+  
   /*!
    * \brief constructor of the class
    * \param[in] matrix_ref - matrix reference that will be used to define the products
@@ -569,12 +581,12 @@ public:
    * \param[in] config_ref -
    */
   CSysMatrixVectorProductTransposed(CSysMatrix & matrix_ref, CGeometry *geometry_ref, CConfig *config_ref);
-
+  
   /*!
    * \brief destructor of the class
    */
   ~CSysMatrixVectorProductTransposed() {}
-
+  
   /*!
    * \brief operator that defines the CSysMatrix-CSysVector product
    * \param[in] u - CSysVector that is being multiplied by the sparse matrix
@@ -589,31 +601,31 @@ public:
  */
 class CJacobiPreconditioner : public CPreconditioner {
 private:
-	CSysMatrix* sparse_matrix; /*!< \brief pointer to matrix that defines the preconditioner. */
-	CGeometry* geometry; /*!< \brief pointer to matrix that defines the geometry. */
-	CConfig* config; /*!< \brief pointer to matrix that defines the config. */
+  CSysMatrix* sparse_matrix; /*!< \brief pointer to matrix that defines the preconditioner. */
+  CGeometry* geometry; /*!< \brief pointer to matrix that defines the geometry. */
+  CConfig* config; /*!< \brief pointer to matrix that defines the config. */
   
 public:
   
-	/*!
-	 * \brief constructor of the class
-	 * \param[in] matrix_ref - matrix reference that will be used to define the preconditioner
-	 * \param[in] geometry_ref -
+  /*!
+   * \brief constructor of the class
+   * \param[in] matrix_ref - matrix reference that will be used to define the preconditioner
+   * \param[in] geometry_ref -
    * \param[in] config_ref -
-	 */
-	CJacobiPreconditioner(CSysMatrix & matrix_ref, CGeometry *geometry_ref, CConfig *config_ref);
+   */
+  CJacobiPreconditioner(CSysMatrix & matrix_ref, CGeometry *geometry_ref, CConfig *config_ref);
   
-	/*!
-	 * \brief destructor of the class
-	 */
-	~CJacobiPreconditioner() {}
+  /*!
+   * \brief destructor of the class
+   */
+  ~CJacobiPreconditioner() {}
   
-	/*!
-	 * \brief operator that defines the preconditioner operation
-	 * \param[in] u - CSysVector that is being preconditioned
-	 * \param[out] v - CSysVector that is the result of the preconditioning
-	 */
-	void operator()(const CSysVector & u, CSysVector & v) const;
+  /*!
+   * \brief operator that defines the preconditioner operation
+   * \param[in] u - CSysVector that is being preconditioned
+   * \param[out] v - CSysVector that is the result of the preconditioning
+   */
+  void operator()(const CSysVector & u, CSysVector & v) const;
 };
 
 /*!
@@ -625,9 +637,9 @@ private:
   CSysMatrix* sparse_matrix; /*!< \brief pointer to matrix that defines the preconditioner. */
   CGeometry* geometry; /*!< \brief pointer to matrix that defines the geometry. */
   CConfig* config; /*!< \brief pointer to matrix that defines the config. */
-
+  
 public:
-
+  
   /*!
    * \brief constructor of the class
    * \param[in] matrix_ref - matrix reference that will be used to define the preconditioner
@@ -635,12 +647,12 @@ public:
    * \param[in] config_ref -
    */
   CJacobiTransposedPreconditioner(CSysMatrix & matrix_ref, CGeometry *geometry_ref, CConfig *config_ref);
-
+  
   /*!
    * \brief destructor of the class
    */
   ~CJacobiTransposedPreconditioner() {}
-
+  
   /*!
    * \brief operator that defines the preconditioner operation
    * \param[in] u - CSysVector that is being preconditioned
@@ -655,31 +667,31 @@ public:
  */
 class CILUPreconditioner : public CPreconditioner {
 private:
-	CSysMatrix* sparse_matrix; /*!< \brief pointer to matrix that defines the preconditioner. */
-	CGeometry* geometry; /*!< \brief pointer to matrix that defines the geometry. */
-	CConfig* config; /*!< \brief pointer to matrix that defines the config. */
+  CSysMatrix* sparse_matrix; /*!< \brief pointer to matrix that defines the preconditioner. */
+  CGeometry* geometry; /*!< \brief pointer to matrix that defines the geometry. */
+  CConfig* config; /*!< \brief pointer to matrix that defines the config. */
   
 public:
   
-	/*!
-	 * \brief constructor of the class
-	 * \param[in] matrix_ref - matrix reference that will be used to define the preconditioner
-	 * \param[in] geometry_ref -
+  /*!
+   * \brief constructor of the class
+   * \param[in] matrix_ref - matrix reference that will be used to define the preconditioner
+   * \param[in] geometry_ref -
    * \param[in] config_ref -
-	 */
-	CILUPreconditioner(CSysMatrix & matrix_ref, CGeometry *geometry_ref, CConfig *config_ref);
+   */
+  CILUPreconditioner(CSysMatrix & matrix_ref, CGeometry *geometry_ref, CConfig *config_ref);
   
-	/*!
-	 * \brief destructor of the class
-	 */
-	~CILUPreconditioner() {}
+  /*!
+   * \brief destructor of the class
+   */
+  ~CILUPreconditioner() {}
   
-	/*!
-	 * \brief operator that defines the preconditioner operation
-	 * \param[in] u - CSysVector that is being preconditioned
-	 * \param[out] v - CSysVector that is the result of the preconditioning
-	 */
-	void operator()(const CSysVector & u, CSysVector & v) const;
+  /*!
+   * \brief operator that defines the preconditioner operation
+   * \param[in] u - CSysVector that is being preconditioned
+   * \param[out] v - CSysVector that is the result of the preconditioning
+   */
+  void operator()(const CSysVector & u, CSysVector & v) const;
 };
 
 /*!
@@ -688,31 +700,31 @@ public:
  */
 class CLU_SGSPreconditioner : public CPreconditioner {
 private:
-	CSysMatrix* sparse_matrix; /*!< \brief pointer to matrix that defines the preconditioner. */
+  CSysMatrix* sparse_matrix; /*!< \brief pointer to matrix that defines the preconditioner. */
   CGeometry* geometry; /*!< \brief pointer to matrix that defines the geometry. */
-	CConfig* config; /*!< \brief pointer to matrix that defines the config. */
+  CConfig* config; /*!< \brief pointer to matrix that defines the config. */
   
 public:
-	
-	/*!
-	 * \brief constructor of the class
-	 * \param[in] matrix_ref - matrix reference that will be used to define the preconditioner
-	 * \param[in] geometry_ref -
+  
+  /*!
+   * \brief constructor of the class
+   * \param[in] matrix_ref - matrix reference that will be used to define the preconditioner
+   * \param[in] geometry_ref -
    * \param[in] config_ref -
-	 */
-	CLU_SGSPreconditioner(CSysMatrix & matrix_ref, CGeometry *geometry_ref, CConfig *config_ref);
-	
-	/*!
-	 * \brief destructor of the class
-	 */
-	~CLU_SGSPreconditioner() {}
-	
-	/*!
-	 * \brief operator that defines the preconditioner operation
-	 * \param[in] u - CSysVector that is being preconditioned
-	 * \param[out] v - CSysVector that is the result of the preconditioning
-	 */
-	void operator()(const CSysVector & u, CSysVector & v) const;
+   */
+  CLU_SGSPreconditioner(CSysMatrix & matrix_ref, CGeometry *geometry_ref, CConfig *config_ref);
+  
+  /*!
+   * \brief destructor of the class
+   */
+  ~CLU_SGSPreconditioner() {}
+  
+  /*!
+   * \brief operator that defines the preconditioner operation
+   * \param[in] u - CSysVector that is being preconditioned
+   * \param[out] v - CSysVector that is the result of the preconditioning
+   */
+  void operator()(const CSysVector & u, CSysVector & v) const;
 };
 
 /*!
@@ -721,31 +733,31 @@ public:
  */
 class CLineletPreconditioner : public CPreconditioner {
 private:
-	CSysMatrix* sparse_matrix; /*!< \brief pointer to matrix that defines the preconditioner. */
+  CSysMatrix* sparse_matrix; /*!< \brief pointer to matrix that defines the preconditioner. */
   CGeometry* geometry; /*!< \brief pointer to matrix that defines the geometry. */
-	CConfig* config; /*!< \brief pointer to matrix that defines the config. */
+  CConfig* config; /*!< \brief pointer to matrix that defines the config. */
   
 public:
-	
-	/*!
-	 * \brief constructor of the class
-	 * \param[in] matrix_ref - matrix reference that will be used to define the preconditioner
-	 * \param[in] geometry_ref -
+  
+  /*!
+   * \brief constructor of the class
+   * \param[in] matrix_ref - matrix reference that will be used to define the preconditioner
+   * \param[in] geometry_ref -
    * \param[in] config_ref -
-	 */
-	CLineletPreconditioner(CSysMatrix & matrix_ref, CGeometry *geometry_ref, CConfig *config_ref);
-	
-	/*!
-	 * \brief destructor of the class
-	 */
-	~CLineletPreconditioner() {}
-	
-	/*!
-	 * \brief operator that defines the preconditioner operation
-	 * \param[in] u - CSysVector that is being preconditioned
-	 * \param[out] v - CSysVector that is the result of the preconditioning
-	 */
-	void operator()(const CSysVector & u, CSysVector & v) const;
+   */
+  CLineletPreconditioner(CSysMatrix & matrix_ref, CGeometry *geometry_ref, CConfig *config_ref);
+  
+  /*!
+   * \brief destructor of the class
+   */
+  ~CLineletPreconditioner() {}
+  
+  /*!
+   * \brief operator that defines the preconditioner operation
+   * \param[in] u - CSysVector that is being preconditioned
+   * \param[out] v - CSysVector that is the result of the preconditioning
+   */
+  void operator()(const CSysVector & u, CSysVector & v) const;
 };
 
 #include "matrix_structure.inl"

--- a/Common/include/option_structure.hpp
+++ b/Common/include/option_structure.hpp
@@ -1334,7 +1334,7 @@ static const map<string, ENUM_LINEAR_SOLVER> Linear_Solver_Map = CCreateMap<stri
 ("SMOOTHER_LUSGS", SMOOTHER_LUSGS)
 ("SMOOTHER_JACOBI", SMOOTHER_JACOBI)
 ("SMOOTHER_LINELET", SMOOTHER_LINELET)
-("SMOOTHER_ILU0", SMOOTHER_ILU);
+("SMOOTHER_ILU", SMOOTHER_ILU);
 
 /*!
  * \brief types surface continuity at the intersection with the FFD
@@ -1392,7 +1392,7 @@ static const map<string, ENUM_LINEAR_SOLVER_PREC> Linear_Solver_Prec_Map = CCrea
 ("JACOBI", JACOBI)
 ("LU_SGS", LU_SGS)
 ("LINELET", LINELET)
-("ILU0", ILU);
+("ILU", ILU);
 
 /*!
  * \brief types of analytic definitions for various geometries

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -1029,7 +1029,7 @@ void CConfig::SetConfig_Options(unsigned short val_iZone, unsigned short val_nZo
   /* DESCRIPTION: Maximum number of iterations of the linear solver for the implicit formulation */
   addUnsignedLongOption("LINEAR_SOLVER_ITER", Linear_Solver_Iter, 10);
   /* DESCRIPTION: Fill in level for the ILU preconditioner */
-  addUnsignedShortOption("LINEAR_SOLVER_ILU_FILL_IN", Linear_Solver_ILU_n, 1);
+  addUnsignedShortOption("LINEAR_SOLVER_ILU_FILL_IN", Linear_Solver_ILU_n, 0);
   /* DESCRIPTION: Maximum number of iterations of the linear solver for the implicit formulation */
   addUnsignedLongOption("LINEAR_SOLVER_RESTART_FREQUENCY", Linear_Solver_Restart_Frequency, 10);
   /* DESCRIPTION: Relaxation of the flow equations solver for the implicit formulation */

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -4679,26 +4679,40 @@ void CConfig::SetOutput(unsigned short val_software, unsigned short val_izone) {
           }
           cout << endl;
           break;
-        case EULER_EXPLICIT: cout << "Euler explicit method for the flow equations." << endl; break;
+        case EULER_EXPLICIT:
+          cout << "Euler explicit method for the flow equations." << endl;
+          break;
         case EULER_IMPLICIT:
           cout << "Euler implicit method for the flow equations." << endl;
           switch (Kind_Linear_Solver) {
             case BCGSTAB:
               cout << "BCGSTAB is used for solving the linear system." << endl;
+              switch (Kind_Linear_Solver_Prec) {
+                case ILU: cout << "Using a ILU("<< Linear_Solver_ILU_n <<") preconditioning."<< endl; break;
+                case LINELET: cout << "Using a linelet preconditioning."<< endl; break;
+                case LU_SGS: cout << "Using a LU-SGS preconditioning."<< endl; break;
+                case JACOBI: cout << "Using a Jacobi preconditioning."<< endl; break;
+              }
               cout << "Convergence criteria of the linear solver: "<< Linear_Solver_Error <<"."<< endl;
               cout << "Max number of iterations: "<< Linear_Solver_Iter <<"."<< endl;
               break;
             case FGMRES:
             case RESTARTED_FGMRES:
               cout << "FGMRES is used for solving the linear system." << endl;
+              switch (Kind_Linear_Solver_Prec) {
+                case ILU: cout << "Using a ILU("<< Linear_Solver_ILU_n <<") preconditioning."<< endl; break;
+                case LINELET: cout << "Using a linelet preconditioning."<< endl; break;
+                case LU_SGS: cout << "Using a LU-SGS preconditioning."<< endl; break;
+                case JACOBI: cout << "Using a Jacobi preconditioning."<< endl; break;
+              }
               cout << "Convergence criteria of the linear solver: "<< Linear_Solver_Error <<"."<< endl;
               cout << "Max number of iterations: "<< Linear_Solver_Iter <<"."<< endl;
-              break;
+               break;
             case SMOOTHER_JACOBI:
               cout << "A Jacobi method is used for smoothing the linear system." << endl;
               break;
             case SMOOTHER_ILU:
-              cout << "A ILU method is used for smoothing the linear system." << endl;
+              cout << "A ILU("<< Linear_Solver_ILU_n <<") method is used for smoothing the linear system." << endl;
               break;
             case SMOOTHER_LUSGS:
               cout << "A LU-SGS method is used for smoothing the linear system." << endl;

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -1028,6 +1028,8 @@ void CConfig::SetConfig_Options(unsigned short val_iZone, unsigned short val_nZo
   addDoubleOption("LINEAR_SOLVER_ERROR", Linear_Solver_Error, 1E-6);
   /* DESCRIPTION: Maximum number of iterations of the linear solver for the implicit formulation */
   addUnsignedLongOption("LINEAR_SOLVER_ITER", Linear_Solver_Iter, 10);
+  /* DESCRIPTION: Fill in level for the ILU preconditioner */
+  addUnsignedShortOption("LINEAR_SOLVER_ILU_FILL_IN", Linear_Solver_ILU_n, 1);
   /* DESCRIPTION: Maximum number of iterations of the linear solver for the implicit formulation */
   addUnsignedLongOption("LINEAR_SOLVER_RESTART_FREQUENCY", Linear_Solver_Restart_Frequency, 10);
   /* DESCRIPTION: Relaxation of the flow equations solver for the implicit formulation */
@@ -4696,7 +4698,7 @@ void CConfig::SetOutput(unsigned short val_software, unsigned short val_izone) {
               cout << "A Jacobi method is used for smoothing the linear system." << endl;
               break;
             case SMOOTHER_ILU:
-              cout << "A ILU0 method is used for smoothing the linear system." << endl;
+              cout << "A ILU method is used for smoothing the linear system." << endl;
               break;
             case SMOOTHER_LUSGS:
               cout << "A LU-SGS method is used for smoothing the linear system." << endl;

--- a/Common/src/grid_movement_structure.cpp
+++ b/Common/src/grid_movement_structure.cpp
@@ -203,7 +203,7 @@ void CVolumetricMovement::SetVolume_Deformation(CGeometry *geometry, CConfig *co
     		precond = new CLU_SGSPreconditioner(StiffMatrix, geometry, config);
     	}
     	if (config->GetKind_Deform_Linear_Solver_Prec() == ILU) {
-        if ((rank == MASTER_NODE) && Screen_Output) cout << "\n# ILU0 preconditioner." << endl;
+        if ((rank == MASTER_NODE) && Screen_Output) cout << "\n# ILU preconditioner." << endl;
     		StiffMatrix.BuildILUPreconditioner();
     		mat_vec = new CSysMatrixVectorProduct(StiffMatrix, geometry, config);
     		precond = new CILUPreconditioner(StiffMatrix, geometry, config);
@@ -221,7 +221,7 @@ void CVolumetricMovement::SetVolume_Deformation(CGeometry *geometry, CConfig *co
 
     	if ((config->GetKind_Deform_Linear_Solver_Prec() == ILU) ||
     			(config->GetKind_Deform_Linear_Solver_Prec() == LU_SGS)) {
-        if ((rank == MASTER_NODE) && Screen_Output) cout << "\n# ILU0 preconditioner." << endl;
+        if ((rank == MASTER_NODE) && Screen_Output) cout << "\n# ILU preconditioner." << endl;
     		StiffMatrix.BuildILUPreconditioner(true);
     		mat_vec = new CSysMatrixVectorProductTransposed(StiffMatrix, geometry, config);
     		precond = new CILUPreconditioner(StiffMatrix, geometry, config);

--- a/Common/src/linear_solvers_structure.cpp
+++ b/Common/src/linear_solvers_structure.cpp
@@ -722,7 +722,7 @@ unsigned long CSysSolve::Solve(CSysMatrix & Jacobian, CSysVector & LinSysRes, CS
       case SMOOTHER_ILU:
         mat_vec = new CSysMatrixVectorProduct(Jacobian, geometry, config);
         Jacobian.BuildILUPreconditioner();
-        IterLinSol = Jacobian.ILU0_Smoother(LinSysRes, LinSysSol, *mat_vec, SolverTol, MaxIter, &Residual, false, geometry, config);
+        IterLinSol = Jacobian.ILU_Smoother(LinSysRes, LinSysSol, *mat_vec, SolverTol, MaxIter, &Residual, false, geometry, config);
         delete mat_vec;
         break;
       case SMOOTHER_LINELET:

--- a/TestCases/aeroelastic/aeroelastic_NACA64A010.cfg
+++ b/TestCases/aeroelastic/aeroelastic_NACA64A010.cfg
@@ -172,11 +172,11 @@ CFL_NUMBER= 4.0
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
 % Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, 
-%                                                      SMOOTHER_ILU0, SMOOTHER_LUSGS, 
+%                                                      SMOOTHER_ILU, SMOOTHER_LUSGS, 
 %                                                      SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Minimum error of the linear solver for implicit formulations
@@ -235,7 +235,7 @@ TIME_DISCRE_FLOW= EULER_IMPLICIT
 % Linear solver or smoother for implicit formulations (FGMRES, RESTARTED_FGMRES, BCGSTAB)
 DEFORM_LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, JACOBI)
 DEFORM_LINEAR_SOLVER_PREC= LU_SGS
 %
 % Number of smoothing iterations for mesh deformation

--- a/TestCases/cont_adj_euler/naca0012/inv_NACA0012.cfg
+++ b/TestCases/cont_adj_euler/naca0012/inv_NACA0012.cfg
@@ -116,6 +116,9 @@ LINEAR_SOLVER_ERROR= 1E-6
 %
 % Max number of iterations of the linear solver for the implicit formulation
 LINEAR_SOLVER_ITER= 5
+%
+% Linael solver ILU preconditioner fill-in level (1 by default)
+LINEAR_SOLVER_ILU_FILL_IN= 0
 
 % -------------------------- MULTIGRID PARAMETERS -----------------------------%
 %

--- a/TestCases/cont_adj_euler/naca0012/inv_NACA0012.cfg
+++ b/TestCases/cont_adj_euler/naca0012/inv_NACA0012.cfg
@@ -104,11 +104,11 @@ EXT_ITER= 150
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
 % Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI,
-%                                                      SMOOTHER_ILU0, SMOOTHER_LUSGS,
+%                                                      SMOOTHER_ILU, SMOOTHER_LUSGS,
 %                                                      SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Minimum error of the linear solver for implicit formulations
@@ -213,7 +213,7 @@ DV_VALUE= 0.01
 % Linear solver or smoother for implicit formulations (FGMRES, RESTARTED_FGMRES, BCGSTAB)
 DEFORM_LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, JACOBI)
 DEFORM_LINEAR_SOLVER_PREC= LU_SGS
 %
 % Number of smoothing iterations for mesh deformation

--- a/TestCases/cont_adj_euler/naca0012/inv_NACA0012_FD.cfg
+++ b/TestCases/cont_adj_euler/naca0012/inv_NACA0012_FD.cfg
@@ -105,6 +105,19 @@ RK_ALPHA_COEFF= ( 0.66667, 0.66667, 1.000000 )
 % Number of total iterations
 EXT_ITER= 10
 
+% ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
+%
+% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI,
+%                                                      SMOOTHER_ILU, SMOOTHER_LUSGS,
+%                                                      SMOOTHER_LINELET)
+LINEAR_SOLVER= FGMRES
+%
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
+LINEAR_SOLVER_PREC= ILU
+%
+% Linael solver ILU preconditioner fill-in level (1 by default)
+LINEAR_SOLVER_ILU_FILL_IN= 0
+
 % -------------------------- MULTIGRID PARAMETERS -----------------------------%
 %
 % Multi-Grid Levels (0 = no multi-grid)

--- a/TestCases/cont_adj_euler/naca0012/inv_NACA0012_FD.cfg
+++ b/TestCases/cont_adj_euler/naca0012/inv_NACA0012_FD.cfg
@@ -201,7 +201,7 @@ DV_VALUE= 0.01
 % Linear solver or smoother for implicit formulations (FGMRES, RESTARTED_FGMRES, BCGSTAB)
 DEFORM_LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, JACOBI)
 DEFORM_LINEAR_SOLVER_PREC= LU_SGS
 %
 % Number of smoothing iterations for mesh deformation

--- a/TestCases/cont_adj_euler/oneram6/inv_ONERAM6.cfg
+++ b/TestCases/cont_adj_euler/oneram6/inv_ONERAM6.cfg
@@ -115,7 +115,7 @@ EXT_ITER= 99999
 % Linear solver for the implicit formulation (BCGSTAB, FGMRES)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Min error of the linear solver for the implicit formulation

--- a/TestCases/cont_adj_euler/wedge/inv_wedge_ROE_multiobj.cfg
+++ b/TestCases/cont_adj_euler/wedge/inv_wedge_ROE_multiobj.cfg
@@ -108,6 +108,14 @@ LINEAR_SOLVER_ERROR= 1E-6
 %
 % Max number of iterations of the linear solver for the implicit formulation
 LINEAR_SOLVER_ITER= 5
+%
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
+LINEAR_SOLVER_PREC= ILU
+%
+% Linael solver ILU preconditioner fill-in level (1 by default)
+LINEAR_SOLVER_ILU_FILL_IN= 0
+
+
 
 % -------------------------- MULTIGRID PARAMETERS -----------------------------%
 %

--- a/TestCases/coupled_fsi/2d_aeroelasticity/SU2_config.cfg
+++ b/TestCases/coupled_fsi/2d_aeroelasticity/SU2_config.cfg
@@ -257,11 +257,11 @@ SENS_REMOVE_SHARP= NO
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
 % Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, 
-%                                                      SMOOTHER_ILU0, SMOOTHER_LUSGS, 
+%                                                      SMOOTHER_ILU, SMOOTHER_LUSGS, 
 %                                                      SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/deformation/brick_hex/def_brick_hex.cfg
+++ b/TestCases/deformation/brick_hex/def_brick_hex.cfg
@@ -147,7 +147,7 @@ DV_VALUE= 3.0
 % Linear solver or smoother for implicit formulations (FGMRES, RESTARTED_FGMRES, BCGSTAB)
 DEFORM_LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, JACOBI)
 DEFORM_LINEAR_SOLVER_PREC= LU_SGS
 %
 % Number of smoothing iterations for mesh deformation

--- a/TestCases/deformation/brick_hex_rans/def_brick_hex_rans.cfg
+++ b/TestCases/deformation/brick_hex_rans/def_brick_hex_rans.cfg
@@ -147,7 +147,7 @@ DV_VALUE= 3.0
 % Linear solver or smoother for implicit formulations (FGMRES, RESTARTED_FGMRES, BCGSTAB)
 DEFORM_LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, JACOBI)
 DEFORM_LINEAR_SOLVER_PREC= LU_SGS
 %
 % Number of smoothing iterations for mesh deformation

--- a/TestCases/deformation/brick_prism/def_brick_prism.cfg
+++ b/TestCases/deformation/brick_prism/def_brick_prism.cfg
@@ -147,7 +147,7 @@ DV_VALUE= 3.0
 % Linear solver or smoother for implicit formulations (FGMRES, RESTARTED_FGMRES, BCGSTAB)
 DEFORM_LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, JACOBI)
 DEFORM_LINEAR_SOLVER_PREC= LU_SGS
 %
 % Number of smoothing iterations for mesh deformation

--- a/TestCases/deformation/brick_prism_rans/def_brick_prism_rans.cfg
+++ b/TestCases/deformation/brick_prism_rans/def_brick_prism_rans.cfg
@@ -147,7 +147,7 @@ DV_VALUE= 5.0
 % Linear solver or smoother for implicit formulations (FGMRES, RESTARTED_FGMRES, BCGSTAB)
 DEFORM_LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, JACOBI)
 DEFORM_LINEAR_SOLVER_PREC= LU_SGS
 %
 % Number of smoothing iterations for mesh deformation

--- a/TestCases/deformation/brick_pyra/def_brick_pyra.cfg
+++ b/TestCases/deformation/brick_pyra/def_brick_pyra.cfg
@@ -147,7 +147,7 @@ DV_VALUE= 3.0
 % Linear solver or smoother for implicit formulations (FGMRES, RESTARTED_FGMRES, BCGSTAB)
 DEFORM_LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, JACOBI)
 DEFORM_LINEAR_SOLVER_PREC= LU_SGS
 %
 % Number of smoothing iterations for mesh deformation

--- a/TestCases/deformation/brick_tets/def_brick_tets.cfg
+++ b/TestCases/deformation/brick_tets/def_brick_tets.cfg
@@ -147,7 +147,7 @@ DV_VALUE= 5.0
 % Linear solver or smoother for implicit formulations (FGMRES, RESTARTED_FGMRES, BCGSTAB)
 DEFORM_LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, JACOBI)
 DEFORM_LINEAR_SOLVER_PREC= LU_SGS
 %
 % Number of smoothing iterations for mesh deformation

--- a/TestCases/deformation/cylindrical_ffd/def_cylindrical.cfg
+++ b/TestCases/deformation/cylindrical_ffd/def_cylindrical.cfg
@@ -127,11 +127,11 @@ LIMITER_ITER= 999999
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
 % Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, 
-%                                                      SMOOTHER_ILU0, SMOOTHER_LUSGS, 
+%                                                      SMOOTHER_ILU, SMOOTHER_LUSGS, 
 %                                                      SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/deformation/naca0012/def_NACA0012.cfg
+++ b/TestCases/deformation/naca0012/def_NACA0012.cfg
@@ -214,7 +214,7 @@ MOTION_FILENAME= mesh_motion.dat
 % Linear solver or smoother for implicit formulations (FGMRES, RESTARTED_FGMRES, BCGSTAB)
 DEFORM_LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, JACOBI)
 DEFORM_LINEAR_SOLVER_PREC= LU_SGS
 %
 % Number of smoothing iterations for mesh deformation

--- a/TestCases/deformation/naca4412/def_NACA4412.cfg
+++ b/TestCases/deformation/naca4412/def_NACA4412.cfg
@@ -119,11 +119,11 @@ LIMITER_ITER= 99999
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
 % Linear solver or smoother for implicit formulations (BCGSTAB, MULTIGRID, FGMRES, SMOOTHER_JACOBI, 
-%                                                      SMOOTHER_ILU0, SMOOTHER_LUSGS, 
+%                                                      SMOOTHER_ILU, SMOOTHER_LUSGS, 
 %                                                      SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/deformation/spherical_ffd/def_spherical.cfg
+++ b/TestCases/deformation/spherical_ffd/def_spherical.cfg
@@ -127,11 +127,11 @@ LIMITER_ITER= 999999
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
 % Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, 
-%                                                      SMOOTHER_ILU0, SMOOTHER_LUSGS, 
+%                                                      SMOOTHER_ILU, SMOOTHER_LUSGS, 
 %                                                      SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Minimum error of the linear solver for implicit formulations
@@ -196,7 +196,7 @@ DV_VALUE= 0.1
 % Linear solver or smoother for implicit formulations (FGMRES, RESTARTED_FGMRES, BCGSTAB)
 DEFORM_LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, JACOBI)
 DEFORM_LINEAR_SOLVER_PREC= LU_SGS
 %
 % Number of smoothing iterations for FEA mesh deformation

--- a/TestCases/deformation/spherical_ffd/def_spherical_bspline.cfg
+++ b/TestCases/deformation/spherical_ffd/def_spherical_bspline.cfg
@@ -127,11 +127,11 @@ LIMITER_ITER= 999999
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
 % Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, 
-%                                                      SMOOTHER_ILU0, SMOOTHER_LUSGS, 
+%                                                      SMOOTHER_ILU, SMOOTHER_LUSGS, 
 %                                                      SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Minimum error of the linear solver for implicit formulations
@@ -196,7 +196,7 @@ DV_VALUE= 0.1
 % Linear solver or smoother for implicit formulations (FGMRES, RESTARTED_FGMRES, BCGSTAB)
 DEFORM_LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, JACOBI)
 DEFORM_LINEAR_SOLVER_PREC= LU_SGS
 %
 % Number of smoothing iterations for FEA mesh deformation

--- a/TestCases/disc_adj_rans/naca0012/turb_NACA0012_sa.cfg
+++ b/TestCases/disc_adj_rans/naca0012/turb_NACA0012_sa.cfg
@@ -119,11 +119,11 @@ LIMITER_ITER= 99999
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
 % Linear solver or smoother for implicit formulations (BCGSTAB, MULTIGRID, FGMRES, SMOOTHER_JACOBI, 
-%                                                      SMOOTHER_ILU0, SMOOTHER_LUSGS, 
+%                                                      SMOOTHER_ILU, SMOOTHER_LUSGS, 
 %                                                      SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/disc_adj_rans/naca0012/turb_NACA0012_sst.cfg
+++ b/TestCases/disc_adj_rans/naca0012/turb_NACA0012_sst.cfg
@@ -119,11 +119,11 @@ LIMITER_ITER= 99999
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
 % Linear solver or smoother for implicit formulations (BCGSTAB, MULTIGRID, FGMRES, SMOOTHER_JACOBI, 
-%                                                      SMOOTHER_ILU0, SMOOTHER_LUSGS, 
+%                                                      SMOOTHER_ILU, SMOOTHER_LUSGS, 
 %                                                      SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/disc_adj_turbomachinery/transonic_stator_2D/transonic_stator.cfg
+++ b/TestCases/disc_adj_turbomachinery/transonic_stator_2D/transonic_stator.cfg
@@ -209,10 +209,10 @@ CFL_ADAPT_PARAM= ( 1.3, 1.2, 1.0, 10.0)
 %
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
-% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU0, SMOOTHER_LUSGS, SMOOTHER_LINELET)
+% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU, SMOOTHER_LUSGS, SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Min error of the linear solver for the implicit formulation

--- a/TestCases/euler/oneram6/inv_ONERAM6.cfg
+++ b/TestCases/euler/oneram6/inv_ONERAM6.cfg
@@ -115,7 +115,7 @@ EXT_ITER= 99999
 % Linear solver for the implicit formulation (BCGSTAB, FGMRES)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Min error of the linear solver for the implicit formulation

--- a/TestCases/gust/inv_gust_NACA0012.cfg
+++ b/TestCases/gust/inv_gust_NACA0012.cfg
@@ -165,11 +165,11 @@ SENS_REMOVE_SHARP= NO
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
 % Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, 
-%                                                      SMOOTHER_ILU0, SMOOTHER_LUSGS, 
+%                                                      SMOOTHER_ILU, SMOOTHER_LUSGS, 
 %                                                      SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/incomp_rans/AhmedBody/AhmedBody.cfg
+++ b/TestCases/incomp_rans/AhmedBody/AhmedBody.cfg
@@ -175,7 +175,7 @@ SENS_REMOVE_SHARP= NO
 % Linear solver for implicit formulations (BCGSTAB, FGMRES)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/parallel_regression.py
+++ b/TestCases/parallel_regression.py
@@ -861,7 +861,7 @@ def main():
     rae2822_def.cfg_dir   = "deformation/rae2822"
     rae2822_def.cfg_file  = "def_RAE2822.cfg"
     rae2822_def.test_iter = 10
-    rae2822_def.test_vals = [6.634760e-09] #residual
+    rae2822_def.test_vals = [9.147140e-09] #residual
     rae2822_def.su2_exec  = "mpirun -n 2 SU2_DEF"
     rae2822_def.timeout   = 1600
     rae2822_def.tol       = 1e-13
@@ -965,7 +965,7 @@ def main():
     cylinder_ffd_def.cfg_dir   = "deformation/cylindrical_ffd"
     cylinder_ffd_def.cfg_file  = "def_cylindrical.cfg"
     cylinder_ffd_def.test_iter = 10
-    cylinder_ffd_def.test_vals = [2.453630e-04] #residual
+    cylinder_ffd_def.test_vals = [7.969090e-04] #residual
     cylinder_ffd_def.su2_exec  = "mpirun -n 2 SU2_DEF"
     cylinder_ffd_def.timeout   = 1600
     cylinder_ffd_def.tol       = 1e-9

--- a/TestCases/parallel_regression.py
+++ b/TestCases/parallel_regression.py
@@ -861,7 +861,7 @@ def main():
     rae2822_def.cfg_dir   = "deformation/rae2822"
     rae2822_def.cfg_file  = "def_RAE2822.cfg"
     rae2822_def.test_iter = 10
-    rae2822_def.test_vals = [9.147140e-09] #residual
+    rae2822_def.test_vals = [6.634760e-09] #residual
     rae2822_def.su2_exec  = "mpirun -n 2 SU2_DEF"
     rae2822_def.timeout   = 1600
     rae2822_def.tol       = 1e-13
@@ -965,7 +965,7 @@ def main():
     cylinder_ffd_def.cfg_dir   = "deformation/cylindrical_ffd"
     cylinder_ffd_def.cfg_file  = "def_cylindrical.cfg"
     cylinder_ffd_def.test_iter = 10
-    cylinder_ffd_def.test_vals = [7.969090e-04] #residual
+    cylinder_ffd_def.test_vals = [2.453630e-04] #residual
     cylinder_ffd_def.su2_exec  = "mpirun -n 2 SU2_DEF"
     cylinder_ffd_def.timeout   = 1600
     cylinder_ffd_def.tol       = 1e-9

--- a/TestCases/parallel_regression_AD.py
+++ b/TestCases/parallel_regression_AD.py
@@ -65,7 +65,7 @@ def main():
     discadj_rans_naca0012_sa.cfg_dir   = "disc_adj_rans/naca0012"
     discadj_rans_naca0012_sa.cfg_file  = "turb_NACA0012_sa.cfg"
     discadj_rans_naca0012_sa.test_iter = 10
-    discadj_rans_naca0012_sa.test_vals = [-1.751959, 0.485790, 0.182890, -0.000018] #last 4 columns
+    discadj_rans_naca0012_sa.test_vals = [-1.751963, 0.485791, 0.182663, -0.000018] #last 4 columns
     discadj_rans_naca0012_sa.su2_exec  = "parallel_computation.py -f"
     discadj_rans_naca0012_sa.timeout   = 1600
     discadj_rans_naca0012_sa.tol       = 0.00001
@@ -76,7 +76,7 @@ def main():
     discadj_rans_naca0012_sst.cfg_dir   = "disc_adj_rans/naca0012"
     discadj_rans_naca0012_sst.cfg_file  = "turb_NACA0012_sst.cfg"
     discadj_rans_naca0012_sst.test_iter = 10
-    discadj_rans_naca0012_sst.test_vals = [-1.654193, -0.499281, 0.145545, -0.000018] #last 4 columns
+    discadj_rans_naca0012_sst.test_vals = [-1.654333, -0.497651, 0.171457, -0.000018] #last 4 columns
     discadj_rans_naca0012_sst.su2_exec  = "parallel_computation.py -f"
     discadj_rans_naca0012_sst.timeout   = 1600
     discadj_rans_naca0012_sst.tol       = 0.00001
@@ -121,7 +121,7 @@ def main():
     discadj_incomp_turb_NACA0012.cfg_dir   = "incomp_rans/naca0012"
     discadj_incomp_turb_NACA0012.cfg_file  = "naca0012_disc.cfg"
     discadj_incomp_turb_NACA0012.test_iter = 100
-    discadj_incomp_turb_NACA0012.test_vals = [-3.627937, -1.624867, 0.000000, 0.000000] #last 4 columns
+    discadj_incomp_turb_NACA0012.test_vals = [-3.627675, -1.624844, 0.000000, 0.000000] #last 4 columns
     discadj_incomp_turb_NACA0012.su2_exec  = "parallel_computation.py -f"
     discadj_incomp_turb_NACA0012.timeout   = 1600
     discadj_incomp_turb_NACA0012.tol       = 0.00001
@@ -152,7 +152,7 @@ def main():
     discadj_trans_stator.cfg_dir   = "disc_adj_turbomachinery/transonic_stator_2D"
     discadj_trans_stator.cfg_file  = "transonic_stator.cfg" 
     discadj_trans_stator.test_iter = 79
-    discadj_trans_stator.test_vals = [-2.001081, -2.115321, -0.450988, -15.778151] #last 4 columns
+    discadj_trans_stator.test_vals = [-2.004304, -2.115821, -0.446650, -15.915734] #last 4 columns
     discadj_trans_stator.su2_exec  = "parallel_computation.py -f"
     discadj_trans_stator.timeout   = 1600
     discadj_trans_stator.tol       = 0.00001

--- a/TestCases/parallel_regression_AD.py
+++ b/TestCases/parallel_regression_AD.py
@@ -65,7 +65,7 @@ def main():
     discadj_rans_naca0012_sa.cfg_dir   = "disc_adj_rans/naca0012"
     discadj_rans_naca0012_sa.cfg_file  = "turb_NACA0012_sa.cfg"
     discadj_rans_naca0012_sa.test_iter = 10
-    discadj_rans_naca0012_sa.test_vals = [-1.751963, 0.485791, 0.182663, -0.000018] #last 4 columns
+    discadj_rans_naca0012_sa.test_vals = [-1.751965, 0.485796, 0.182895, -0.000018] #last 4 columns
     discadj_rans_naca0012_sa.su2_exec  = "parallel_computation.py -f"
     discadj_rans_naca0012_sa.timeout   = 1600
     discadj_rans_naca0012_sa.tol       = 0.00001
@@ -76,7 +76,7 @@ def main():
     discadj_rans_naca0012_sst.cfg_dir   = "disc_adj_rans/naca0012"
     discadj_rans_naca0012_sst.cfg_file  = "turb_NACA0012_sst.cfg"
     discadj_rans_naca0012_sst.test_iter = 10
-    discadj_rans_naca0012_sst.test_vals = [-1.654333, -0.497651, 0.171457, -0.000018] #last 4 columns
+    discadj_rans_naca0012_sst.test_vals = [-1.654193, -0.499281, 0.145545, -0.000018] #last 4 columns
     discadj_rans_naca0012_sst.su2_exec  = "parallel_computation.py -f"
     discadj_rans_naca0012_sst.timeout   = 1600
     discadj_rans_naca0012_sst.tol       = 0.00001
@@ -121,7 +121,7 @@ def main():
     discadj_incomp_turb_NACA0012.cfg_dir   = "incomp_rans/naca0012"
     discadj_incomp_turb_NACA0012.cfg_file  = "naca0012_disc.cfg"
     discadj_incomp_turb_NACA0012.test_iter = 100
-    discadj_incomp_turb_NACA0012.test_vals = [-3.627675, -1.624844, 0.000000, 0.000000] #last 4 columns
+    discadj_incomp_turb_NACA0012.test_vals = [-3.627937, -1.624867, 0.000000, 0.000000] #last 4 columns
     discadj_incomp_turb_NACA0012.su2_exec  = "parallel_computation.py -f"
     discadj_incomp_turb_NACA0012.timeout   = 1600
     discadj_incomp_turb_NACA0012.tol       = 0.00001
@@ -152,7 +152,7 @@ def main():
     discadj_trans_stator.cfg_dir   = "disc_adj_turbomachinery/transonic_stator_2D"
     discadj_trans_stator.cfg_file  = "transonic_stator.cfg" 
     discadj_trans_stator.test_iter = 79
-    discadj_trans_stator.test_vals = [-2.004304, -2.115821, -0.446650, -15.915734] #last 4 columns
+    discadj_trans_stator.test_vals = [-2.001081, -2.115321, -0.450988, -15.778151] #last 4 columns
     discadj_trans_stator.su2_exec  = "parallel_computation.py -f"
     discadj_trans_stator.timeout   = 1600
     discadj_trans_stator.tol       = 0.00001

--- a/TestCases/rans/naca0012/turb_NACA0012_sa.cfg
+++ b/TestCases/rans/naca0012/turb_NACA0012_sa.cfg
@@ -118,11 +118,11 @@ LIMITER_ITER= 99999
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
 % Linear solver or smoother for implicit formulations (BCGSTAB, MULTIGRID, FGMRES, SMOOTHER_JACOBI, 
-%                                                      SMOOTHER_ILU0, SMOOTHER_LUSGS, 
+%                                                      SMOOTHER_ILU, SMOOTHER_LUSGS, 
 %                                                      SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/rans/naca0012/turb_NACA0012_sa_binary.cfg
+++ b/TestCases/rans/naca0012/turb_NACA0012_sa_binary.cfg
@@ -124,11 +124,11 @@ LIMITER_ITER= 99999
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
 % Linear solver or smoother for implicit formulations (BCGSTAB, MULTIGRID, FGMRES, SMOOTHER_JACOBI, 
-%                                                      SMOOTHER_ILU0, SMOOTHER_LUSGS, 
+%                                                      SMOOTHER_ILU, SMOOTHER_LUSGS, 
 %                                                      SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/rans/naca0012/turb_NACA0012_sa_neg.cfg
+++ b/TestCases/rans/naca0012/turb_NACA0012_sa_neg.cfg
@@ -112,11 +112,11 @@ LIMITER_ITER= 99999
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
 % Linear solver or smoother for implicit formulations (BCGSTAB, MULTIGRID, FGMRES, SMOOTHER_JACOBI, 
-%                                                      SMOOTHER_ILU0, SMOOTHER_LUSGS, 
+%                                                      SMOOTHER_ILU, SMOOTHER_LUSGS, 
 %                                                      SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/rans/naca0012/turb_NACA0012_sst.cfg
+++ b/TestCases/rans/naca0012/turb_NACA0012_sst.cfg
@@ -118,11 +118,11 @@ LIMITER_ITER= 99999
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
 % Linear solver or smoother for implicit formulations (BCGSTAB, MULTIGRID, FGMRES, SMOOTHER_JACOBI, 
-%                                                      SMOOTHER_ILU0, SMOOTHER_LUSGS, 
+%                                                      SMOOTHER_ILU, SMOOTHER_LUSGS, 
 %                                                      SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/rans/naca0012/turb_NACA0012_sst_multigrid_restart.cfg
+++ b/TestCases/rans/naca0012/turb_NACA0012_sst_multigrid_restart.cfg
@@ -248,11 +248,11 @@ SENS_REMOVE_SHARP= NO
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
 % Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, 
-%                                                      SMOOTHER_ILU0, SMOOTHER_LUSGS, 
+%                                                      SMOOTHER_ILU, SMOOTHER_LUSGS, 
 %                                                      SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/rans/propeller/propeller.cfg
+++ b/TestCases/rans/propeller/propeller.cfg
@@ -152,11 +152,11 @@ OBJECTIVE_FUNCTION= DRAG
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
 % Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, 
-%                                                      SMOOTHER_ILU0, SMOOTHER_LUSGS, 
+%                                                      SMOOTHER_ILU, SMOOTHER_LUSGS, 
 %                                                      SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/rans/rae2822/turb_SST_RAE2822.cfg
+++ b/TestCases/rans/rae2822/turb_SST_RAE2822.cfg
@@ -99,7 +99,7 @@ EXT_ITER= 99999
 % Linear solver for the implicit formulation (BCGSTAB, FGMRES)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Min error of the linear solver for the implicit formulation

--- a/TestCases/serial_regression.py
+++ b/TestCases/serial_regression.py
@@ -829,7 +829,7 @@ def main():
     rae2822_def.cfg_dir   = "deformation/rae2822"
     rae2822_def.cfg_file  = "def_RAE2822.cfg"
     rae2822_def.test_iter = 10
-    rae2822_def.test_vals = [8.348610e-09] #residual
+    rae2822_def.test_vals = [6.018010e-09] #residual
     rae2822_def.su2_exec  = "SU2_DEF"
     rae2822_def.timeout   = 1600
     rae2822_def.tol       = 1e-13

--- a/TestCases/serial_regression.py
+++ b/TestCases/serial_regression.py
@@ -933,7 +933,7 @@ def main():
     cylinder_ffd_def.cfg_dir   = "deformation/cylindrical_ffd"
     cylinder_ffd_def.cfg_file  = "def_cylindrical.cfg"
     cylinder_ffd_def.test_iter = 10
-    cylinder_ffd_def.test_vals = [4.030020e-04] #residual
+    cylinder_ffd_def.test_vals = [1.454210e-05] #residual
     cylinder_ffd_def.su2_exec  = "SU2_DEF"
     cylinder_ffd_def.timeout   = 1600
     cylinder_ffd_def.tol       = 1e-09

--- a/TestCases/serial_regression.py
+++ b/TestCases/serial_regression.py
@@ -829,7 +829,7 @@ def main():
     rae2822_def.cfg_dir   = "deformation/rae2822"
     rae2822_def.cfg_file  = "def_RAE2822.cfg"
     rae2822_def.test_iter = 10
-    rae2822_def.test_vals = [6.018010e-09] #residual
+    rae2822_def.test_vals = [8.348610e-09] #residual
     rae2822_def.su2_exec  = "SU2_DEF"
     rae2822_def.timeout   = 1600
     rae2822_def.tol       = 1e-13
@@ -933,7 +933,7 @@ def main():
     cylinder_ffd_def.cfg_dir   = "deformation/cylindrical_ffd"
     cylinder_ffd_def.cfg_file  = "def_cylindrical.cfg"
     cylinder_ffd_def.test_iter = 10
-    cylinder_ffd_def.test_vals = [1.454210e-05] #residual
+    cylinder_ffd_def.test_vals = [4.030020e-04] #residual
     cylinder_ffd_def.su2_exec  = "SU2_DEF"
     cylinder_ffd_def.timeout   = 1600
     cylinder_ffd_def.tol       = 1e-09

--- a/TestCases/serial_regression_AD.py
+++ b/TestCases/serial_regression_AD.py
@@ -65,7 +65,7 @@ def main():
     discadj_rans_naca0012_sa.cfg_dir   = "disc_adj_rans/naca0012"
     discadj_rans_naca0012_sa.cfg_file  = "turb_NACA0012_sa.cfg"
     discadj_rans_naca0012_sa.test_iter = 10
-    discadj_rans_naca0012_sa.test_vals = [-1.751962, 0.485775, 0.182122, -0.000018] #last 4 columns
+    discadj_rans_naca0012_sa.test_vals = [-1.751962, 0.485783, 0.182582, -0.000018] #last 4 columns
     discadj_rans_naca0012_sa.su2_exec  = "SU2_CFD_AD"
     discadj_rans_naca0012_sa.timeout   = 1600
     discadj_rans_naca0012_sa.tol       = 0.00001
@@ -76,7 +76,7 @@ def main():
     discadj_rans_naca0012_sst.cfg_dir   = "disc_adj_rans/naca0012"
     discadj_rans_naca0012_sst.cfg_file  = "turb_NACA0012_sst.cfg"
     discadj_rans_naca0012_sst.test_iter = 10
-    discadj_rans_naca0012_sst.test_vals = [-1.654903, -0.491416, 0.109157, 0.000011] #last 4 columns
+    discadj_rans_naca0012_sst.test_vals = [-1.654514, -0.494134, 0.157260, -0.000010] #last 4 columns
     discadj_rans_naca0012_sst.su2_exec  = "SU2_CFD_AD"
     discadj_rans_naca0012_sst.timeout   = 1600
     discadj_rans_naca0012_sst.tol       = 0.00001
@@ -121,7 +121,7 @@ def main():
     discadj_incomp_turb_NACA0012.cfg_dir   = "incomp_rans/naca0012"
     discadj_incomp_turb_NACA0012.cfg_file  = "naca0012_disc.cfg"
     discadj_incomp_turb_NACA0012.test_iter = 100
-    discadj_incomp_turb_NACA0012.test_vals = [-3.627673, -1.624120, 0.000000, 0.000000] #last 4 columns
+    discadj_incomp_turb_NACA0012.test_vals = [-3.627667, -1.624327, 0.000000, 0.000000] #last 4 columns
     discadj_incomp_turb_NACA0012.su2_exec  = "SU2_CFD_AD"
     discadj_incomp_turb_NACA0012.timeout   = 1600
     discadj_incomp_turb_NACA0012.tol       = 0.00001

--- a/TestCases/serial_regression_AD.py
+++ b/TestCases/serial_regression_AD.py
@@ -154,16 +154,16 @@ def main():
     ######################################
     
     # test discrete_adjoint.py
-    discadj_euler_py = TestCase('discadj_euler_py')
-    discadj_euler_py.cfg_dir = "cont_adj_euler/naca0012"
-    discadj_euler_py.cfg_file  = "inv_NACA0012.cfg"
-    discadj_euler_py.test_iter = 10
-    discadj_euler_py.su2_exec  = "discrete_adjoint.py"
-    discadj_euler_py.timeout   = 1600
-    discadj_euler_py.reference_file = "of_grad_cd_disc.dat.ref"
-    discadj_euler_py.test_file = "of_grad_cd.dat"
-    pass_list.append(discadj_euler_py.run_filediff())
-    test_list.append(discadj_euler_py)
+#    discadj_euler_py = TestCase('discadj_euler_py')
+#    discadj_euler_py.cfg_dir = "cont_adj_euler/naca0012"
+#    discadj_euler_py.cfg_file  = "inv_NACA0012.cfg"
+#    discadj_euler_py.test_iter = 10
+#    discadj_euler_py.su2_exec  = "discrete_adjoint.py"
+#    discadj_euler_py.timeout   = 1600
+#    discadj_euler_py.reference_file = "of_grad_cd_disc.dat.ref"
+#    discadj_euler_py.test_file = "of_grad_cd.dat"
+#    pass_list.append(discadj_euler_py.run_filediff())
+#    test_list.append(discadj_euler_py)
     
     # test direct_differentiation.py
     directdiff_euler_py = TestCase('directdiff_euler_py')

--- a/TestCases/serial_regression_AD.py
+++ b/TestCases/serial_regression_AD.py
@@ -154,16 +154,16 @@ def main():
     ######################################
     
     # test discrete_adjoint.py
-#    discadj_euler_py = TestCase('discadj_euler_py')
-#    discadj_euler_py.cfg_dir = "cont_adj_euler/naca0012"
-#    discadj_euler_py.cfg_file  = "inv_NACA0012.cfg"
-#    discadj_euler_py.test_iter = 10
-#    discadj_euler_py.su2_exec  = "discrete_adjoint.py"
-#    discadj_euler_py.timeout   = 1600
-#    discadj_euler_py.reference_file = "of_grad_cd_disc.dat.ref"
-#    discadj_euler_py.test_file = "of_grad_cd.dat"
-#    pass_list.append(discadj_euler_py.run_filediff())
-#    test_list.append(discadj_euler_py)
+    discadj_euler_py = TestCase('discadj_euler_py')
+    discadj_euler_py.cfg_dir = "cont_adj_euler/naca0012"
+    discadj_euler_py.cfg_file  = "inv_NACA0012.cfg"
+    discadj_euler_py.test_iter = 10
+    discadj_euler_py.su2_exec  = "discrete_adjoint.py"
+    discadj_euler_py.timeout   = 1600
+    discadj_euler_py.reference_file = "of_grad_cd_disc.dat.ref"
+    discadj_euler_py.test_file = "of_grad_cd.dat"
+    pass_list.append(discadj_euler_py.run_filediff())
+    test_list.append(discadj_euler_py)
     
     # test direct_differentiation.py
     directdiff_euler_py = TestCase('directdiff_euler_py')

--- a/TestCases/serial_regression_AD.py
+++ b/TestCases/serial_regression_AD.py
@@ -65,7 +65,7 @@ def main():
     discadj_rans_naca0012_sa.cfg_dir   = "disc_adj_rans/naca0012"
     discadj_rans_naca0012_sa.cfg_file  = "turb_NACA0012_sa.cfg"
     discadj_rans_naca0012_sa.test_iter = 10
-    discadj_rans_naca0012_sa.test_vals = [-1.751962, 0.485783, 0.182582, -0.000018] #last 4 columns
+    discadj_rans_naca0012_sa.test_vals = [-1.751962, 0.485775, 0.182122, -0.000018] #last 4 columns
     discadj_rans_naca0012_sa.su2_exec  = "SU2_CFD_AD"
     discadj_rans_naca0012_sa.timeout   = 1600
     discadj_rans_naca0012_sa.tol       = 0.00001
@@ -76,7 +76,7 @@ def main():
     discadj_rans_naca0012_sst.cfg_dir   = "disc_adj_rans/naca0012"
     discadj_rans_naca0012_sst.cfg_file  = "turb_NACA0012_sst.cfg"
     discadj_rans_naca0012_sst.test_iter = 10
-    discadj_rans_naca0012_sst.test_vals = [-1.654514, -0.494134, 0.157260, -0.000010] #last 4 columns
+    discadj_rans_naca0012_sst.test_vals = [-1.654903, -0.491416, 0.109157, 0.000011] #last 4 columns
     discadj_rans_naca0012_sst.su2_exec  = "SU2_CFD_AD"
     discadj_rans_naca0012_sst.timeout   = 1600
     discadj_rans_naca0012_sst.tol       = 0.00001
@@ -121,7 +121,7 @@ def main():
     discadj_incomp_turb_NACA0012.cfg_dir   = "incomp_rans/naca0012"
     discadj_incomp_turb_NACA0012.cfg_file  = "naca0012_disc.cfg"
     discadj_incomp_turb_NACA0012.test_iter = 100
-    discadj_incomp_turb_NACA0012.test_vals = [-3.627667, -1.624327, 0.000000, 0.000000] #last 4 columns
+    discadj_incomp_turb_NACA0012.test_vals = [-3.627673, -1.624120, 0.000000, 0.000000] #last 4 columns
     discadj_incomp_turb_NACA0012.su2_exec  = "SU2_CFD_AD"
     discadj_incomp_turb_NACA0012.timeout   = 1600
     discadj_incomp_turb_NACA0012.tol       = 0.00001

--- a/TestCases/sliding_interface/bars_SST_2D/bars.cfg
+++ b/TestCases/sliding_interface/bars_SST_2D/bars.cfg
@@ -183,7 +183,7 @@ EXT_ITER= 99999
 % Linear solver for the implicit formulation (BCGSTAB, FGMRES)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Min error of the linear solver for the implicit formulation

--- a/TestCases/sliding_interface/channel_2D/channel_2D_NN.cfg
+++ b/TestCases/sliding_interface/channel_2D/channel_2D_NN.cfg
@@ -122,10 +122,10 @@ CFL_ADAPT_PARAM= ( 0.3, 0.5, 1.0, 1000.0)
 %
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
-% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU0, SMOOTHER_LUSGS, SMOOTHER_LINELET)
+% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU, SMOOTHER_LUSGS, SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Min error of the linear solver for the implicit formulation

--- a/TestCases/sliding_interface/channel_2D/channel_2D_WA.cfg
+++ b/TestCases/sliding_interface/channel_2D/channel_2D_WA.cfg
@@ -123,10 +123,10 @@ CFL_ADAPT_PARAM= ( 0.3, 0.5, 1.0, 1000.0)
 %
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
-% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU0, SMOOTHER_LUSGS, SMOOTHER_LINELET)
+% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU, SMOOTHER_LUSGS, SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Min error of the linear solver for the implicit formulation

--- a/TestCases/sliding_interface/channel_3D/channel_3D_NN.cfg
+++ b/TestCases/sliding_interface/channel_3D/channel_3D_NN.cfg
@@ -124,10 +124,10 @@ CFL_ADAPT_PARAM= ( 0.3, 0.5, 1.0, 1000.0)
 %
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
-% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU0, SMOOTHER_LUSGS, SMOOTHER_LINELET)
+% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU, SMOOTHER_LUSGS, SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Min error of the linear solver for the implicit formulation

--- a/TestCases/sliding_interface/channel_3D/channel_3D_WA.cfg
+++ b/TestCases/sliding_interface/channel_3D/channel_3D_WA.cfg
@@ -125,10 +125,10 @@ CFL_ADAPT_PARAM= ( 0.3, 0.5, 1.0, 1000.0)
 %
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
-% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU0, SMOOTHER_LUSGS, SMOOTHER_LINELET)
+% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU, SMOOTHER_LUSGS, SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Min error of the linear solver for the implicit formulation

--- a/TestCases/sliding_interface/pipe/pipe_NN.cfg
+++ b/TestCases/sliding_interface/pipe/pipe_NN.cfg
@@ -127,10 +127,10 @@ CFL_ADAPT_PARAM= ( 0.3, 0.5, 1.0, 1000.0)
 %
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
-% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU0, SMOOTHER_LUSGS, SMOOTHER_LINELET)
+% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU, SMOOTHER_LUSGS, SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Min error of the linear solver for the implicit formulation

--- a/TestCases/sliding_interface/pipe/pipe_WA.cfg
+++ b/TestCases/sliding_interface/pipe/pipe_WA.cfg
@@ -128,10 +128,10 @@ CFL_ADAPT_PARAM= ( 0.3, 0.5, 1.0, 1000.0)
 %
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
-% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU0, SMOOTHER_LUSGS, SMOOTHER_LINELET)
+% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU, SMOOTHER_LUSGS, SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Min error of the linear solver for the implicit formulation

--- a/TestCases/sliding_interface/rotating_cylinders/rot_cylinders_NN.cfg
+++ b/TestCases/sliding_interface/rotating_cylinders/rot_cylinders_NN.cfg
@@ -128,10 +128,10 @@ CFL_ADAPT_PARAM= ( 0.3, 0.5, 1.0, 1000.0)
 %
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
-% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU0, SMOOTHER_LUSGS, SMOOTHER_LINELET)
+% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU, SMOOTHER_LUSGS, SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Min error of the linear solver for the implicit formulation

--- a/TestCases/sliding_interface/rotating_cylinders/rot_cylinders_WA.cfg
+++ b/TestCases/sliding_interface/rotating_cylinders/rot_cylinders_WA.cfg
@@ -129,10 +129,10 @@ CFL_ADAPT_PARAM= ( 0.3, 0.5, 1.0, 1000.0)
 %
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
-% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU0, SMOOTHER_LUSGS, SMOOTHER_LINELET)
+% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU, SMOOTHER_LUSGS, SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Min error of the linear solver for the implicit formulation

--- a/TestCases/sliding_interface/single_stage/single_stage_NN.cfg
+++ b/TestCases/sliding_interface/single_stage/single_stage_NN.cfg
@@ -142,10 +142,10 @@ CFL_ADAPT_PARAM= ( 0.3, 0.5, 1.0, 1000.0)
 %
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
-% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU0, SMOOTHER_LUSGS, SMOOTHER_LINELET)
+% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU, SMOOTHER_LUSGS, SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Min error of the linear solver for the implicit formulation

--- a/TestCases/sliding_interface/single_stage/single_stage_WA.cfg
+++ b/TestCases/sliding_interface/single_stage/single_stage_WA.cfg
@@ -142,10 +142,10 @@ CFL_ADAPT_PARAM= ( 0.3, 0.5, 1.0, 1000.0)
 %
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
-% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU0, SMOOTHER_LUSGS, SMOOTHER_LINELET)
+% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU, SMOOTHER_LUSGS, SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Min error of the linear solver for the implicit formulation

--- a/TestCases/sliding_interface/supersonic_vortex_shedding/sup_vor_shed_NN.cfg
+++ b/TestCases/sliding_interface/supersonic_vortex_shedding/sup_vor_shed_NN.cfg
@@ -129,10 +129,10 @@ CFL_ADAPT_PARAM= ( 0.3, 0.5, 1.0, 1000.0)
 %
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
-% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU0, SMOOTHER_LUSGS, SMOOTHER_LINELET)
+% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU, SMOOTHER_LUSGS, SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Min error of the linear solver for the implicit formulation

--- a/TestCases/sliding_interface/supersonic_vortex_shedding/sup_vor_shed_WA.cfg
+++ b/TestCases/sliding_interface/supersonic_vortex_shedding/sup_vor_shed_WA.cfg
@@ -130,10 +130,10 @@ CFL_ADAPT_PARAM= ( 0.3, 0.5, 1.0, 1000.0)
 %
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
-% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU0, SMOOTHER_LUSGS, SMOOTHER_LINELET)
+% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU, SMOOTHER_LUSGS, SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Min error of the linear solver for the implicit formulation

--- a/TestCases/sliding_interface/uniform_flow/uniform_NN.cfg
+++ b/TestCases/sliding_interface/uniform_flow/uniform_NN.cfg
@@ -129,10 +129,10 @@ CFL_ADAPT_PARAM= ( 0.3, 0.5, 1.0, 1000.0)
 %
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
-% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU0, SMOOTHER_LUSGS, SMOOTHER_LINELET)
+% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU, SMOOTHER_LUSGS, SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Min error of the linear solver for the implicit formulation

--- a/TestCases/sliding_interface/uniform_flow/uniform_WA.cfg
+++ b/TestCases/sliding_interface/uniform_flow/uniform_WA.cfg
@@ -130,10 +130,10 @@ CFL_ADAPT_PARAM= ( 0.3, 0.5, 1.0, 1000.0)
 %
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
-% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU0, SMOOTHER_LUSGS, SMOOTHER_LINELET)
+% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU, SMOOTHER_LUSGS, SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Min error of the linear solver for the implicit formulation

--- a/TestCases/turbomachinery/APU_turbocharger/Jones.cfg
+++ b/TestCases/turbomachinery/APU_turbocharger/Jones.cfg
@@ -220,10 +220,10 @@ CFL_ADAPT_PARAM= ( 1.3, 1.2, 5.0, 30.0)
 %
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
-% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU0, SMOOTHER_LUSGS, SMOOTHER_LINELET)
+% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU, SMOOTHER_LUSGS, SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Min error of the linear solver for the implicit formulation

--- a/TestCases/turbomachinery/APU_turbocharger/Jones_rst.cfg
+++ b/TestCases/turbomachinery/APU_turbocharger/Jones_rst.cfg
@@ -220,10 +220,10 @@ CFL_ADAPT_PARAM= ( 1.3, 1.2, 5.0, 30.0)
 %
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
-% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU0, SMOOTHER_LUSGS, SMOOTHER_LINELET)
+% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU, SMOOTHER_LUSGS, SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Min error of the linear solver for the implicit formulation

--- a/TestCases/turbomachinery/axial_stage_2D/Axial_stage2D.cfg
+++ b/TestCases/turbomachinery/axial_stage_2D/Axial_stage2D.cfg
@@ -210,10 +210,10 @@ TRANSLATION_RATE_Y= 0.0 -150.0
 
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
-% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU0, SMOOTHER_LUSGS, SMOOTHER_LINELET)
+% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU, SMOOTHER_LUSGS, SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Min error of the linear solver for the implicit formulation

--- a/TestCases/turbomachinery/centrifugal_blade/centrifugal_blade.cfg
+++ b/TestCases/turbomachinery/centrifugal_blade/centrifugal_blade.cfg
@@ -205,10 +205,10 @@ CFL_ADAPT_PARAM= ( 0.3, 0.4, 10.0, 1000.0)
 %
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
-% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU0, SMOOTHER_LUSGS, SMOOTHER_LINELET)
+% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU, SMOOTHER_LUSGS, SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Min error of the linear solver for the implicit formulation

--- a/TestCases/turbomachinery/centrifugal_stage/centrifugal_stage.cfg
+++ b/TestCases/turbomachinery/centrifugal_stage/centrifugal_stage.cfg
@@ -212,10 +212,10 @@ CFL_ADAPT_PARAM= ( 0.3, 0.5, 1.0, 1000.0)
 %
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
-% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU0, SMOOTHER_LUSGS, SMOOTHER_LINELET)
+% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU, SMOOTHER_LUSGS, SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Min error of the linear solver for the implicit formulation

--- a/TestCases/turbomachinery/transonic_stator_2D/transonic_stator.cfg
+++ b/TestCases/turbomachinery/transonic_stator_2D/transonic_stator.cfg
@@ -208,10 +208,10 @@ CFL_ADAPT_PARAM= ( 1.3, 1.2, 1.0, 10.0)
 %
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
-% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU0, SMOOTHER_LUSGS, SMOOTHER_LINELET)
+% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU, SMOOTHER_LUSGS, SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Min error of the linear solver for the implicit formulation

--- a/TestCases/turbomachinery/transonic_stator_2D/transonic_stator_rst.cfg
+++ b/TestCases/turbomachinery/transonic_stator_2D/transonic_stator_rst.cfg
@@ -213,10 +213,10 @@ CFL_ADAPT_PARAM= ( 1.3, 1.2, 1.0, 10.0)
 %
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
-% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU0, SMOOTHER_LUSGS, SMOOTHER_LINELET)
+% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, SMOOTHER_ILU, SMOOTHER_LUSGS, SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
 % Min error of the linear solver for the implicit formulation

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -664,8 +664,8 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (1 by default)
-LINEAR_SOLVER_ILU_FILL_IN= 1
+% Linael solver ILU preconditioner fill-in level (0 by default)
+LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations
 LINEAR_SOLVER_ERROR= 1E-6

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -657,12 +657,15 @@ SENS_REMOVE_SHARP= NO
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
 % Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI, 
-%                                                      SMOOTHER_ILU0, SMOOTHER_LUSGS, 
+%                                                      SMOOTHER_ILU, SMOOTHER_LUSGS, 
 %                                                      SMOOTHER_LINELET)
 LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, LINELET, JACOBI)
-LINEAR_SOLVER_PREC= ILU0
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
+LINEAR_SOLVER_PREC= ILU
+%
+% Linael solver ILU preconditioner fill-in level (1 by default)
+LINEAR_SOLVER_ILU_FILL_IN= 1
 %
 % Minimum error of the linear solver for implicit formulations
 LINEAR_SOLVER_ERROR= 1E-6
@@ -879,8 +882,8 @@ DV_VALUE= 0.01
 % Linear solver or smoother for implicit formulations (FGMRES, RESTARTED_FGMRES, BCGSTAB)
 DEFORM_LINEAR_SOLVER= FGMRES
 %
-% Preconditioner of the Krylov linear solver (ILU0, LU_SGS, JACOBI)
-DEFORM_LINEAR_SOLVER_PREC= ILU0
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, JACOBI)
+DEFORM_LINEAR_SOLVER_PREC= ILU
 %
 % Number of smoothing iterations for mesh deformation
 DEFORM_LINEAR_ITER= 1000


### PR DESCRIPTION
ILU preconditioner implementation with an arbitrary fill-in level (n).

In my opinion ILU(1) is a good compromise between time and accuracy. As I pointed out in my previous pull request a fully working ILU preconditioner changes the way SU2 can be (should be) used... now CFL>>10 is a standard in almost any run with a decent grid.

The fill-in level is controlled with LINEAR_SOLVER_ILU_FILL_IN and, instead of the ILU0 option, we are using just ILU. 