### PR TITLE
Overhauled node sorting in periodic geometry to be less buggy

### DIFF
--- a/Common/src/geometry_structure.cpp
+++ b/Common/src/geometry_structure.cpp
@@ -18794,30 +18794,55 @@ void CPeriodicGeometry::SetMeshFile(CGeometry *geometry, CConfig *config, string
   /*--- Ghost points, look at the nodes in the send receive ---*/
   iMarkerReceive = nMarker - 1;
   GhostPoints = nElem_Bound[iMarkerReceive];
-  
+
   /*--- Change the numbering to guarantee that the all the receive
-   points are at the end of the file ---*/
-  unsigned long OldnPoint = geometry->GetnPoint();
-  unsigned long *NewSort = new unsigned long[nPoint];
-  for (iPoint = 0; iPoint < nPoint; iPoint++) {
-    NewSort[iPoint] = iPoint;
-  }
-  
-  unsigned long Index = OldnPoint-1;
+   points are at the end of the file. ---*/
+  std::vector<unsigned long> receive_nodes;
+  std::vector<unsigned long> send_nodes;
   for (iMarker = 0; iMarker < nMarker; iMarker++) {
     if (bound[iMarker][0]->GetVTK_Type() == VERTEX) {
       if (config->GetMarker_All_SendRecv(iMarker) < 0) {
         for (iElem_Bound = 0; iElem_Bound < nElem_Bound[iMarker]; iElem_Bound++) {
-          if (bound[iMarker][iElem_Bound]->GetNode(0) < geometry->GetnPoint()) {
-            NewSort[bound[iMarker][iElem_Bound]->GetNode(0)] = Index;
-            NewSort[Index] = bound[iMarker][iElem_Bound]->GetNode(0);
-            Index--;
+          if (bound[iMarker][iElem_Bound]->GetRotation_Type() == 1) {
+            receive_nodes.push_back(bound[iMarker][iElem_Bound]->GetNode(0));
+          } else {
+            send_nodes.push_back(bound[iMarker][iElem_Bound]->GetNode(0));
           }
         }
       }
     }
   }
+
+  /*--- Build the sorted lists of node numbers with receive/send at the end
+   * NewSort[i] = j maps the new number (i) to the old number (j)
+   * ReverseSort[j] = i maps the old number (j) to the new number (i) ---*/
+  std::vector<unsigned long> NewSort;
+  std::vector<unsigned long> ReverseSort;
+  for (iPoint = 0; iPoint < nPoint; iPoint++) {
+    bool isReceive = (find(receive_nodes.begin(), receive_nodes.end(), iPoint)
+                      != receive_nodes.end());
+    bool isSend = (find(send_nodes.begin(), send_nodes.end(), iPoint)
+                   != send_nodes.end());
+    if (!isSend && !isReceive) {
+      NewSort.push_back(iPoint);
+    }
+  }
+  NewSort.insert(NewSort.end(), receive_nodes.begin(), receive_nodes.end());
+  NewSort.insert(NewSort.end(), send_nodes.begin(), send_nodes.end());
   
+  ReverseSort.resize(NewSort.size());
+  for (iPoint = 0; iPoint < nPoint; iPoint++) {
+    unsigned short jPoint;
+    for (jPoint = 0; jPoint < nPoint; jPoint++) {
+      if (NewSort[iPoint] == jPoint) {
+        ReverseSort[jPoint] = iPoint;
+        break;
+      }
+    }
+    if (jPoint == nPoint) { // Loop fell through without break
+      SU2_MPI::Error("Remapping of periodic nodes failed.", CURRENT_FUNCTION);
+    }
+  }
   
   /*--- Write dimension, number of elements and number of points ---*/
   output_file << "NDIME= " << nDim << endl;
@@ -18825,14 +18850,16 @@ void CPeriodicGeometry::SetMeshFile(CGeometry *geometry, CConfig *config, string
   for (iElem = 0; iElem < nElem; iElem++) {
     output_file << elem[iElem]->GetVTK_Type();
     for (iNodes = 0; iNodes < elem[iElem]->GetnNodes(); iNodes++)
-      output_file << "\t" << NewSort[elem[iElem]->GetNode(iNodes)];
+      output_file << "\t" << ReverseSort[elem[iElem]->GetNode(iNodes)];
     output_file << "\t"<<iElem<< endl;
   }
   
   output_file << "NPOIN= " << nPoint << "\t" << nPoint - GhostPoints << endl;
   for (iPoint = 0; iPoint < nPoint; iPoint++) {
-    for (iDim = 0; iDim < nDim; iDim++)
-      output_file << scientific << "\t" << node[NewSort[iPoint]]->GetCoord(iDim) ;
+    for (iDim = 0; iDim < nDim; iDim++) {
+      output_file << scientific;
+      output_file << "\t" << node[NewSort[iPoint]]->GetCoord(iDim) ;
+    }
     output_file << "\t" << iPoint << endl;
   }
   
@@ -18847,9 +18874,9 @@ void CPeriodicGeometry::SetMeshFile(CGeometry *geometry, CConfig *config, string
       for (iElem_Bound = 0; iElem_Bound < nElem_Bound[iMarker]; iElem_Bound++) {
         output_file << bound[iMarker][iElem_Bound]->GetVTK_Type() << "\t" ;
         for (iNodes = 0; iNodes < bound[iMarker][iElem_Bound]->GetnNodes()-1; iNodes++)
-          output_file << NewSort[bound[iMarker][iElem_Bound]->GetNode(iNodes)] << "\t" ;
+          output_file << ReverseSort[bound[iMarker][iElem_Bound]->GetNode(iNodes)] << "\t" ;
         iNodes = bound[iMarker][iElem_Bound]->GetnNodes()-1;
-        output_file << NewSort[bound[iMarker][iElem_Bound]->GetNode(iNodes)] << endl;
+        output_file << ReverseSort[bound[iMarker][iElem_Bound]->GetNode(iNodes)] << endl;
       }
       
       /*--- Write any new elements at the end of the list. ---*/
@@ -18857,9 +18884,9 @@ void CPeriodicGeometry::SetMeshFile(CGeometry *geometry, CConfig *config, string
         for (iElem_Bound = 0; iElem_Bound < nNewElem_BoundPer[iMarker]; iElem_Bound++) {
           output_file << newBoundPer[iMarker][iElem_Bound]->GetVTK_Type() << "\t" ;
           for (iNodes = 0; iNodes < newBoundPer[iMarker][iElem_Bound]->GetnNodes()-1; iNodes++)
-            output_file << NewSort[newBoundPer[iMarker][iElem_Bound]->GetNode(iNodes)] << "\t" ;
+            output_file << ReverseSort[newBoundPer[iMarker][iElem_Bound]->GetNode(iNodes)] << "\t" ;
           iNodes = newBoundPer[iMarker][iElem_Bound]->GetnNodes()-1;
-          output_file << NewSort[newBoundPer[iMarker][iElem_Bound]->GetNode(iNodes)] << endl;
+          output_file << ReverseSort[newBoundPer[iMarker][iElem_Bound]->GetNode(iNodes)] << endl;
         }
       }
       
@@ -18873,7 +18900,7 @@ void CPeriodicGeometry::SetMeshFile(CGeometry *geometry, CConfig *config, string
       
       for (iElem_Bound = 0; iElem_Bound < nElem_Bound[iMarker]; iElem_Bound++) {
         output_file << bound[iMarker][iElem_Bound]->GetVTK_Type() << "\t" <<
-        NewSort[bound[iMarker][iElem_Bound]->GetNode(0)] << "\t" <<
+        ReverseSort[bound[iMarker][iElem_Bound]->GetNode(0)] << "\t" <<
         bound[iMarker][iElem_Bound]->GetRotation_Type()  << endl;
       }
     }
@@ -18911,10 +18938,6 @@ void CPeriodicGeometry::SetMeshFile(CGeometry *geometry, CConfig *config, string
   
   
   output_file.close();
-  
-  /*--- Free memory ---*/
-  delete [] NewSort;
-  
 }
 
 void CPeriodicGeometry::SetTecPlot(char mesh_filename[MAX_STRING_SIZE], bool new_file) {


### PR DESCRIPTION
As described in Issue #431, using `SU2_MSH` for periodic mesh construction can be buggy due to its sorting of nodes.  Under certain conditions, nodes can be duplicated and/or missing from the output *.su2 file.

This pull request implements a more robust sorting process, where the sorting occurs in the following steps:

1. Send/receive nodes are explicitly identified
2. The sorted list is created without any send/receive nodes.
3. The receive and then send nodes are added to the sorted list.

Here's a few comments about the pull request:
+ Since this routine is only run once, I felt the usability of std::vector outweighed the computational efficiency of raw arrays.
+ I had to create two lists, NewSort and ReverseSort, instead of the original one list (NewSort).  That's because two different mappings between node numbers need to occur.  In the old code, where the list was sorted by switching elements, the two mappings _should_ have been identical.  Since the improved method does not use switching, two lists are necessary.
+ There's a lot of memory leaks/uninitialized values when checking this pull request with Valgrind.  I checked them, and this pull request doesn't create any _new_ memory issues.  Apparently both `SU2_CFD` and `SU2_MSH` have memory issues.

#### Verification
Since none of the existing regression tests run `SU2_MSH`, I created a separate case to verify both the bug and the fix.  It's a simple 3x3 cube that's periodic in the z-direction.  I've attached the files below. Here's the steps:

1. Run `SU2_MSH MSH.cfg`
2. Run `SU2_CFD per_CFD_dev.cfg`

Using the existing develop branch, the verification case runs into a segfault when writing the output.  This pull request allows the verification case to complete successfully.

You can also check the original test case from Issue #431 to verify the bug fix. If any of you know of additional verification tests I could run, then please let me know.

Test case: [cube.tar.gz](https://github.com/su2code/SU2/files/1639835/cube.tar.gz)

This fixes #431 