### PR TITLE
Extend custom python BC to include Euler/NS and turbulence variables.

### DIFF
--- a/Common/src/geometry_structure.cpp
+++ b/Common/src/geometry_structure.cpp
@@ -1302,6 +1302,9 @@ void CGeometry::SetCustomBoundary(CConfig *config) {
             CustomBoundaryTemperature[iMarker][iVertex] = config->GetIsothermal_Temperature(Marker_Tag);
           }
           break;
+        case INLET_FLOW:
+          // This case is handled in the solver class.
+          break;
         default:
           cout << "WARNING: Marker " << Marker_Tag << " is not customizable. Using default behavior." << endl;
           break;

--- a/Common/src/geometry_structure.cpp
+++ b/Common/src/geometry_structure.cpp
@@ -1322,11 +1322,20 @@ void CGeometry::UpdateCustomBoundaryConditions(CGeometry **geometry_container, C
   for (iMGlevel=1; iMGlevel <= nMGlevel; iMGlevel++){
     iMGfine = iMGlevel-1;
     for(iMarker = 0; iMarker< config->GetnMarker_All(); iMarker++){
-      if (config->GetMarker_All_PyCustom(iMarker) && config->GetMarker_All_KindBC(iMarker) == HEAT_FLUX){
-        geometry_container[iMGlevel]->SetMultiGridWallHeatFlux(geometry_container[iMGfine], iMarker);
-      }
-      else if (config->GetMarker_All_PyCustom(iMarker) && config->GetMarker_All_KindBC(iMarker) == ISOTHERMAL) {
-        geometry_container[iMGlevel]->SetMultiGridWallTemperature(geometry_container[iMGfine], iMarker);
+      if(config->GetMarker_All_PyCustom(iMarker)){
+        switch(config->GetMarker_All_KindBC(iMarker)){
+          case HEAT_FLUX:
+            geometry_container[iMGlevel]->SetMultiGridWallHeatFlux(geometry_container[iMGfine], iMarker);
+            break;
+          case ISOTHERMAL:
+            geometry_container[iMGlevel]->SetMultiGridWallTemperature(geometry_container[iMGfine], iMarker);
+            break;
+          case INLET_FLOW:
+            if (nMGlevel > 0)
+              SU2_MPI::Error("Multigrid is not currently supported for custom inlet profiles.", CURRENT_FUNCTION);
+            break; // Break not necessary, but prevents false compiler warnings
+          default: break;
+        }
       }
     }
   }

--- a/Common/src/geometry_structure.cpp
+++ b/Common/src/geometry_structure.cpp
@@ -1330,10 +1330,7 @@ void CGeometry::UpdateCustomBoundaryConditions(CGeometry **geometry_container, C
           case ISOTHERMAL:
             geometry_container[iMGlevel]->SetMultiGridWallTemperature(geometry_container[iMGfine], iMarker);
             break;
-          case INLET_FLOW:
-            if (nMGlevel > 0)
-              SU2_MPI::Error("Multigrid is not currently supported for custom inlet profiles.", CURRENT_FUNCTION);
-            break; // Break not necessary, but prevents false compiler warnings
+          // Inlet flow handled in solver class.
           default: break;
         }
       }

--- a/SU2_CFD/include/driver_structure.hpp
+++ b/SU2_CFD/include/driver_structure.hpp
@@ -553,6 +553,15 @@ public:
   void SetVertexFlowDir(unsigned short iMarker, unsigned short iVertex, unsigned short iDim, su2double val_FlowDir);
 
   /*!
+   * \brief Set a turbulence variable on a specified inlet marker.
+   * \param[in] iMarker - Marker identifier.
+   * \param[in] iVertex - Vertex identifier.
+   * \param[in] iDim - Index of the turbulence variable (i.e. k is 0 in SST)
+   * \param[in] val_turb_var - Value of the turbulence variable to be used.
+   */
+  void SetVertexTurbVar(unsigned short iMarker, unsigned short iVertex, unsigned short iDim, su2double val_tub_var);
+
+  /*!
    * \brief Compute the heat flux at a vertex on a specified marker (3 components).
    * \param[in] iMarker - Marker identifier.
    * \param[in] iVertex - Vertex identifier.

--- a/SU2_CFD/include/driver_structure.hpp
+++ b/SU2_CFD/include/driver_structure.hpp
@@ -528,6 +528,31 @@ public:
   void SetVertexTemperature(unsigned short iMarker, unsigned short iVertex, su2double val_WallTemp);
 
   /*!
+   * \brief Set the total temperature of a vertex on a specified inlet marker.
+   * \param[in] iMarker - Marker identifier.
+   * \param[in] iVertex - Vertex identifier.
+   * \param[in] val_Ttotal - Value of the total (stagnation) temperature.
+   */
+  void SetVertexTtotal(unsigned short iMarker, unsigned short iVertex, su2double val_Ttotal);
+
+  /*!
+   * \brief Set the total pressure of a vertex on a specified inlet marker.
+   * \param[in] iMarker - Marker identifier.
+   * \param[in] iVertex - Vertex identifier.
+   * \param[in] val_Ptotal - Value of the total (stagnation) pressure.
+   */
+  void SetVertexPtotal(unsigned short iMarker, unsigned short iVertex, su2double val_Ptotal);
+
+  /*!
+   * \brief Set the flow direction of a vertex on a specified inlet marker.
+   * \param[in] iMarker - Marker identifier.
+   * \param[in] iVertex - Vertex identifier.
+   * \param[in] iDim - Index of the flow direction unit vector
+   * \param[in] val_FlowDir - Component of a unit vector representing the flow direction
+   */
+  void SetVertexFlowDir(unsigned short iMarker, unsigned short iVertex, unsigned short iDim, su2double val_FlowDir);
+
+  /*!
    * \brief Compute the heat flux at a vertex on a specified marker (3 components).
    * \param[in] iMarker - Marker identifier.
    * \param[in] iVertex - Vertex identifier.
@@ -608,6 +633,12 @@ public:
    * \return List of heat transfer boundary markers tags.
    */
   vector<string> GetAllCHTMarkersTag();
+
+  /*!
+   * \brief Get all the (subsonic) inlet boundary markers tags.
+   * \return List of inlet boundary markers tags.
+   */
+  vector<string> GetAllInletMarkersTag();
 
   /*!
    * \brief Get all the boundary markers tags with their associated indices.

--- a/SU2_CFD/include/driver_structure.hpp
+++ b/SU2_CFD/include/driver_structure.hpp
@@ -528,40 +528,6 @@ public:
   void SetVertexTemperature(unsigned short iMarker, unsigned short iVertex, su2double val_WallTemp);
 
   /*!
-   * \brief Set the total temperature of a vertex on a specified inlet marker.
-   * \param[in] iMarker - Marker identifier.
-   * \param[in] iVertex - Vertex identifier.
-   * \param[in] val_Ttotal - Value of the total (stagnation) temperature.
-   */
-  void SetVertexTtotal(unsigned short iMarker, unsigned short iVertex, su2double val_Ttotal);
-
-  /*!
-   * \brief Set the total pressure of a vertex on a specified inlet marker.
-   * \param[in] iMarker - Marker identifier.
-   * \param[in] iVertex - Vertex identifier.
-   * \param[in] val_Ptotal - Value of the total (stagnation) pressure.
-   */
-  void SetVertexPtotal(unsigned short iMarker, unsigned short iVertex, su2double val_Ptotal);
-
-  /*!
-   * \brief Set the flow direction of a vertex on a specified inlet marker.
-   * \param[in] iMarker - Marker identifier.
-   * \param[in] iVertex - Vertex identifier.
-   * \param[in] iDim - Index of the flow direction unit vector
-   * \param[in] val_FlowDir - Component of a unit vector representing the flow direction
-   */
-  void SetVertexFlowDir(unsigned short iMarker, unsigned short iVertex, unsigned short iDim, su2double val_FlowDir);
-
-  /*!
-   * \brief Set a turbulence variable on a specified inlet marker.
-   * \param[in] iMarker - Marker identifier.
-   * \param[in] iVertex - Vertex identifier.
-   * \param[in] iDim - Index of the turbulence variable (i.e. k is 0 in SST)
-   * \param[in] val_turb_var - Value of the turbulence variable to be used.
-   */
-  void SetVertexTurbVar(unsigned short iMarker, unsigned short iVertex, unsigned short iDim, su2double val_tub_var);
-
-  /*!
    * \brief Compute the heat flux at a vertex on a specified marker (3 components).
    * \param[in] iMarker - Marker identifier.
    * \param[in] iVertex - Vertex identifier.
@@ -791,6 +757,41 @@ public:
    * \brief Transfer data among different zones (multiple zone).
    */
   void Transfer_Data(unsigned short donorZone, unsigned short targetZone);
+
+  /*!
+   * \brief Set the total temperature of a vertex on a specified inlet marker.
+   * \param[in] iMarker - Marker identifier.
+   * \param[in] iVertex - Vertex identifier.
+   * \param[in] val_Ttotal - Value of the total (stagnation) temperature.
+   */
+  void SetVertexTtotal(unsigned short iMarker, unsigned short iVertex, su2double val_Ttotal);
+
+  /*!
+   * \brief Set the total pressure of a vertex on a specified inlet marker.
+   * \param[in] iMarker - Marker identifier.
+   * \param[in] iVertex - Vertex identifier.
+   * \param[in] val_Ptotal - Value of the total (stagnation) pressure.
+   */
+  void SetVertexPtotal(unsigned short iMarker, unsigned short iVertex, su2double val_Ptotal);
+
+  /*!
+   * \brief Set the flow direction of a vertex on a specified inlet marker.
+   * \param[in] iMarker - Marker identifier.
+   * \param[in] iVertex - Vertex identifier.
+   * \param[in] iDim - Index of the flow direction unit vector
+   * \param[in] val_FlowDir - Component of a unit vector representing the flow direction
+   */
+  void SetVertexFlowDir(unsigned short iMarker, unsigned short iVertex, unsigned short iDim, su2double val_FlowDir);
+
+  /*!
+   * \brief Set a turbulence variable on a specified inlet marker.
+   * \param[in] iMarker - Marker identifier.
+   * \param[in] iVertex - Vertex identifier.
+   * \param[in] iDim - Index of the turbulence variable (i.e. k is 0 in SST)
+   * \param[in] val_turb_var - Value of the turbulence variable to be used.
+   */
+  void SetVertexTurbVar(unsigned short iMarker, unsigned short iVertex, unsigned short iDim, su2double val_tub_var);
+
 };
 
 

--- a/SU2_CFD/include/solver_structure.hpp
+++ b/SU2_CFD/include/solver_structure.hpp
@@ -2775,6 +2775,15 @@ public:
 
   /*!
    * \brief A virtual member
+   * \param[in] iMarker - Marker identifier.
+   * \param[in] iVertex - Vertex identifier.
+   * \param[in] iDim - Index of the turbulence variable (i.e. k is 0 in SST)
+   * \param[in] val_turb_var - Value of the turbulence variable to be used.
+   */
+  virtual void SetInlet_TurbVar(unsigned short val_marker, unsigned long val_vertex, unsigned short val_dim, su2double val_turb_var);
+
+  /*!
+   * \brief A virtual member
    * \param[in] config - Definition of the particular problem.
    */
   virtual void SetInlet(CConfig *config);
@@ -8576,7 +8585,7 @@ protected:
   *upperlimit;            /*!< \brief contains upper limits for turbulence variables. */
   su2double Gamma;           /*!< \brief Fluid's Gamma constant (ratio of specific heats). */
   su2double Gamma_Minus_One; /*!< \brief Fluids's Gamma - 1.0  . */
-  su2double*** Inlet_Turb_Vars; /*!< \brief Turbulence variables at inlet profiles */
+  su2double*** Inlet_TurbVars; /*!< \brief Turbulence variables at inlet profiles */
   unsigned long nMarker, /*!< \brief Total number of markers using the grid information. */
   *nVertex;              /*!< \brief Store nVertex at each marker for deallocation */
   
@@ -8780,6 +8789,15 @@ public:
    * \param[in] val_vertex - vertex index
    */
   int GetnSlidingStates(unsigned short val_marker, unsigned long val_vertex);
+
+  /*!
+   * \brief Set custom turbulence variables at the vertex of an inlet.
+   * \param[in] iMarker - Marker identifier.
+   * \param[in] iVertex - Vertex identifier.
+   * \param[in] iDim - Index of the turbulence variable (i.e. k is 0 in SST)
+   * \param[in] val_turb_var - Value of the turbulence variable to be used.
+   */
+  void SetInlet_TurbVar(unsigned short val_marker, unsigned long val_vertex, unsigned short val_dim, su2double val_turb_var);
 };
 
 /*!

--- a/SU2_CFD/include/solver_structure.hpp
+++ b/SU2_CFD/include/solver_structure.hpp
@@ -8576,6 +8576,7 @@ protected:
   *upperlimit;            /*!< \brief contains upper limits for turbulence variables. */
   su2double Gamma;           /*!< \brief Fluid's Gamma constant (ratio of specific heats). */
   su2double Gamma_Minus_One; /*!< \brief Fluids's Gamma - 1.0  . */
+  su2double*** Inlet_Turb_Vars; /*!< \brief Turbulence variables at inlet profiles */
   unsigned long nMarker, /*!< \brief Total number of markers using the grid information. */
   *nVertex;              /*!< \brief Store nVertex at each marker for deallocation */
   
@@ -8598,9 +8599,10 @@ public:
   
   /*!
    * \brief Constructor of the class.
+   * \param[in] geometry - Geometrical definition of the problem.
    * \param[in] config - Definition of the particular problem.
    */
-  CTurbSolver(CConfig *config);
+  CTurbSolver(CGeometry* geometry, CConfig *config);
   
   /*!
    * \brief Impose the send-receive boundary condition.
@@ -8653,7 +8655,7 @@ public:
    */
   void Viscous_Residual(CGeometry *geometry, CSolver **solver_container, CNumerics *numerics,
                         CConfig *config, unsigned short iMesh, unsigned short iRKStep);
-  
+
   /*!
    * \brief Impose the Symmetry Plane boundary condition.
    * \param[in] geometry - Geometrical definition of the problem.
@@ -9047,6 +9049,12 @@ public:
    */
   void SetDES_LengthScale(CSolver** solver, CGeometry *geometry, CConfig *config);
   
+  /*!
+   * \brief Setup the inlet per the config file and stores the result
+   * \param[in] config - Definition of the particular problem.
+   */
+  void SetInlet(CConfig *config);
+
 };
 
 /*!
@@ -9127,6 +9135,8 @@ public:
   void Source_Template(CGeometry *geometry, CSolver **solver_container, CNumerics *numerics,
                        CConfig *config, unsigned short iMesh);
   
+
+
   /*!
    * \brief Impose the Navier-Stokes wall boundary condition.
    * \param[in] geometry - Geometrical definition of the problem.
@@ -9226,12 +9236,18 @@ public:
    * \return A pointer to an array containing a set of constants
    */
   su2double* GetConstants();
-  
+
   /*!
    * \brief Set the solution using the Freestream values.
    * \param[in] config - Definition of the particular problem.
    */
   void SetFreeStream_Solution(CConfig *config);
+  
+  /*!
+   * \brief Setup the inlet per the config file and stores the result
+   * \param[in] config - Definition of the particular problem.
+   */
+  void SetInlet(CConfig *config);
   
 };
 

--- a/SU2_CFD/include/solver_structure.hpp
+++ b/SU2_CFD/include/solver_structure.hpp
@@ -8664,7 +8664,7 @@ public:
    */
   void Viscous_Residual(CGeometry *geometry, CSolver **solver_container, CNumerics *numerics,
                         CConfig *config, unsigned short iMesh, unsigned short iRKStep);
-
+  
   /*!
    * \brief Impose the Symmetry Plane boundary condition.
    * \param[in] geometry - Geometrical definition of the problem.
@@ -9153,8 +9153,6 @@ public:
   void Source_Template(CGeometry *geometry, CSolver **solver_container, CNumerics *numerics,
                        CConfig *config, unsigned short iMesh);
   
-
-
   /*!
    * \brief Impose the Navier-Stokes wall boundary condition.
    * \param[in] geometry - Geometrical definition of the problem.
@@ -9254,7 +9252,7 @@ public:
    * \return A pointer to an array containing a set of constants
    */
   su2double* GetConstants();
-
+  
   /*!
    * \brief Set the solution using the Freestream values.
    * \param[in] config - Definition of the particular problem.

--- a/SU2_CFD/include/solver_structure.hpp
+++ b/SU2_CFD/include/solver_structure.hpp
@@ -2724,52 +2724,67 @@ public:
   virtual void SetActDisk_DeltaT(unsigned short val_marker, unsigned long val_vertex, su2double val_deltat);
   
   /*!
-   * \brief A virtual member.
-   * \param[in] val_marker - Surface marker where the coefficient is computed.
-   * \param[in] val_vertex - Vertex of the marker <i>val_marker</i> where the coefficient is evaluated.
-   * \return Value of the pressure coefficient.
+   * \brief A virtual member
+   * \param[in] val_marker - Surface marker where the total temperature is evaluated.
+   * \param[in] val_vertex - Vertex of the marker <i>val_marker</i> where the total temperature is evaluated.
+   * \return Value of the total temperature
    */
   virtual su2double GetInlet_Ttotal(unsigned short val_marker, unsigned long val_vertex);
   
   /*!
-   * \brief A virtual member.
-   * \param[in] val_marker - Surface marker where the coefficient is computed.
-   * \param[in] val_vertex - Vertex of the marker <i>val_marker</i> where the coefficient is evaluated.
-   * \return Value of the pressure coefficient.
+   * \brief A virtual member
+   * \param[in] val_marker - Surface marker where the total pressure is evaluated.
+   * \param[in] val_vertex - Vertex of the marker <i>val_marker</i> where the total pressure is evaluated.
+   * \return Value of the total pressure
    */
   virtual su2double GetInlet_Ptotal(unsigned short val_marker, unsigned long val_vertex);
   
   /*!
-   * \brief A virtual member.
-   * \param[in] val_marker - Surface marker where the coefficient is computed.
-   * \param[in] val_vertex - Vertex of the marker <i>val_marker</i> where the coefficient is evaluated.
-   * \return Value of the pressure coefficient.
+   * \brief A virtual member
+   * \param[in] val_marker - Surface marker where the flow direction is evaluated
+   * \param[in] val_vertex - Vertex of the marker <i>val_marker</i> where the flow direction is evaluated
+   * \param[in] val_dim - The component of the flow direction unit vector to be evaluated
+   * \return Component of a unit vector representing the flow direction.
    */
   virtual su2double GetInlet_FlowDir(unsigned short val_marker, unsigned long val_vertex, unsigned short val_dim);
   
   /*!
-   * \brief A virtual member.
-   * \param[in] val_marker - Surface marker where the coefficient is computed.
-   * \param[in] val_vertex - Vertex of the marker <i>val_marker</i> where the coefficient is evaluated.
-   * \return Value of the pressure coefficient.
+   * \brief A virtual member
+   * \param[in] val_marker - Surface marker where the total temperature is set.
+   * \param[in] val_vertex - Vertex of the marker <i>val_marker</i> where the total temperature is set.
+   * \param[in] val_ttotal - Value of the total temperature
    */
   virtual void SetInlet_Ttotal(unsigned short val_marker, unsigned long val_vertex, su2double val_ttotal);
   
   /*!
-   * \brief A virtual member.
-   * \param[in] val_marker - Surface marker where the coefficient is computed.
-   * \param[in] val_vertex - Vertex of the marker <i>val_marker</i> where the coefficient is evaluated.
-   * \return Value of the pressure coefficient.
+   * \brief A virtual member
+   * \param[in] val_marker - Surface marker where the total pressure is set.
+   * \param[in] val_vertex - Vertex of the marker <i>val_marker</i> where the total pressure is set.
+   * \param[in] val_ptotal - Value of the total pressure
    */
   virtual void SetInlet_Ptotal(unsigned short val_marker, unsigned long val_vertex, su2double val_ptotal);
   
   /*!
-   * \brief A virtual member.
-   * \param[in] val_marker - Surface marker where the coefficient is computed.
-   * \param[in] val_vertex - Vertex of the marker <i>val_marker</i> where the coefficient is evaluated.
-   * \return Value of the pressure coefficient.
+   * \brief A virtual member
+   * \param[in] val_marker - Surface marker where the flow direction is set.
+   * \param[in] val_vertex - Vertex of the marker <i>val_marker</i> where the flow direction is set.
+   * \param[in] val_dim - The component of the flow direction unit vector to be set
+   * \param[in] val_flowdir - Component of a unit vector representing the flow direction.
    */
   virtual void SetInlet_FlowDir(unsigned short val_marker, unsigned long val_vertex, unsigned short val_dim, su2double val_flowdir);
+
+  /*!
+   * \brief A virtual member
+   * \param[in] config - Definition of the particular problem.
+   */
+  virtual void SetInlet(CConfig *config);
+
+  /*!
+   * \brief Update the multi-grid structure for the customized boundary conditions
+   * \param geometry_container - Geometrical definition.
+   * \param config - Definition of the particular problem.
+   */
+  virtual void UpdateCustomBoundaryConditions(CGeometry **geometry_container, CConfig *config);
 
   /*!
    * \brief A virtual member.
@@ -6013,52 +6028,67 @@ public:
   void SetActDisk_DeltaT(unsigned short val_marker, unsigned long val_vertex, su2double val_deltat);
   
   /*!
-   * \brief Value of the characteristic global index at the boundaries.
-   * \param[in] val_marker - Surface marker where the coefficient is computed.
-   * \param[in] val_vertex - Vertex of the marker <i>val_marker</i> where the coefficient is evaluated.
-   * \return Value of the pressure coefficient.
+   * \brief Value of the total temperature at an inlet boundary.
+   * \param[in] val_marker - Surface marker where the total temperature is evaluated.
+   * \param[in] val_vertex - Vertex of the marker <i>val_marker</i> where the total temperature is evaluated.
+   * \return Value of the total temperature
    */
   su2double GetInlet_Ttotal(unsigned short val_marker, unsigned long val_vertex);
   
   /*!
-   * \brief Value of the characteristic global index at the boundaries.
-   * \param[in] val_marker - Surface marker where the coefficient is computed.
-   * \param[in] val_vertex - Vertex of the marker <i>val_marker</i> where the coefficient is evaluated.
-   * \return Value of the pressure coefficient.
+   * \brief Value of the total pressure at an inlet boundary.
+   * \param[in] val_marker - Surface marker where the total pressure is evaluated.
+   * \param[in] val_vertex - Vertex of the marker <i>val_marker</i> where the total pressure is evaluated.
+   * \return Value of the total pressure
    */
   su2double GetInlet_Ptotal(unsigned short val_marker, unsigned long val_vertex);
   
   /*!
-   * \brief Value of the characteristic global index at the boundaries.
-   * \param[in] val_marker - Surface marker where the coefficient is computed.
-   * \param[in] val_vertex - Vertex of the marker <i>val_marker</i> where the coefficient is evaluated.
-   * \return Value of the pressure coefficient.
+   * \brief A component of the unit vector representing the flow direction at an inlet boundary.
+   * \param[in] val_marker - Surface marker where the flow direction is evaluated
+   * \param[in] val_vertex - Vertex of the marker <i>val_marker</i> where the flow direction is evaluated
+   * \param[in] val_dim - The component of the flow direction unit vector to be evaluated
+   * \return Component of a unit vector representing the flow direction.
    */
   su2double GetInlet_FlowDir(unsigned short val_marker, unsigned long val_vertex, unsigned short val_dim);
   
   /*!
-   * \brief Value of the characteristic global index at the boundaries.
-   * \param[in] val_marker - Surface marker where the coefficient is computed.
-   * \param[in] val_vertex - Vertex of the marker <i>val_marker</i> where the coefficient is evaluated.
-   * \return Value of the pressure coefficient.
+   * \brief Set the value of the total temperature at an inlet boundary.
+   * \param[in] val_marker - Surface marker where the total temperature is set.
+   * \param[in] val_vertex - Vertex of the marker <i>val_marker</i> where the total temperature is set.
+   * \param[in] val_ttotal - Value of the total temperature
    */
   void SetInlet_Ttotal(unsigned short val_marker, unsigned long val_vertex, su2double val_ttotal);
   
   /*!
-   * \brief Value of the characteristic global index at the boundaries.
-   * \param[in] val_marker - Surface marker where the coefficient is computed.
-   * \param[in] val_vertex - Vertex of the marker <i>val_marker</i> where the coefficient is evaluated.
-   * \return Value of the pressure coefficient.
+   * \brief Set the value of the total pressure at an inlet boundary.
+   * \param[in] val_marker - Surface marker where the total pressure is set.
+   * \param[in] val_vertex - Vertex of the marker <i>val_marker</i> where the total pressure is set.
+   * \param[in] val_ptotal - Value of the total pressure
    */
   void SetInlet_Ptotal(unsigned short val_marker, unsigned long val_vertex, su2double val_ptotal);
   
   /*!
-   * \brief Value of the characteristic global index at the boundaries.
-   * \param[in] val_marker - Surface marker where the coefficient is computed.
-   * \param[in] val_vertex - Vertex of the marker <i>val_marker</i> where the coefficient is evaluated.
-   * \return Value of the pressure coefficient.
+   * \brief Set a component of the unit vector representing the flow direction at an inlet boundary.
+   * \param[in] val_marker - Surface marker where the flow direction is set.
+   * \param[in] val_vertex - Vertex of the marker <i>val_marker</i> where the flow direction is set.
+   * \param[in] val_dim - The component of the flow direction unit vector to be set
+   * \param[in] val_flowdir - Component of a unit vector representing the flow direction.
    */
   void SetInlet_FlowDir(unsigned short val_marker, unsigned long val_vertex, unsigned short val_dim, su2double val_flowdir);
+
+  /*!
+   * \brief Setup the inlet per the config file and stores the result
+   * \param[in] config - Definition of the particular problem.
+   */
+  void SetInlet(CConfig *config);
+
+  /*!
+   * \brief Update the multi-grid structure for the customized boundary conditions
+   * \param geometry_container - Geometrical definition.
+   * \param config - Definition of the particular problem.
+   */
+  void UpdateCustomBoundaryConditions(CGeometry **geometry_container, CConfig *config);
 
   /*!
    * \brief Set the total residual adding the term that comes from the Dual Time Strategy.

--- a/SU2_CFD/include/solver_structure.inl
+++ b/SU2_CFD/include/solver_structure.inl
@@ -532,6 +532,10 @@ inline void CSolver::SetInlet_Ptotal(unsigned short val_marker, unsigned long va
 
 inline void CSolver::SetInlet_FlowDir(unsigned short val_marker, unsigned long val_vertex, unsigned short val_dim, su2double val_flowdir) { }
 
+inline void CSolver::SetInlet(CConfig *config) { }
+
+inline void CSolver::UpdateCustomBoundaryConditions(CGeometry **geometry_container, CConfig *config) { }
+
 inline su2double CSolver::GetCSkinFriction(unsigned short val_marker, unsigned long val_vertex, unsigned short val_dim) { return 0; }
 
 inline su2double CSolver::GetHeatFlux(unsigned short val_marker, unsigned long val_vertex) { return 0; }

--- a/SU2_CFD/include/solver_structure.inl
+++ b/SU2_CFD/include/solver_structure.inl
@@ -532,6 +532,8 @@ inline void CSolver::SetInlet_Ptotal(unsigned short val_marker, unsigned long va
 
 inline void CSolver::SetInlet_FlowDir(unsigned short val_marker, unsigned long val_vertex, unsigned short val_dim, su2double val_flowdir) { }
 
+inline void CSolver::SetInlet_TurbVar(unsigned short val_marker, unsigned long val_vertex, unsigned short val_dim, su2double val_turb_var) { }
+
 inline void CSolver::SetInlet(CConfig *config) { }
 
 inline void CSolver::UpdateCustomBoundaryConditions(CGeometry **geometry_container, CConfig *config) { }
@@ -2076,6 +2078,11 @@ inline void CTurbSolver::SetnSlidingStates(unsigned short val_marker, unsigned l
 
 inline su2double CTurbSolver::GetSlidingState(unsigned short val_marker, unsigned long val_vertex, unsigned short val_state, unsigned long donor_index) { return SlidingState[val_marker][val_vertex][val_state][donor_index]; }
 
+inline void CTurbSolver::SetInlet_TurbVar(unsigned short val_marker, unsigned long val_vertex, unsigned short val_dim, su2double val_turb_var) {
+  if (Inlet_TurbVars == NULL || Inlet_TurbVars[val_marker] == NULL)
+    SU2_MPI::Error("Tried to set a turbulence variable on an invalid marker!", CURRENT_FUNCTION);
+  else Inlet_TurbVars[val_marker][val_vertex][val_dim] = val_turb_var;
+}
 
 inline void CTurbSASolver::SetFreeStream_Solution(CConfig *config) {
   for (unsigned long iPoint = 0; iPoint < nPoint; iPoint++)

--- a/SU2_CFD/include/solver_structure.inl
+++ b/SU2_CFD/include/solver_structure.inl
@@ -1145,11 +1145,44 @@ inline su2double CEulerSolver::GetInlet_Ptotal(unsigned short val_marker, unsign
 
 inline su2double CEulerSolver::GetInlet_FlowDir(unsigned short val_marker, unsigned long val_vertex, unsigned short val_dim) { return Inlet_FlowDir[val_marker][val_vertex][val_dim]; }
 
-inline void CEulerSolver::SetInlet_Ttotal(unsigned short val_marker, unsigned long val_vertex, su2double val_ttotal) { Inlet_Ttotal[val_marker][val_vertex] = val_ttotal; }
+inline void CEulerSolver::SetInlet_Ttotal(unsigned short val_marker, unsigned long val_vertex, su2double val_ttotal) {
+  /*--- Since this call can be accessed indirectly using python, do some error
+   * checking to prevent segmentation faults ---*/
+  if (val_marker >= nMarker)
+    SU2_MPI::Error("Out-of-bounds marker index used on inlet.", CURRENT_FUNCTION);
+  else if (Inlet_Ttotal == NULL || Inlet_Ttotal[val_marker] == NULL)
+    SU2_MPI::Error("Tried to set custom inlet BC on an invalid marker.", CURRENT_FUNCTION);
+  else if (val_vertex >= nVertex[val_marker])
+    SU2_MPI::Error("Out-of-bounds vertex index used on inlet.", CURRENT_FUNCTION);
+  else
+    Inlet_Ttotal[val_marker][val_vertex] = val_ttotal;
+}
 
-inline void CEulerSolver::SetInlet_Ptotal(unsigned short val_marker, unsigned long val_vertex, su2double val_ptotal) { Inlet_Ptotal[val_marker][val_vertex] = val_ptotal; }
+inline void CEulerSolver::SetInlet_Ptotal(unsigned short val_marker, unsigned long val_vertex, su2double val_ptotal) {
+  /*--- Since this call can be accessed indirectly using python, do some error
+   * checking to prevent segmentation faults ---*/
+  if (val_marker >= nMarker)
+    SU2_MPI::Error("Out-of-bounds marker index used on inlet.", CURRENT_FUNCTION);
+  else if (Inlet_Ptotal == NULL || Inlet_Ptotal[val_marker] == NULL)
+    SU2_MPI::Error("Tried to set custom inlet BC on an invalid marker.", CURRENT_FUNCTION);
+  else if (val_vertex >= nVertex[val_marker])
+    SU2_MPI::Error("Out-of-bounds vertex index used on inlet.", CURRENT_FUNCTION);
+  else
+    Inlet_Ptotal[val_marker][val_vertex] = val_ptotal;
+}
 
-inline void CEulerSolver::SetInlet_FlowDir(unsigned short val_marker, unsigned long val_vertex, unsigned short val_dim, su2double val_flowdir) { Inlet_FlowDir[val_marker][val_vertex][val_dim] = val_flowdir; }
+inline void CEulerSolver::SetInlet_FlowDir(unsigned short val_marker, unsigned long val_vertex, unsigned short val_dim, su2double val_flowdir) {
+  /*--- Since this call can be accessed indirectly using python, do some error
+   * checking to prevent segmentation faults ---*/
+  if (val_marker >= nMarker)
+    SU2_MPI::Error("Out-of-bounds marker index used on inlet.", CURRENT_FUNCTION);
+  else if (Inlet_FlowDir == NULL || Inlet_FlowDir[val_marker] == NULL)
+      SU2_MPI::Error("Tried to set custom inlet BC on an invalid marker.", CURRENT_FUNCTION);
+  else if (val_vertex >= nVertex[val_marker])
+    SU2_MPI::Error("Out-of-bounds vertex index used on inlet.", CURRENT_FUNCTION);
+  else
+    Inlet_FlowDir[val_marker][val_vertex][val_dim] = val_flowdir;
+}
 
 inline su2double CEulerSolver::GetCL_Inv(unsigned short val_marker) { return CL_Inv[val_marker]; }
 
@@ -2079,11 +2112,18 @@ inline void CTurbSolver::SetnSlidingStates(unsigned short val_marker, unsigned l
 inline su2double CTurbSolver::GetSlidingState(unsigned short val_marker, unsigned long val_vertex, unsigned short val_state, unsigned long donor_index) { return SlidingState[val_marker][val_vertex][val_state][donor_index]; }
 
 inline void CTurbSolver::SetInlet_TurbVar(unsigned short val_marker, unsigned long val_vertex, unsigned short val_dim, su2double val_turb_var) {
-  if (Inlet_TurbVars == NULL || Inlet_TurbVars[val_marker] == NULL)
-    SU2_MPI::Error("Tried to set a turbulence variable on an invalid marker.", CURRENT_FUNCTION);
+  /*--- Since this call can be accessed indirectly using python, do some error
+   * checking to prevent segmentation faults ---*/
+  if (val_marker >= nMarker)
+    SU2_MPI::Error("Out-of-bounds marker index used on inlet.", CURRENT_FUNCTION);
+  else if (Inlet_TurbVars == NULL || Inlet_TurbVars[val_marker] == NULL)
+    SU2_MPI::Error("Tried to set custom inlet BC on an invalid marker.", CURRENT_FUNCTION);
+  else if (val_vertex >= nVertex[val_marker])
+    SU2_MPI::Error("Out-of-bounds vertex index used on inlet.", CURRENT_FUNCTION);
   else if (val_dim >= nVar)
     SU2_MPI::Error("Out-of-bounds index used for inlet turbulence variable.", CURRENT_FUNCTION);
-  else Inlet_TurbVars[val_marker][val_vertex][val_dim] = val_turb_var;
+  else
+    Inlet_TurbVars[val_marker][val_vertex][val_dim] = val_turb_var;
 }
 
 inline void CTurbSASolver::SetFreeStream_Solution(CConfig *config) {

--- a/SU2_CFD/include/solver_structure.inl
+++ b/SU2_CFD/include/solver_structure.inl
@@ -2080,7 +2080,9 @@ inline su2double CTurbSolver::GetSlidingState(unsigned short val_marker, unsigne
 
 inline void CTurbSolver::SetInlet_TurbVar(unsigned short val_marker, unsigned long val_vertex, unsigned short val_dim, su2double val_turb_var) {
   if (Inlet_TurbVars == NULL || Inlet_TurbVars[val_marker] == NULL)
-    SU2_MPI::Error("Tried to set a turbulence variable on an invalid marker!", CURRENT_FUNCTION);
+    SU2_MPI::Error("Tried to set a turbulence variable on an invalid marker.", CURRENT_FUNCTION);
+  else if (val_dim >= nVar)
+    SU2_MPI::Error("Out-of-bounds index used for inlet turbulence variable.", CURRENT_FUNCTION);
   else Inlet_TurbVars[val_marker][val_vertex][val_dim] = val_turb_var;
 }
 

--- a/SU2_CFD/src/python_wrapper_structure.cpp
+++ b/SU2_CFD/src/python_wrapper_structure.cpp
@@ -533,7 +533,13 @@ void CDriver::SetVertexFlowDir(unsigned short iMarker, unsigned short iVertex, u
 
 void CDriver::SetVertexTurbVar(unsigned short iMarker, unsigned short iVertex, unsigned short iDim, su2double val_turb_var){
 
-  solver_container[ZONE_0][MESH_0][FLOW_SOL]->SetInlet_TurbVar(iMarker, iVertex, iDim, val_turb_var);
+  if (solver_container[ZONE_0] == NULL ||
+      solver_container[ZONE_0][MESH_0] ==  NULL) {
+    SU2_MPI::Error("Could not find an appropriate solver.", CURRENT_FUNCTION);
+  } else if (solver_container[ZONE_0][MESH_0][TURB_SOL] == NULL) {
+    SU2_MPI::Error("Tried to set turbulence variables without a turbulence solver.", CURRENT_FUNCTION);
+  }
+  solver_container[ZONE_0][MESH_0][TURB_SOL]->SetInlet_TurbVar(iMarker, iVertex, iDim, val_turb_var);
 
 }
 

--- a/SU2_CFD/src/python_wrapper_structure.cpp
+++ b/SU2_CFD/src/python_wrapper_structure.cpp
@@ -48,6 +48,7 @@ void CDriver::PythonInterface_Preprocessing(){
       geometry_container[iZone][iMesh]->SetCustomBoundary(config_container[iZone]);
     }
     geometry_container[iZone][MESH_0]->UpdateCustomBoundaryConditions(geometry_container[iZone], config_container[iZone]);
+    solver_container[iZone][MESH_0][FLOW_SOL]->UpdateCustomBoundaryConditions(geometry_container[iZone], config_container[iZone]);
   }
   /*--- Initialize some variables used for external communications trough the Py wrapper. ---*/
   PyWrapVarCoord[0] = 0.0;
@@ -512,6 +513,24 @@ void CDriver::SetVertexTemperature(unsigned short iMarker, unsigned short iVerte
   geometry_container[ZONE_0][MESH_0]->SetCustomBoundaryTemperature(iMarker, iVertex, val_WallTemp);
 }
 
+void CDriver::SetVertexTtotal(unsigned short iMarker, unsigned short iVertex, su2double val_Ttotal){
+
+  solver_container[ZONE_0][MESH_0][FLOW_SOL]->SetInlet_Ttotal(iMarker, iVertex, val_Ttotal);
+
+}
+
+void CDriver::SetVertexPtotal(unsigned short iMarker, unsigned short iVertex, su2double val_Ptotal){
+
+  solver_container[ZONE_0][MESH_0][FLOW_SOL]->SetInlet_Ptotal(iMarker, iVertex, val_Ptotal);
+
+}
+
+void CDriver::SetVertexFlowDir(unsigned short iMarker, unsigned short iVertex, unsigned short iDim, su2double val_FlowDir){
+
+  solver_container[ZONE_0][MESH_0][FLOW_SOL]->SetInlet_FlowDir(iMarker, iVertex, iDim, val_FlowDir);
+
+}
+
 bool CDriver::ComputeVertexHeatFluxes(unsigned short iMarker, unsigned short iVertex){
 
   unsigned long iPoint;
@@ -705,6 +724,26 @@ vector<string> CDriver::GetAllCHTMarkersTag(){
   }
 
   return CHTBoundariesTagList;
+}
+
+vector<string> CDriver::GetAllInletMarkersTag(){
+
+  vector<string> BoundariesTagList;
+  unsigned short iMarker, nBoundariesMarker;
+  string Marker_Tag;
+
+  nBoundariesMarker = config_container[ZONE_0]->GetnMarker_All();
+
+  for(iMarker=0; iMarker<nBoundariesMarker; iMarker++){
+    bool isCustomizable = config_container[ZONE_0]->GetMarker_All_PyCustom(iMarker);
+    bool isInlet = (config_container[ZONE_0]->GetMarker_All_KindBC(iMarker) == INLET_FLOW);
+    if(isCustomizable && isInlet) {
+      Marker_Tag = config_container[ZONE_0]->GetMarker_All_TagBound(iMarker);
+      BoundariesTagList.push_back(Marker_Tag);
+    }
+  }
+
+  return BoundariesTagList;
 }
 
 map<string, int> CDriver::GetAllBoundaryMarkers(){

--- a/SU2_CFD/src/python_wrapper_structure.cpp
+++ b/SU2_CFD/src/python_wrapper_structure.cpp
@@ -988,7 +988,6 @@ void CFluidDriver::SetVertexTurbVar(unsigned short iMarker, unsigned short iVert
 
 }
 
-
 void CFluidDriver::BoundaryConditionsUpdate(){
 
   int rank = MASTER_NODE;

--- a/SU2_CFD/src/python_wrapper_structure.cpp
+++ b/SU2_CFD/src/python_wrapper_structure.cpp
@@ -531,6 +531,12 @@ void CDriver::SetVertexFlowDir(unsigned short iMarker, unsigned short iVertex, u
 
 }
 
+void CDriver::SetVertexTurbVar(unsigned short iMarker, unsigned short iVertex, unsigned short iDim, su2double val_turb_var){
+
+  solver_container[ZONE_0][MESH_0][FLOW_SOL]->SetInlet_TurbVar(iMarker, iVertex, iDim, val_turb_var);
+
+}
+
 bool CDriver::ComputeVertexHeatFluxes(unsigned short iMarker, unsigned short iVertex){
 
   unsigned long iPoint;

--- a/SU2_CFD/src/python_wrapper_structure.cpp
+++ b/SU2_CFD/src/python_wrapper_structure.cpp
@@ -513,36 +513,6 @@ void CDriver::SetVertexTemperature(unsigned short iMarker, unsigned short iVerte
   geometry_container[ZONE_0][MESH_0]->SetCustomBoundaryTemperature(iMarker, iVertex, val_WallTemp);
 }
 
-void CDriver::SetVertexTtotal(unsigned short iMarker, unsigned short iVertex, su2double val_Ttotal){
-
-  solver_container[ZONE_0][MESH_0][FLOW_SOL]->SetInlet_Ttotal(iMarker, iVertex, val_Ttotal);
-
-}
-
-void CDriver::SetVertexPtotal(unsigned short iMarker, unsigned short iVertex, su2double val_Ptotal){
-
-  solver_container[ZONE_0][MESH_0][FLOW_SOL]->SetInlet_Ptotal(iMarker, iVertex, val_Ptotal);
-
-}
-
-void CDriver::SetVertexFlowDir(unsigned short iMarker, unsigned short iVertex, unsigned short iDim, su2double val_FlowDir){
-
-  solver_container[ZONE_0][MESH_0][FLOW_SOL]->SetInlet_FlowDir(iMarker, iVertex, iDim, val_FlowDir);
-
-}
-
-void CDriver::SetVertexTurbVar(unsigned short iMarker, unsigned short iVertex, unsigned short iDim, su2double val_turb_var){
-
-  if (solver_container[ZONE_0] == NULL ||
-      solver_container[ZONE_0][MESH_0] ==  NULL) {
-    SU2_MPI::Error("Could not find an appropriate solver.", CURRENT_FUNCTION);
-  } else if (solver_container[ZONE_0][MESH_0][TURB_SOL] == NULL) {
-    SU2_MPI::Error("Tried to set turbulence variables without a turbulence solver.", CURRENT_FUNCTION);
-  }
-  solver_container[ZONE_0][MESH_0][TURB_SOL]->SetInlet_TurbVar(iMarker, iVertex, iDim, val_turb_var);
-
-}
-
 bool CDriver::ComputeVertexHeatFluxes(unsigned short iMarker, unsigned short iVertex){
 
   unsigned long iPoint;
@@ -987,6 +957,37 @@ void CFluidDriver::SetInitialMesh() {
   }
   //}
 }
+
+void CFluidDriver::SetVertexTtotal(unsigned short iMarker, unsigned short iVertex, su2double val_Ttotal){
+
+  solver_container[ZONE_0][MESH_0][FLOW_SOL]->SetInlet_Ttotal(iMarker, iVertex, val_Ttotal);
+
+}
+
+void CFluidDriver::SetVertexPtotal(unsigned short iMarker, unsigned short iVertex, su2double val_Ptotal){
+
+  solver_container[ZONE_0][MESH_0][FLOW_SOL]->SetInlet_Ptotal(iMarker, iVertex, val_Ptotal);
+
+}
+
+void CFluidDriver::SetVertexFlowDir(unsigned short iMarker, unsigned short iVertex, unsigned short iDim, su2double val_FlowDir){
+
+  solver_container[ZONE_0][MESH_0][FLOW_SOL]->SetInlet_FlowDir(iMarker, iVertex, iDim, val_FlowDir);
+
+}
+
+void CFluidDriver::SetVertexTurbVar(unsigned short iMarker, unsigned short iVertex, unsigned short iDim, su2double val_turb_var){
+
+  if (solver_container[ZONE_0] == NULL ||
+      solver_container[ZONE_0][MESH_0] ==  NULL) {
+    SU2_MPI::Error("Could not find an appropriate solver.", CURRENT_FUNCTION);
+  } else if (solver_container[ZONE_0][MESH_0][TURB_SOL] == NULL) {
+    SU2_MPI::Error("Tried to set turbulence variables without a turbulence solver.", CURRENT_FUNCTION);
+  }
+  solver_container[ZONE_0][MESH_0][TURB_SOL]->SetInlet_TurbVar(iMarker, iVertex, iDim, val_turb_var);
+
+}
+
 
 void CFluidDriver::BoundaryConditionsUpdate(){
 

--- a/SU2_CFD/src/solver_direct_mean.cpp
+++ b/SU2_CFD/src/solver_direct_mean.cpp
@@ -8662,7 +8662,10 @@ void CEulerSolver::UpdateCustomBoundaryConditions(CGeometry **geometry_container
   // TODO: Update the fluid boundary conditions for MG
   nMGlevel = config->GetnMGLevels();
   if (nMGlevel > 1) {
-    SU2_MPI::Error("Custom inlet BCs are not currently compatible with multigrid.", CURRENT_FUNCTION);
+    for (iMarker=0; iMarker < nMarker; iMarker++) {
+      if (config->GetMarker_All_PyCustom(iMarker))
+        SU2_MPI::Error("Custom inlet BCs are not currently compatible with multigrid.", CURRENT_FUNCTION);
+    }
   }
 }
 

--- a/SU2_CFD/src/solver_direct_mean.cpp
+++ b/SU2_CFD/src/solver_direct_mean.cpp
@@ -8621,6 +8621,7 @@ void CEulerSolver::SetInlet(CConfig *config) {
    * values (available through the py wrapper). This is intentional; the
    * default values for these custom BCs are initialized with the default
    * values specified in the config (avoiding non physical values) --- */
+  cout << "Setting default inlet conditions..." << endl;
   for(iMarker=0; iMarker < nMarker; iMarker++) {
     if (config->GetMarker_All_KindBC(iMarker) == INLET_FLOW) {
       string Marker_Tag = config->GetMarker_All_TagBound(iMarker);

--- a/SU2_CFD/src/solver_direct_mean.cpp
+++ b/SU2_CFD/src/solver_direct_mean.cpp
@@ -8637,7 +8637,6 @@ void CEulerSolver::SetInlet(CConfig *config) {
    * values (available through the py wrapper). This is intentional; the
    * default values for these custom BCs are initialized with the default
    * values specified in the config (avoiding non physical values) --- */
-  cout << "Setting default inlet conditions..." << endl;
   for(iMarker=0; iMarker < nMarker; iMarker++) {
     if (config->GetMarker_All_KindBC(iMarker) == INLET_FLOW) {
       string Marker_Tag = config->GetMarker_All_TagBound(iMarker);

--- a/SU2_CFD/src/solver_direct_mean.cpp
+++ b/SU2_CFD/src/solver_direct_mean.cpp
@@ -547,9 +547,13 @@ CEulerSolver::CEulerSolver(CGeometry *geometry, CConfig *config, unsigned short 
 
   Inlet_Ttotal = new su2double* [nMarker];
   for (iMarker = 0; iMarker < nMarker; iMarker++) {
-    Inlet_Ttotal[iMarker] = new su2double [geometry->nVertex[iMarker]];
-    for (iVertex = 0; iVertex < geometry->nVertex[iMarker]; iVertex++) {
-      Inlet_Ttotal[iMarker][iVertex] = 0;
+    if (config->GetMarker_All_KindBC(iMarker) == INLET_FLOW) {
+      Inlet_Ttotal[iMarker] = new su2double [geometry->nVertex[iMarker]];
+      for (iVertex = 0; iVertex < geometry->nVertex[iMarker]; iVertex++) {
+        Inlet_Ttotal[iMarker][iVertex] = 0;
+      }
+    } else {
+      Inlet_Ttotal[iMarker] = NULL;
     }
   }
 
@@ -557,9 +561,13 @@ CEulerSolver::CEulerSolver(CGeometry *geometry, CConfig *config, unsigned short 
 
   Inlet_Ptotal = new su2double* [nMarker];
   for (iMarker = 0; iMarker < nMarker; iMarker++) {
-    Inlet_Ptotal[iMarker] = new su2double [geometry->nVertex[iMarker]];
-    for (iVertex = 0; iVertex < geometry->nVertex[iMarker]; iVertex++) {
-      Inlet_Ptotal[iMarker][iVertex] = 0;
+    if (config->GetMarker_All_KindBC(iMarker) == INLET_FLOW) {
+      Inlet_Ptotal[iMarker] = new su2double [geometry->nVertex[iMarker]];
+      for (iVertex = 0; iVertex < geometry->nVertex[iMarker]; iVertex++) {
+        Inlet_Ptotal[iMarker][iVertex] = 0;
+      }
+    } else {
+      Inlet_Ptotal[iMarker] = NULL;
     }
   }
 
@@ -567,12 +575,16 @@ CEulerSolver::CEulerSolver(CGeometry *geometry, CConfig *config, unsigned short 
 
   Inlet_FlowDir = new su2double** [nMarker];
   for (iMarker = 0; iMarker < nMarker; iMarker++) {
-    Inlet_FlowDir[iMarker] = new su2double* [geometry->nVertex[iMarker]];
-    for (iVertex = 0; iVertex < geometry->nVertex[iMarker]; iVertex++) {
-      Inlet_FlowDir[iMarker][iVertex] = new su2double [nDim];
-      for (iDim = 0; iDim < nDim; iDim++) {
-        Inlet_FlowDir[iMarker][iVertex][iDim] = 0;
+    if (config->GetMarker_All_KindBC(iMarker) == INLET_FLOW) {
+      Inlet_FlowDir[iMarker] = new su2double* [geometry->nVertex[iMarker]];
+      for (iVertex = 0; iVertex < geometry->nVertex[iMarker]; iVertex++) {
+        Inlet_FlowDir[iMarker][iVertex] = new su2double [nDim];
+        for (iDim = 0; iDim < nDim; iDim++) {
+          Inlet_FlowDir[iMarker][iVertex][iDim] = 0;
+        }
       }
+    } else {
+      Inlet_FlowDir[iMarker] = NULL;
     }
   }
 
@@ -1022,21 +1034,25 @@ CEulerSolver::~CEulerSolver(void) {
 
   if (Inlet_Ttotal != NULL) {
     for (iMarker = 0; iMarker < nMarker; iMarker++)
-      delete [] Inlet_Ttotal[iMarker];
+      if (Inlet_Ttotal[iMarker] != NULL)
+        delete [] Inlet_Ttotal[iMarker];
     delete [] Inlet_Ttotal;
   }
 
   if (Inlet_Ptotal != NULL) {
     for (iMarker = 0; iMarker < nMarker; iMarker++)
-      delete [] Inlet_Ptotal[iMarker];
+      if (Inlet_Ptotal[iMarker] != NULL)
+        delete [] Inlet_Ptotal[iMarker];
     delete [] Inlet_Ptotal;
   }
 
   if (Inlet_FlowDir != NULL) {
     for (iMarker = 0; iMarker < nMarker; iMarker++) {
-      for (iVertex = 0; iVertex < nVertex[iMarker]; iVertex++)
-        delete [] Inlet_FlowDir[iMarker][iVertex];
-      delete [] Inlet_FlowDir[iMarker];
+      if (Inlet_FlowDir[iMarker] != NULL) {
+        for (iVertex = 0; iVertex < nVertex[iMarker]; iVertex++)
+          delete [] Inlet_FlowDir[iMarker][iVertex];
+        delete [] Inlet_FlowDir[iMarker];
+      }
     }
     delete [] Inlet_FlowDir;
   }
@@ -15256,35 +15272,47 @@ CNSSolver::CNSSolver(CGeometry *geometry, CConfig *config, unsigned short iMesh)
   }
   
   /*--- Store the value of the Total Pressure at the inlet BC ---*/
-  
+
   Inlet_Ttotal = new su2double* [nMarker];
   for (iMarker = 0; iMarker < nMarker; iMarker++) {
-    Inlet_Ttotal[iMarker] = new su2double [geometry->nVertex[iMarker]];
-    for (iVertex = 0; iVertex < geometry->nVertex[iMarker]; iVertex++) {
-      Inlet_Ttotal[iMarker][iVertex] = 0;
+    if (config->GetMarker_All_KindBC(iMarker) == INLET_FLOW) {
+      Inlet_Ttotal[iMarker] = new su2double [geometry->nVertex[iMarker]];
+      for (iVertex = 0; iVertex < geometry->nVertex[iMarker]; iVertex++) {
+        Inlet_Ttotal[iMarker][iVertex] = 0;
+      }
+    } else {
+      Inlet_Ttotal[iMarker] = NULL;
     }
   }
-  
+
   /*--- Store the value of the Total Temperature at the inlet BC ---*/
-  
+
   Inlet_Ptotal = new su2double* [nMarker];
   for (iMarker = 0; iMarker < nMarker; iMarker++) {
-    Inlet_Ptotal[iMarker] = new su2double [geometry->nVertex[iMarker]];
-    for (iVertex = 0; iVertex < geometry->nVertex[iMarker]; iVertex++) {
-      Inlet_Ptotal[iMarker][iVertex] = 0;
+    if (config->GetMarker_All_KindBC(iMarker) == INLET_FLOW) {
+      Inlet_Ptotal[iMarker] = new su2double [geometry->nVertex[iMarker]];
+      for (iVertex = 0; iVertex < geometry->nVertex[iMarker]; iVertex++) {
+        Inlet_Ptotal[iMarker][iVertex] = 0;
+      }
+    } else {
+      Inlet_Ptotal[iMarker] = NULL;
     }
   }
-  
+
   /*--- Store the value of the Flow direction at the inlet BC ---*/
-  
+
   Inlet_FlowDir = new su2double** [nMarker];
   for (iMarker = 0; iMarker < nMarker; iMarker++) {
-    Inlet_FlowDir[iMarker] = new su2double* [geometry->nVertex[iMarker]];
-    for (iVertex = 0; iVertex < geometry->nVertex[iMarker]; iVertex++) {
-      Inlet_FlowDir[iMarker][iVertex] = new su2double [nDim];
-      for (iDim = 0; iDim < nDim; iDim++) {
-        Inlet_FlowDir[iMarker][iVertex][iDim] = 0;
+    if (config->GetMarker_All_KindBC(iMarker) == INLET_FLOW) {
+      Inlet_FlowDir[iMarker] = new su2double* [geometry->nVertex[iMarker]];
+      for (iVertex = 0; iVertex < geometry->nVertex[iMarker]; iVertex++) {
+        Inlet_FlowDir[iMarker][iVertex] = new su2double [nDim];
+        for (iDim = 0; iDim < nDim; iDim++) {
+          Inlet_FlowDir[iMarker][iVertex][iDim] = 0;
+        }
       }
+    } else {
+      Inlet_FlowDir[iMarker] = NULL;
     }
   }
 

--- a/SU2_CFD/src/solver_direct_mean.cpp
+++ b/SU2_CFD/src/solver_direct_mean.cpp
@@ -15271,7 +15271,7 @@ CNSSolver::CNSSolver(CGeometry *geometry, CConfig *config, unsigned short iMesh)
   }
   
   /*--- Store the value of the Total Pressure at the inlet BC ---*/
-
+  
   Inlet_Ttotal = new su2double* [nMarker];
   for (iMarker = 0; iMarker < nMarker; iMarker++) {
     if (config->GetMarker_All_KindBC(iMarker) == INLET_FLOW) {
@@ -15283,9 +15283,9 @@ CNSSolver::CNSSolver(CGeometry *geometry, CConfig *config, unsigned short iMesh)
       Inlet_Ttotal[iMarker] = NULL;
     }
   }
-
+  
   /*--- Store the value of the Total Temperature at the inlet BC ---*/
-
+  
   Inlet_Ptotal = new su2double* [nMarker];
   for (iMarker = 0; iMarker < nMarker; iMarker++) {
     if (config->GetMarker_All_KindBC(iMarker) == INLET_FLOW) {
@@ -15297,9 +15297,9 @@ CNSSolver::CNSSolver(CGeometry *geometry, CConfig *config, unsigned short iMesh)
       Inlet_Ptotal[iMarker] = NULL;
     }
   }
-
+  
   /*--- Store the value of the Flow direction at the inlet BC ---*/
-
+  
   Inlet_FlowDir = new su2double** [nMarker];
   for (iMarker = 0; iMarker < nMarker; iMarker++) {
     if (config->GetMarker_All_KindBC(iMarker) == INLET_FLOW) {

--- a/SU2_CFD/src/solver_direct_mean.cpp
+++ b/SU2_CFD/src/solver_direct_mean.cpp
@@ -8663,7 +8663,9 @@ void CEulerSolver::UpdateCustomBoundaryConditions(CGeometry **geometry_container
   nMGlevel = config->GetnMGLevels();
   if (nMGlevel > 1) {
     for (iMarker=0; iMarker < nMarker; iMarker++) {
-      if (config->GetMarker_All_PyCustom(iMarker))
+      bool isCustomizable = config->GetMarker_All_PyCustom(iMarker);
+      bool isInlet = (config->GetMarker_All_KindBC(iMarker) == INLET_FLOW);
+      if (isCustomizable && isInlet)
         SU2_MPI::Error("Custom inlet BCs are not currently compatible with multigrid.", CURRENT_FUNCTION);
     }
   }

--- a/SU2_CFD/src/solver_direct_turbulent.cpp
+++ b/SU2_CFD/src/solver_direct_turbulent.cpp
@@ -41,10 +41,11 @@ CTurbSolver::CTurbSolver(void) : CSolver() {
   upperlimit    = NULL;
   nVertex       = NULL;
   nMarker       = 0;
+  Inlet_Turb_Vars = NULL;
   
 }
 
-CTurbSolver::CTurbSolver(CConfig *config) : CSolver() {
+CTurbSolver::CTurbSolver(CGeometry* geometry, CConfig *config) : CSolver() {
   
   Gamma = config->GetGamma();
   Gamma_Minus_One = Gamma - 1.0;
@@ -53,17 +54,36 @@ CTurbSolver::CTurbSolver(CConfig *config) : CSolver() {
   FlowPrimVar_j = NULL;
   lowerlimit    = NULL;
   upperlimit    = NULL;
+  nMarker       = config->GetnMarker_All();
+  
+  /*--- Store the number of vertices on each marker for deallocation later ---*/
+  nVertex = new unsigned long[nMarker];
+  for (unsigned long iMarker = 0; iMarker < nMarker; iMarker++)
+    nVertex[iMarker] = geometry->nVertex[iMarker];
   
 }
 
 CTurbSolver::~CTurbSolver(void) {
-  
+
+  if (Inlet_Turb_Vars != NULL) {
+    for (unsigned long iMarker = 0; iMarker < nMarker; iMarker++) {
+      if (Inlet_Turb_Vars[iMarker] != NULL) {
+        for (unsigned long iVertex = 0; iVertex < nVertex[iMarker]; iVertex++) {
+          delete [] Inlet_Turb_Vars[iMarker][iVertex];
+        }
+        delete [] Inlet_Turb_Vars[iMarker];
+      }
+    }
+    delete [] Inlet_Turb_Vars;
+  }
+
   if (FlowPrimVar_i != NULL) delete [] FlowPrimVar_i;
   if (FlowPrimVar_j != NULL) delete [] FlowPrimVar_j;
   if (lowerlimit != NULL) delete [] lowerlimit;
   if (upperlimit != NULL) delete [] upperlimit;
   if (nVertex != NULL) delete [] nVertex;
   
+
 }
 
 void CTurbSolver::Set_MPI_Solution(CGeometry *geometry, CConfig *config) {
@@ -1172,9 +1192,14 @@ void CTurbSolver::LoadRestart(CGeometry **geometry, CSolver ***solver, CConfig *
 
 }
 
-CTurbSASolver::CTurbSASolver(void) : CTurbSolver() { }
+CTurbSASolver::CTurbSASolver(void) : CTurbSolver() {
 
-CTurbSASolver::CTurbSASolver(CGeometry *geometry, CConfig *config, unsigned short iMesh, CFluidModel* FluidModel) : CTurbSolver() {
+  Inlet_Turb_Vars = NULL;
+
+}
+
+CTurbSASolver::CTurbSASolver(CGeometry *geometry, CConfig *config, unsigned short iMesh, CFluidModel* FluidModel)
+    : CTurbSolver(geometry, config) {
   unsigned short iVar, iDim, nLineLets;
   unsigned long iPoint;
   su2double Density_Inf, Viscosity_Inf, Factor_nu_Inf, Factor_nu_Engine, Factor_nu_ActDisk;
@@ -1334,7 +1359,7 @@ CTurbSASolver::CTurbSASolver(CGeometry *geometry, CConfig *config, unsigned shor
 
   /*--- Initializate quantities for SlidingMesh Interface ---*/
 
-  unsigned long iMarker,  nMarker = config->GetnMarker_All();
+  unsigned long iMarker;
 
   SlidingState       = new su2double*** [nMarker];
   SlidingStateNodes  = new int*         [nMarker];
@@ -1359,6 +1384,10 @@ CTurbSASolver::CTurbSASolver(CGeometry *geometry, CConfig *config, unsigned shor
 
     }
   }
+
+  /*--- Set up inlet profiles, if necessary ---*/
+
+  SetInlet(config);
 
 }
 
@@ -1389,6 +1418,7 @@ CTurbSASolver::~CTurbSASolver(void) {
     }
     delete [] SlidingStateNodes;
   }
+
 }
 
 void CTurbSASolver::Preprocessing(CGeometry *geometry, CSolver **solver_container, CConfig *config, unsigned short iMesh, unsigned short iRKStep, unsigned short RunTime_EqSystem, bool Output) {
@@ -1714,6 +1744,7 @@ void CTurbSASolver::BC_Inlet(CGeometry *geometry, CSolver **solver_container, CN
   unsigned short iDim;
   unsigned long iVertex, iPoint, Point_Normal;
   su2double *V_inlet, *V_domain, *Normal;
+  bool isCustomizable = config->GetMarker_All_PyCustom(val_marker);
   
   Normal = new su2double[nDim];
   
@@ -1754,7 +1785,13 @@ void CTurbSASolver::BC_Inlet(CGeometry *geometry, CSolver **solver_container, CN
       /*--- Set the turbulent variable states (prescribed for an inflow) ---*/
       
       Solution_i[0] = node[iPoint]->GetSolution(0);
-      Solution_j[0] = nu_tilde_Inf;
+
+      if (isCustomizable) {
+        /*--- Only use the array version of the inlet BC when necessary ---*/
+        Solution_j[0] = Inlet_Turb_Vars[val_marker][iVertex][0];
+      } else {
+        Solution_j[0] = nu_tilde_Inf;
+      }
       
       conv_numerics->SetTurbVar(Solution_i, Solution_j);
       
@@ -3130,14 +3167,40 @@ void CTurbSASolver::SetDES_LengthScale(CSolver **solver, CGeometry *geometry, CC
   }
 }
 
+void CTurbSASolver::SetInlet(CConfig* config) {
+
+  /*-- Allocation has to happen in derived classes (not CTurbSolver),
+   * due to arbitrary number of turbulence variables ---*/
+  Inlet_Turb_Vars = new su2double**[nMarker];
+  for (unsigned long iMarker = 0; iMarker < nMarker; iMarker++) {
+    bool isCustomizable = config->GetMarker_All_PyCustom(iMarker);
+    bool isInlet = (config->GetMarker_All_KindBC(iMarker) == INLET_FLOW);
+    if (isCustomizable && isInlet) {
+      Inlet_Turb_Vars[iMarker] = new su2double*[nVertex[iMarker]];
+      for(unsigned long iVertex=0; iVertex < nVertex[iMarker]; iVertex++){
+        Inlet_Turb_Vars[iMarker][iVertex] = new su2double[nVar];
+        /*--- The default values for these custom BCs are initialized with
+         * the freestream values to avoid nonphysical values at unspecified
+         * points ---*/
+        Inlet_Turb_Vars[iMarker][iVertex][0] = nu_tilde_Inf;
+      }
+    } else {
+      Inlet_Turb_Vars[iMarker] = NULL;
+    }
+  }
+
+}
+
 CTurbSSTSolver::CTurbSSTSolver(void) : CTurbSolver() {
   
   /*--- Array initialization ---*/
   constants = NULL;
+  Inlet_Turb_Vars = NULL;
   
 }
 
-CTurbSSTSolver::CTurbSSTSolver(CGeometry *geometry, CConfig *config, unsigned short iMesh) : CTurbSolver() {
+CTurbSSTSolver::CTurbSSTSolver(CGeometry *geometry, CConfig *config, unsigned short iMesh)
+    : CTurbSolver(geometry, config) {
   unsigned short iVar, iDim, nLineLets;
   unsigned long iPoint;
   ifstream restart_file;
@@ -3294,7 +3357,7 @@ CTurbSSTSolver::CTurbSSTSolver(CGeometry *geometry, CConfig *config, unsigned sh
 
   /*--- Initializate quantities for SlidingMesh Interface ---*/
 
-  unsigned long iMarker,  nMarker = config->GetnMarker_All();
+  unsigned long iMarker;
 
   SlidingState       = new su2double*** [nMarker];
   SlidingStateNodes  = new int*         [nMarker];
@@ -3319,7 +3382,11 @@ CTurbSSTSolver::CTurbSSTSolver(CGeometry *geometry, CConfig *config, unsigned sh
 
     }
   }
-  
+
+  /*--- Set up inlet profiles, if necessary ---*/
+
+  SetInlet(config);
+
 }
 
 CTurbSSTSolver::~CTurbSSTSolver(void) {
@@ -3351,6 +3418,7 @@ CTurbSSTSolver::~CTurbSSTSolver(void) {
     }
     delete [] SlidingStateNodes;
   }
+
 }
 
 void CTurbSSTSolver::Preprocessing(CGeometry *geometry, CSolver **solver_container, CConfig *config, unsigned short iMesh, unsigned short iRKStep, unsigned short RunTime_EqSystem, bool Output) {
@@ -3683,6 +3751,7 @@ void CTurbSSTSolver::BC_Inlet(CGeometry *geometry, CSolver **solver_container, C
   unsigned short iVar, iDim;
   unsigned long iVertex, iPoint, Point_Normal;
   su2double *V_inlet, *V_domain, *Normal;
+  bool isCustomizable = config->GetMarker_All_PyCustom(val_marker);
   
   Normal = new su2double[nDim];
   
@@ -3719,8 +3788,14 @@ void CTurbSSTSolver::BC_Inlet(CGeometry *geometry, CSolver **solver_container, C
       for (iVar = 0; iVar < nVar; iVar++)
       Solution_i[iVar] = node[iPoint]->GetSolution(iVar);
       
-      Solution_j[0]= kine_Inf;
-      Solution_j[1]= omega_Inf;
+      if (isCustomizable) {
+        /*--- Only use the array version of the inlet BC when necessary ---*/
+        Solution_j[0] = Inlet_Turb_Vars[val_marker][iVertex][0];
+        Solution_j[1] = Inlet_Turb_Vars[val_marker][iVertex][1];
+      } else {
+        Solution_j[0] = kine_Inf;
+        Solution_j[1] = omega_Inf;
+      }
       
       conv_numerics->SetTurbVar(Solution_i, Solution_j);
       
@@ -4213,4 +4288,30 @@ void CTurbSSTSolver::BC_Fluid_Interface(CGeometry *geometry, CSolver **solver_co
 
 su2double* CTurbSSTSolver::GetConstants() {
   return constants;
+}
+
+
+void CTurbSSTSolver::SetInlet(CConfig* config) {
+
+  /*-- Allocation has to happen in derived classes (not CTurbSolver),
+   * due to arbitrary number of turbulence variables ---*/
+  Inlet_Turb_Vars = new su2double**[nMarker];
+  for (unsigned long iMarker = 0; iMarker < nMarker; iMarker++) {
+    bool isCustomizable = config->GetMarker_All_PyCustom(iMarker);
+    bool isInlet = (config->GetMarker_All_KindBC(iMarker) == INLET_FLOW);
+    if (isCustomizable && isInlet) {
+      Inlet_Turb_Vars[iMarker] = new su2double*[nVertex[iMarker]];
+      for(unsigned long iVertex=0; iVertex < nVertex[iMarker]; iVertex++){
+        Inlet_Turb_Vars[iMarker][iVertex] = new su2double[nVar];
+        /*--- The default values for these custom BCs are initialized with
+         * the freestream values to avoid nonphysical values at unspecified
+         * points ---*/
+        Inlet_Turb_Vars[iMarker][iVertex][0] = kine_Inf;
+        Inlet_Turb_Vars[iMarker][iVertex][1] = omega_Inf;
+      }
+    } else {
+      Inlet_Turb_Vars[iMarker] = NULL;
+    }
+  }
+
 }

--- a/SU2_CFD/src/solver_direct_turbulent.cpp
+++ b/SU2_CFD/src/solver_direct_turbulent.cpp
@@ -41,7 +41,7 @@ CTurbSolver::CTurbSolver(void) : CSolver() {
   upperlimit    = NULL;
   nVertex       = NULL;
   nMarker       = 0;
-  Inlet_Turb_Vars = NULL;
+  Inlet_TurbVars = NULL;
   
 }
 
@@ -65,16 +65,16 @@ CTurbSolver::CTurbSolver(CGeometry* geometry, CConfig *config) : CSolver() {
 
 CTurbSolver::~CTurbSolver(void) {
 
-  if (Inlet_Turb_Vars != NULL) {
+  if (Inlet_TurbVars != NULL) {
     for (unsigned long iMarker = 0; iMarker < nMarker; iMarker++) {
-      if (Inlet_Turb_Vars[iMarker] != NULL) {
+      if (Inlet_TurbVars[iMarker] != NULL) {
         for (unsigned long iVertex = 0; iVertex < nVertex[iMarker]; iVertex++) {
-          delete [] Inlet_Turb_Vars[iMarker][iVertex];
+          delete [] Inlet_TurbVars[iMarker][iVertex];
         }
-        delete [] Inlet_Turb_Vars[iMarker];
+        delete [] Inlet_TurbVars[iMarker];
       }
     }
-    delete [] Inlet_Turb_Vars;
+    delete [] Inlet_TurbVars;
   }
 
   if (FlowPrimVar_i != NULL) delete [] FlowPrimVar_i;
@@ -1194,7 +1194,7 @@ void CTurbSolver::LoadRestart(CGeometry **geometry, CSolver ***solver, CConfig *
 
 CTurbSASolver::CTurbSASolver(void) : CTurbSolver() {
 
-  Inlet_Turb_Vars = NULL;
+  Inlet_TurbVars = NULL;
 
 }
 
@@ -1788,7 +1788,7 @@ void CTurbSASolver::BC_Inlet(CGeometry *geometry, CSolver **solver_container, CN
 
       if (isCustomizable) {
         /*--- Only use the array version of the inlet BC when necessary ---*/
-        Solution_j[0] = Inlet_Turb_Vars[val_marker][iVertex][0];
+        Solution_j[0] = Inlet_TurbVars[val_marker][iVertex][0];
       } else {
         Solution_j[0] = nu_tilde_Inf;
       }
@@ -3171,21 +3171,21 @@ void CTurbSASolver::SetInlet(CConfig* config) {
 
   /*-- Allocation has to happen in derived classes (not CTurbSolver),
    * due to arbitrary number of turbulence variables ---*/
-  Inlet_Turb_Vars = new su2double**[nMarker];
+  Inlet_TurbVars = new su2double**[nMarker];
   for (unsigned long iMarker = 0; iMarker < nMarker; iMarker++) {
     bool isCustomizable = config->GetMarker_All_PyCustom(iMarker);
     bool isInlet = (config->GetMarker_All_KindBC(iMarker) == INLET_FLOW);
     if (isCustomizable && isInlet) {
-      Inlet_Turb_Vars[iMarker] = new su2double*[nVertex[iMarker]];
+      Inlet_TurbVars[iMarker] = new su2double*[nVertex[iMarker]];
       for(unsigned long iVertex=0; iVertex < nVertex[iMarker]; iVertex++){
-        Inlet_Turb_Vars[iMarker][iVertex] = new su2double[nVar];
+        Inlet_TurbVars[iMarker][iVertex] = new su2double[nVar];
         /*--- The default values for these custom BCs are initialized with
          * the freestream values to avoid nonphysical values at unspecified
          * points ---*/
-        Inlet_Turb_Vars[iMarker][iVertex][0] = nu_tilde_Inf;
+        Inlet_TurbVars[iMarker][iVertex][0] = nu_tilde_Inf;
       }
     } else {
-      Inlet_Turb_Vars[iMarker] = NULL;
+      Inlet_TurbVars[iMarker] = NULL;
     }
   }
 
@@ -3195,7 +3195,7 @@ CTurbSSTSolver::CTurbSSTSolver(void) : CTurbSolver() {
   
   /*--- Array initialization ---*/
   constants = NULL;
-  Inlet_Turb_Vars = NULL;
+  Inlet_TurbVars = NULL;
   
 }
 
@@ -3790,8 +3790,8 @@ void CTurbSSTSolver::BC_Inlet(CGeometry *geometry, CSolver **solver_container, C
       
       if (isCustomizable) {
         /*--- Only use the array version of the inlet BC when necessary ---*/
-        Solution_j[0] = Inlet_Turb_Vars[val_marker][iVertex][0];
-        Solution_j[1] = Inlet_Turb_Vars[val_marker][iVertex][1];
+        Solution_j[0] = Inlet_TurbVars[val_marker][iVertex][0];
+        Solution_j[1] = Inlet_TurbVars[val_marker][iVertex][1];
       } else {
         Solution_j[0] = kine_Inf;
         Solution_j[1] = omega_Inf;
@@ -4295,22 +4295,22 @@ void CTurbSSTSolver::SetInlet(CConfig* config) {
 
   /*-- Allocation has to happen in derived classes (not CTurbSolver),
    * due to arbitrary number of turbulence variables ---*/
-  Inlet_Turb_Vars = new su2double**[nMarker];
+  Inlet_TurbVars = new su2double**[nMarker];
   for (unsigned long iMarker = 0; iMarker < nMarker; iMarker++) {
     bool isCustomizable = config->GetMarker_All_PyCustom(iMarker);
     bool isInlet = (config->GetMarker_All_KindBC(iMarker) == INLET_FLOW);
     if (isCustomizable && isInlet) {
-      Inlet_Turb_Vars[iMarker] = new su2double*[nVertex[iMarker]];
+      Inlet_TurbVars[iMarker] = new su2double*[nVertex[iMarker]];
       for(unsigned long iVertex=0; iVertex < nVertex[iMarker]; iVertex++){
-        Inlet_Turb_Vars[iMarker][iVertex] = new su2double[nVar];
+        Inlet_TurbVars[iMarker][iVertex] = new su2double[nVar];
         /*--- The default values for these custom BCs are initialized with
          * the freestream values to avoid nonphysical values at unspecified
          * points ---*/
-        Inlet_Turb_Vars[iMarker][iVertex][0] = kine_Inf;
-        Inlet_Turb_Vars[iMarker][iVertex][1] = omega_Inf;
+        Inlet_TurbVars[iMarker][iVertex][0] = kine_Inf;
+        Inlet_TurbVars[iMarker][iVertex][1] = omega_Inf;
       }
     } else {
-      Inlet_Turb_Vars[iMarker] = NULL;
+      Inlet_TurbVars[iMarker] = NULL;
     }
   }
 


### PR DESCRIPTION
Piggybacking on pull request #488, this pull request adds the ability to specify the values of the inlet variables for inlet boundary conditions.  This includes both the Euler/Navier-Stokes variables as well as the turbulence variables.  No new inlet conditions are created; rather, the existing inlet conditions (such as total pressure and total temperature) can be set to custom values.

This is similar to the branch I mentioned in #467.  The main difference is that the other branch uses hardcoded routines in C++ to read in a table of values and set the inlet conditions.  This branch forgoes all of that and lets the user decide how to specify the inlet conditions.  This allows both function-based inlet conditions (using python functions) or table-based inlet conditions (using python to read in the values from a file).

I'm not opposed to a purely C++ approach to accomplishing the same objective, but I think the python way is much more flexible.

Multigrid is **not** currently supported.  I don't currently know enough about the agglomeration routines to ensure that I implemented it correctly. Multigrid is not a high priority for me, since periodic BCs and time-stepping are also incompatible with multigrid.

### Verification

As a test-case, I used the flat-plate boundary layer problem in the Tutorials/TestCases directories.  I chopped the domain off around x=.5, then used the values from a converged simulation to set the inlet to the correct values at x=.5.  You can see some of the results below.

I can turn the truncated flat plate into a regression test, if you would like.

![x-momentumcontour](https://user-images.githubusercontent.com/13340225/35588322-e69ac5f4-05c5-11e8-902d-64941ab731fb.png)
Figure 1: A comparison of the momentum in the x-direction between truncated and full domains.

![x-momentum_line](https://user-images.githubusercontent.com/13340225/35588290-cb0141c4-05c5-11e8-88d3-085018fabf52.png)
Figure 2: A comparison of the momentum profiles at x~=1.5.

![nu_tildecontour](https://user-images.githubusercontent.com/13340225/35588241-9891e5a4-05c5-11e8-9861-50064b28689e.png)
Figure 3: A comparison of the turbulent variable between truncated and full domains.

![nu_tilde_line](https://user-images.githubusercontent.com/13340225/35588249-9d94e3e4-05c5-11e8-9fc6-fbe9e89d144e.png)
Figure 4: A comparison of the turbulent variable profiles at x~=1.5