### PR TITLE
Change the integer type in periodic node sorting

### DIFF
--- a/Common/src/geometry_structure.cpp
+++ b/Common/src/geometry_structure.cpp
@@ -18832,7 +18832,7 @@ void CPeriodicGeometry::SetMeshFile(CGeometry *geometry, CConfig *config, string
   
   ReverseSort.resize(NewSort.size());
   for (iPoint = 0; iPoint < nPoint; iPoint++) {
-    unsigned short jPoint;
+    unsigned long jPoint;
     for (jPoint = 0; jPoint < nPoint; jPoint++) {
       if (NewSort[iPoint] == jPoint) {
         ReverseSort[jPoint] = iPoint;


### PR DESCRIPTION
I accidentally used the wrong type of integer at one point in the periodic-node-resorting.  As pointed out by @LaSerpe, `jPoint` should be an unsigned long to handle large numbers of grid points.