### PR TITLE
Modifications to enable compilation under Windows with MINGW

### DIFF
--- a/Common/src/geometry_structure.cpp
+++ b/Common/src/geometry_structure.cpp
@@ -11026,7 +11026,11 @@ void CPhysicalGeometry::SetTurboVertex(CConfig *config, unsigned short val_iZone
       mode_t nMode = 0733; // UNIX style permissions
       int nError = 0;
 #if defined(_WIN32)
+#ifdef __MINGW32__
+      nError = mkdir(sPath.c_str());  // MINGW on Windows
+#else
       nError = _mkdir(sPath.c_str()); // can be used on Windows
+#endif
 #else
       nError = mkdir(sPath.c_str(),nMode); // can be used on non-Windows
 #endif

--- a/externals/metis/GKlib/gk_arch.h
+++ b/externals/metis/GKlib/gk_arch.h
@@ -41,7 +41,9 @@
 #endif
   #include <inttypes.h>
   #include <sys/types.h>
+#ifndef __MINGW32__
   #include <sys/resource.h>
+#endif
   #include <sys/time.h>
 #endif
 

--- a/externals/metis/GKlib/gk_getopt.h
+++ b/externals/metis/GKlib/gk_getopt.h
@@ -52,11 +52,11 @@ struct gk_option {
 
 
 /* Function prototypes */
-extern int gk_getopt(int __argc, char **__argv, char *__shortopts);
-extern int gk_getopt_long(int __argc, char **__argv, char *__shortopts,
-              struct gk_option *__longopts, int *__longind);
-extern int gk_getopt_long_only (int __argc, char **__argv,
-              char *__shortopts, struct gk_option *__longopts, int *__longind);
+extern int gk_getopt(int argc, char **argv, char *shortopts);
+extern int gk_getopt_long(int argc, char **argv, char *shortopts,
+              struct gk_option *longopts, int *longind);
+extern int gk_getopt_long_only (int argc, char **argv,
+              char *shortopts, struct gk_option *longopts, int *longind);
 
 
 

--- a/externals/parmetis/include/parmetis.h
+++ b/externals/parmetis/include/parmetis.h
@@ -18,7 +18,9 @@
 #include <metis.h>
 
 #ifndef _MSC_VER
+#ifndef __MINGW32__
 #define __cdecl
+#endif
 #endif
 
 #if IDXTYPEWIDTH == 32


### PR DESCRIPTION
This pull request enables the compilation under Windows using the MINGW compilers. For details how to set up the corresponding build environment, see http://www.math.ucla.edu/~wotaoyin/windows_coding.html. It enables to create a parallel executable under Windows using Microsoft MPI.
