### PR TITLE
Fix set force proj vector

### DIFF
--- a/SU2_CFD/src/solver_adjoint_mean.cpp
+++ b/SU2_CFD/src/solver_adjoint_mean.cpp
@@ -2077,7 +2077,7 @@ void CAdjEulerSolver::SetForceProj_Vector(CGeometry *geometry, CSolver **solver_
    Since there may be more than one objective per marker, first we have to set all Force projection vectors to 0 ---*/
   
   for (iMarker = 0; iMarker<nMarker; iMarker++) {
-    if ((iMarker<nMarker) && (config->GetMarker_All_KindBC(iMarker) != SEND_RECEIVE) &&
+    if ((config->GetMarker_All_KindBC(iMarker) != SEND_RECEIVE) &&
            (config->GetMarker_All_Monitoring(iMarker) == YES))
       for (iVertex = 0; iVertex < geometry->nVertex[iMarker]; iVertex++) {
         for (iDim=0; iDim<nDim; iDim++)

--- a/SU2_CFD/src/solver_adjoint_mean.cpp
+++ b/SU2_CFD/src/solver_adjoint_mean.cpp
@@ -2099,7 +2099,7 @@ void CAdjEulerSolver::SetForceProj_Vector(CGeometry *geometry, CSolver **solver_
     }
 
     
-    if ((config->GetMarker_All_KindBC(iMarker) != SEND_RECEIVE) &&
+    if ((iMarker<nMarker) && (config->GetMarker_All_KindBC(iMarker) != SEND_RECEIVE) &&
         (config->GetMarker_All_Monitoring(iMarker) == YES)) {
       for (iVertex = 0; iVertex < geometry->nVertex[iMarker]; iVertex++) {
         


### PR DESCRIPTION
This pull request fixes a segfault issue in the continuous adjoint solver initialization. Since iMarker is recycled in SetForceProj_Vector, it could be set as nMarker if no matching marker is found for a given Marker_Monitoring, which leads to an out-of-bounds access.

A check on the value of iMarker has been moved from the first for loop (where it is unnecessary), to the second for loop where iMarker is recycled and the segfault occurs.