### PR TITLE
Feature polar : addition of dummy parameters to compute_polar.py

### DIFF
--- a/SU2_PY/compute_polar.py
+++ b/SU2_PY/compute_polar.py
@@ -127,6 +127,7 @@ def main():
    # prepare config
    config.NUMBER_PART = options.partitions
    config.EXT_ITER    = options.iterations
+   config.NZONES      = 1
 
    # find solution files if they exist
    state.find_files(config)
@@ -264,6 +265,10 @@ def main():
                                   'PARAM': [[0.0, 0.05]],
                                   'SCALE': [1.0],
                                   'SIZE': [1]}
+         if not 'OPT_OBJECTIVE' in konfig:
+            obj = {}
+            obj['DRAG'] = {'SCALE':1.e-2,'OBJTYPE':'DEFAULT'}
+            konfig.OPT_OBJECTIVE  = obj
          #
          # --------- end of dummy optimization variables definition section -----------------------
          #


### PR DESCRIPTION
Current version of eval function in develop branch causes a crash of compute_polar.py
Addition of two dummy parameters to the script resolves that:
NZONES (integer) and OPT_OBJECTIVES (dictionary) are not used but need to be set for commands like
drag = SU2.eval.func('DRAG',konfig,ztate).
Involved with addition o4 4 lines to compute_polar.py.
Best regards,
Eran