### PR TITLE
Fix a few memory issues in 6.0.0

### DIFF
--- a/Common/include/geometry_structure.hpp
+++ b/Common/include/geometry_structure.hpp
@@ -126,7 +126,8 @@ public:
 	CVertex*** vertex;		/*!< \brief Boundary Vertex vector (dual grid information). */
   CTurboVertex**** turbovertex; /*!< \brief Boundary Vertex vector ordered for turbomachinery calculation(dual grid information). */
   unsigned long *nVertex;	/*!< \brief Number of vertex for each marker. */
-  unsigned short *nSpanWiseSections; /*!< \brief Number of Span wise section for each turbo marker. */
+  unsigned short *nSpanWiseSections; /*!< \brief Number of Span wise section for each turbo marker, indexed by inflow/outflow */
+  unsigned short *nSpanSectionsByMarker; /*! <\brief Number of Span wise section for each turbo marker, indexed by marker.  Needed for deallocation.*/
   unsigned short nTurboPerf; /*!< \brief Number of Span wise section for each turbo marker. */
   su2double **SpanWiseValue; /*!< \brief Span wise values for each turbo marker. */
   long **nVertexSpan; /*! <\brief number of vertexes for span wise section for each marker.  */

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -490,6 +490,7 @@ void CConfig::SetPointersNull(void) {
   RelaxFactorAverage       = NULL;
   RelaxFactorFourier       = NULL;
   nSpan_iZones             = NULL;
+  FinalRotation_Rate_Z     = NULL;
   ExtraRelFacGiles         = NULL;
   Mixedout_Coeff           = NULL;
   RampRotatingFrame_Coeff  = NULL;
@@ -6241,6 +6242,7 @@ CConfig::~CConfig(void) {
   if (RelaxFactorAverage != NULL) delete [] RelaxFactorAverage;
   if (RelaxFactorFourier != NULL) delete [] RelaxFactorFourier;
   if (nSpan_iZones != NULL) delete [] nSpan_iZones;
+  if (FinalRotation_Rate_Z != NULL) delete [] FinalRotation_Rate_Z;
   if (Kind_TurboMachinery != NULL) delete [] Kind_TurboMachinery;
 
   if (Marker_MixingPlaneInterface !=NULL) delete [] Marker_MixingPlaneInterface;

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -290,6 +290,9 @@ void CConfig::SetPointersNull(void) {
   Marker_CfgFile_DV           = NULL;   Marker_All_DV            = NULL;
   Marker_CfgFile_Moving       = NULL;   Marker_All_Moving        = NULL;
   Marker_CfgFile_PerBound     = NULL;   Marker_All_PerBound      = NULL;    Marker_PerBound   = NULL;
+  Marker_CfgFile_Turbomachinery = NULL; Marker_All_Turbomachinery = NULL;
+  Marker_CfgFile_TurbomachineryFlag = NULL; Marker_All_TurbomachineryFlag = NULL;
+  Marker_CfgFile_MixingPlaneInterface = NULL; Marker_All_MixingPlaneInterface = NULL;
   Marker_CfgFile_ZoneInterface = NULL;
   Marker_CfgFile_PyCustom     = NULL;   Marker_All_PyCustom      = NULL;
   
@@ -5932,11 +5935,19 @@ CConfig::~CConfig(void) {
   if (Marker_All_Moving     != NULL) delete[] Marker_All_Moving;
 
   if (Marker_CfgFile_PyCustom    != NULL) delete[] Marker_CfgFile_PyCustom;
-
   if (Marker_All_PyCustom != NULL) delete[] Marker_All_PyCustom;
   
   if (Marker_CfgFile_PerBound != NULL) delete[] Marker_CfgFile_PerBound;
   if (Marker_All_PerBound     != NULL) delete[] Marker_All_PerBound;
+
+  if (Marker_CfgFile_Turbomachinery != NULL) delete [] Marker_CfgFile_Turbomachinery;
+  if (Marker_All_Turbomachinery     != NULL) delete [] Marker_All_Turbomachinery;
+
+  if (Marker_CfgFile_TurbomachineryFlag != NULL) delete [] Marker_CfgFile_TurbomachineryFlag;
+  if (Marker_All_TurbomachineryFlag     != NULL) delete [] Marker_All_TurbomachineryFlag;
+
+  if (Marker_CfgFile_MixingPlaneInterface != NULL) delete [] Marker_CfgFile_MixingPlaneInterface;
+  if (Marker_All_MixingPlaneInterface     != NULL) delete [] Marker_All_MixingPlaneInterface;
 
   if (Marker_DV!= NULL)               delete[] Marker_DV;
   if (Marker_Moving != NULL)           delete[] Marker_Moving;

--- a/Common/src/dual_grid_structure.cpp
+++ b/Common/src/dual_grid_structure.cpp
@@ -659,8 +659,6 @@ CTurboVertex::CTurboVertex(unsigned long val_point, unsigned short val_nDim) : C
 
 CTurboVertex::~CTurboVertex() {
 
-	if (Normal != NULL) delete[] Normal;
-	if (Nodes != NULL) delete[] Nodes;
 	if (TurboNormal != NULL) delete [] TurboNormal;
 
 }

--- a/Common/src/geometry_structure.cpp
+++ b/Common/src/geometry_structure.cpp
@@ -4981,6 +4981,131 @@ CPhysicalGeometry::~CPhysicalGeometry(void) {
   if (Global_to_Local_Marker != NULL) delete [] Global_to_Local_Marker;
   if (Local_to_Global_Marker != NULL) delete [] Local_to_Global_Marker;
   
+  /*--- Free up memory from turbomachinery performance computation  ---*/
+
+  unsigned short iMarker;
+  if (TangGridVelIn != NULL) {
+    for (iMarker = 0; iMarker < nTurboPerf; iMarker++)
+      if (TangGridVelIn[iMarker] != NULL) delete [] TangGridVelIn[iMarker];
+    delete [] TangGridVelIn;
+  }
+  if (SpanAreaIn != NULL) {
+    for (iMarker = 0; iMarker < nTurboPerf; iMarker++)
+      if (SpanAreaIn[iMarker] != NULL) delete [] SpanAreaIn[iMarker];
+    delete [] SpanAreaIn;
+  }
+  if (TurboRadiusIn != NULL) {
+    for (iMarker = 0; iMarker < nTurboPerf; iMarker++)
+      if (TurboRadiusIn[iMarker] != NULL) delete [] TurboRadiusIn[iMarker];
+    delete [] TurboRadiusIn;
+  }
+  if (TangGridVelOut != NULL) {
+    for (iMarker = 0; iMarker < nTurboPerf; iMarker++)
+      if (TangGridVelOut[iMarker] != NULL) delete [] TangGridVelOut[iMarker];
+    delete [] TangGridVelOut;
+  }
+  if (SpanAreaOut != NULL) {
+    for (iMarker = 0; iMarker < nTurboPerf; iMarker++)
+      if (SpanAreaOut[iMarker] != NULL) delete [] SpanAreaOut[iMarker];
+    delete [] SpanAreaOut;
+  }
+  if (TurboRadiusOut != NULL) {
+    for (iMarker = 0; iMarker < nTurboPerf; iMarker++)
+      if (TurboRadiusOut[iMarker] != NULL) delete [] TurboRadiusOut[iMarker];
+    delete [] TurboRadiusOut;
+  }
+
+  /*--- Free up memory from turbomachinery computations  ---*/
+
+  if (nSpanWiseSections != NULL) delete [] nSpanWiseSections;
+  if (SpanWiseValue != NULL) {
+    for (iMarker = 0; iMarker < 2; iMarker++)
+      if (SpanWiseValue[iMarker] != NULL) delete [] SpanWiseValue[iMarker];
+    delete [] SpanWiseValue;
+  }
+  if (nVertexSpan != NULL) {
+    for (iMarker = 0; iMarker < nMarker; iMarker++)
+      if (nVertexSpan[iMarker] != NULL) delete [] nVertexSpan[iMarker];
+    delete [] nVertexSpan;
+  }
+  if (nTotVertexSpan != NULL) {
+    for (iMarker = 0; iMarker < nMarker; iMarker++)
+      if (nTotVertexSpan[iMarker] != NULL) delete [] nTotVertexSpan[iMarker];
+    delete [] nTotVertexSpan;
+  }
+
+  /*--- FIXME: turbovertex, AverageTurboNormal, AverageNormal, and
+   * AverageGridVel all need to be deallocated further, but their allocation
+   * depends on the config file.  Additional data needs to be stored during
+   * allocation to aid in deallocation. ---*/
+  if (turbovertex != NULL) {
+    for (iMarker = 0; iMarker < nMarker; iMarker++)
+      if (turbovertex[iMarker] != NULL) {
+        delete [] turbovertex[iMarker];
+      }
+    delete [] turbovertex;
+  }
+  if (AverageTurboNormal != NULL) {
+    for (iMarker = 0; iMarker < nMarker; iMarker++)
+      if (AverageTurboNormal[iMarker] != NULL) {
+        delete [] AverageTurboNormal[iMarker];
+      }
+    delete [] AverageTurboNormal;
+  }
+  if (AverageNormal != NULL) {
+    for (iMarker = 0; iMarker < nMarker; iMarker++)
+      if (AverageNormal[iMarker] != NULL) {
+        delete [] AverageNormal[iMarker];
+      }
+    delete [] AverageNormal;
+  }
+  unsigned short iSpan;
+  if (AverageGridVel != NULL) {
+    for (iMarker = 0; iMarker < nMarker; iMarker++)
+      if (AverageGridVel[iMarker] != NULL) {
+
+        for (iSpan= 0; iSpan < nSpanWiseSections[marker_flag-1] + 1; iSpan++)
+          delete [] AverageGridVel[iMarker][iSpan];
+      }
+    delete [] AverageGridVel;
+  }
+
+//  turbovertex                       = new CTurboVertex***[nMarker];
+//  AverageTurboNormal                = new su2double**[nMarker];
+//  AverageNormal                     = new su2double**[nMarker];
+//  AverageGridVel                    = new su2double**[nMarker];
+
+  if (AverageTangGridVel != NULL) {
+    for (iMarker = 0; iMarker < nMarker; iMarker++)
+      if (AverageTangGridVel[iMarker] != NULL) delete [] AverageTangGridVel[iMarker];
+    delete [] AverageTangGridVel;
+  }
+  if (SpanArea != NULL) {
+    for (iMarker = 0; iMarker < nMarker; iMarker++)
+      if (SpanArea[iMarker] != NULL) delete [] SpanArea[iMarker];
+    delete [] SpanArea;
+  }
+  if (TurboRadius != NULL) {
+    for (iMarker = 0; iMarker < nMarker; iMarker++)
+      if (TurboRadius[iMarker] != NULL) delete [] TurboRadius[iMarker];
+    delete [] TurboRadius;
+  }
+  if (MaxAngularCoord != NULL) {
+    for (iMarker = 0; iMarker < nMarker; iMarker++)
+      if (MaxAngularCoord[iMarker] != NULL) delete [] MaxAngularCoord[iMarker];
+    delete [] MaxAngularCoord;
+  }
+  if (MinAngularCoord != NULL) {
+    for (iMarker = 0; iMarker < nMarker; iMarker++)
+      if (MinAngularCoord[iMarker] != NULL) delete [] MinAngularCoord[iMarker];
+    delete [] MinAngularCoord;
+  }
+  if (MinRelAngularCoord != NULL) {
+    for (iMarker = 0; iMarker < nMarker; iMarker++)
+      if (MinRelAngularCoord[iMarker] != NULL) delete [] MinRelAngularCoord[iMarker];
+    delete [] MinRelAngularCoord;
+  }
+
 }
 
 

--- a/Common/src/geometry_structure.cpp
+++ b/Common/src/geometry_structure.cpp
@@ -5022,24 +5022,6 @@ CPhysicalGeometry::~CPhysicalGeometry(void) {
 
   /*--- Free up memory from turbomachinery computations  ---*/
 
-  if (nSpanWiseSections != NULL) delete [] nSpanWiseSections;
-  if (nSpanSectionsByMarker != NULL) delete [] nSpanSectionsByMarker;
-  if (SpanWiseValue != NULL) {
-    for (iMarker = 0; iMarker < 2; iMarker++)
-      if (SpanWiseValue[iMarker] != NULL) delete [] SpanWiseValue[iMarker];
-    delete [] SpanWiseValue;
-  }
-  if (nVertexSpan != NULL) {
-    for (iMarker = 0; iMarker < nMarker; iMarker++)
-      if (nVertexSpan[iMarker] != NULL) delete [] nVertexSpan[iMarker];
-    delete [] nVertexSpan;
-  }
-  if (nTotVertexSpan != NULL) {
-    for (iMarker = 0; iMarker < nMarker; iMarker++)
-      if (nTotVertexSpan[iMarker] != NULL) delete [] nTotVertexSpan[iMarker];
-    delete [] nTotVertexSpan;
-  }
-
   unsigned short iSpan, iVertex;
   if (turbovertex != NULL) {
     for (iMarker = 0; iMarker < nMarker; iMarker++) {
@@ -5117,6 +5099,24 @@ CPhysicalGeometry::~CPhysicalGeometry(void) {
     for (iMarker = 0; iMarker < nMarker; iMarker++)
       if (MinRelAngularCoord[iMarker] != NULL) delete [] MinRelAngularCoord[iMarker];
     delete [] MinRelAngularCoord;
+  }
+
+  if (nSpanWiseSections != NULL) delete [] nSpanWiseSections;
+  if (nSpanSectionsByMarker != NULL) delete [] nSpanSectionsByMarker;
+  if (SpanWiseValue != NULL) {
+    for (iMarker = 0; iMarker < 2; iMarker++)
+      if (SpanWiseValue[iMarker] != NULL) delete [] SpanWiseValue[iMarker];
+    delete [] SpanWiseValue;
+  }
+  if (nVertexSpan != NULL) {
+    for (iMarker = 0; iMarker < nMarker; iMarker++)
+      if (nVertexSpan[iMarker] != NULL) delete [] nVertexSpan[iMarker];
+    delete [] nVertexSpan;
+  }
+  if (nTotVertexSpan != NULL) {
+    for (iMarker = 0; iMarker < nMarker; iMarker++)
+      if (nTotVertexSpan[iMarker] != NULL) delete [] nTotVertexSpan[iMarker];
+    delete [] nTotVertexSpan;
   }
 
 }

--- a/Common/src/geometry_structure.cpp
+++ b/Common/src/geometry_structure.cpp
@@ -5042,7 +5042,7 @@ CPhysicalGeometry::~CPhysicalGeometry(void) {
   if (AverageTurboNormal != NULL) {
     for (iMarker = 0; iMarker < nMarker; iMarker++) {
       if (AverageTurboNormal[iMarker] != NULL) {
-        for (iSpan= 0; iSpan < nSpanSectionsByMarker[iMarker]; iSpan++)
+        for (iSpan= 0; iSpan < nSpanSectionsByMarker[iMarker]+1; iSpan++)
           delete [] AverageTurboNormal[iMarker][iSpan];
         delete [] AverageTurboNormal[iMarker];
       }
@@ -5052,7 +5052,7 @@ CPhysicalGeometry::~CPhysicalGeometry(void) {
   if (AverageNormal != NULL) {
     for (iMarker = 0; iMarker < nMarker; iMarker++) {
       if (AverageNormal[iMarker] != NULL) {
-        for (iSpan= 0; iSpan < nSpanSectionsByMarker[iMarker]; iSpan++)
+        for (iSpan= 0; iSpan < nSpanSectionsByMarker[iMarker]+1; iSpan++)
           delete [] AverageNormal[iMarker][iSpan];
         delete [] AverageNormal[iMarker];
       }
@@ -5062,7 +5062,7 @@ CPhysicalGeometry::~CPhysicalGeometry(void) {
   if (AverageGridVel != NULL) {
     for (iMarker = 0; iMarker < nMarker; iMarker++) {
       if (AverageGridVel[iMarker] != NULL) {
-        for (iSpan= 0; iSpan < nSpanSectionsByMarker[iMarker]; iSpan++)
+        for (iSpan= 0; iSpan < nSpanSectionsByMarker[iMarker]+1; iSpan++)
           delete [] AverageGridVel[iMarker][iSpan];
         delete [] AverageGridVel[iMarker];
       }
@@ -11431,6 +11431,7 @@ void CPhysicalGeometry::SetAvgTurboValue(CConfig *config, unsigned short val_iZo
       if (config->GetMarker_All_Turbomachinery(iMarker) == iMarkerTP){
         if (config->GetMarker_All_TurbomachineryFlag(iMarker) == marker_flag){
           if(allocate){
+            nSpanSectionsByMarker[iMarker]            = nSpanWiseSections[marker_flag-1];
             AverageTurboNormal[iMarker]               = new su2double *[nSpanWiseSections[marker_flag-1] + 1];
             AverageNormal[iMarker]                    = new su2double *[nSpanWiseSections[marker_flag-1] + 1];
             AverageGridVel[iMarker]                   = new su2double *[nSpanWiseSections[marker_flag-1] + 1];

--- a/Common/src/geometry_structure.cpp
+++ b/Common/src/geometry_structure.cpp
@@ -1835,9 +1835,10 @@ CPhysicalGeometry::CPhysicalGeometry() : CGeometry() {
   ending_node   = NULL;
   npoint_procs  = NULL;
 
-  /*--- Arrays for defining the tutbomachinery structure ---*/
+  /*--- Arrays for defining the turbomachinery structure ---*/
 
   nSpanWiseSections       = NULL;
+  nSpanSectionsByMarker   = NULL;
   SpanWiseValue           = NULL;
   nVertexSpan             = NULL;
   nTotVertexSpan          = NULL;
@@ -1873,9 +1874,10 @@ CPhysicalGeometry::CPhysicalGeometry(CConfig *config, unsigned short val_iZone, 
   ending_node   = NULL;
   npoint_procs  = NULL;
   
-  /*--- Arrays for defining the tutbomachinery structure ---*/
+  /*--- Arrays for defining the turbomachinery structure ---*/
 
   nSpanWiseSections       = NULL;
+  nSpanSectionsByMarker   = NULL;
   SpanWiseValue           = NULL;
   nVertexSpan             = NULL;
   nTotVertexSpan          = NULL;
@@ -2019,9 +2021,10 @@ CPhysicalGeometry::CPhysicalGeometry(CGeometry *geometry, CConfig *config) {
   ending_node   = NULL;
   npoint_procs  = NULL;
 
-  /*--- Arrays for defining the tutbomachinery structure ---*/
+  /*--- Arrays for defining the turbomachinery structure ---*/
 
   nSpanWiseSections       = NULL;
+  nSpanSectionsByMarker   = NULL;
   SpanWiseValue           = NULL;
   nVertexSpan             = NULL;
   nTotVertexSpan          = NULL;

--- a/Common/src/matrix_structure.cpp
+++ b/Common/src/matrix_structure.cpp
@@ -38,6 +38,8 @@ CSysMatrix::CSysMatrix(void) {
   size = SU2_MPI::GetSize();
   rank = SU2_MPI::GetRank();
   
+  ilu_fill_in       = 0;
+
   /*--- Array initialization ---*/
 
   matrix            = NULL;

--- a/SU2_CFD/include/solver_structure.hpp
+++ b/SU2_CFD/include/solver_structure.hpp
@@ -4368,6 +4368,7 @@ protected:
   bool AoA_FD_Change;
   unsigned long BCThrust_Counter;
   unsigned short nSpanWiseSections;  /*!< \brief Number of span-wise sections. */
+  unsigned short nSpanMax; /*!< \brief Max number of maximum span-wise sections for all zones */
   unsigned short nMarkerTurboPerf;  /*!< \brief Number of turbo performance. */
 
   CFluidModel  *FluidModel;  /*!< \brief fluid model used in the solver */

--- a/SU2_CFD/src/driver_structure.cpp
+++ b/SU2_CFD/src/driver_structure.cpp
@@ -442,6 +442,7 @@ void CDriver::Postprocessing() {
     for (iZone = 0; iZone < nZone; iZone++) {
       ConvHist_file[iZone].close();
     }
+    delete [] ConvHist_file;
 
   }
 

--- a/SU2_CFD/src/driver_structure.cpp
+++ b/SU2_CFD/src/driver_structure.cpp
@@ -493,8 +493,12 @@ void CDriver::Postprocessing() {
   
   if (transfer_container != NULL) {
     for (iZone = 0; iZone < nZone; iZone++) {
-        if (transfer_container[iZone] != NULL)
-          delete [] transfer_container[iZone];
+      if (transfer_container[iZone] != NULL) {
+        for (unsigned short jZone = 0; jZone < nZone; jZone++)
+          if (transfer_container[iZone][jZone] != NULL)
+            delete transfer_container[iZone][jZone];
+        delete [] transfer_container[iZone];
+      }
     }
     delete [] transfer_container;
     if (rank == MASTER_NODE) cout << "Deleted CTransfer container." << endl;

--- a/SU2_CFD/src/output_structure.cpp
+++ b/SU2_CFD/src/output_structure.cpp
@@ -315,6 +315,7 @@ COutput::~COutput(void) {
       delete [] TotalStaticEfficiency[iMarker];
       delete [] TotalTotalEfficiency [iMarker];
       delete [] KineticEnergyLoss    [iMarker];
+      delete [] TRadius              [iMarker];
       delete [] TotalPressureLoss    [iMarker];
       delete [] MassFlowIn           [iMarker];
       delete [] MassFlowOut          [iMarker];
@@ -331,6 +332,7 @@ COutput::~COutput(void) {
       delete [] FlowAngleIn_BC       [iMarker];
       delete [] EntropyIn            [iMarker];
       delete [] EntropyIn_BC         [iMarker];
+      delete [] EntropyOut           [iMarker];
       delete [] TotalEnthalpyIn_BC   [iMarker];
       delete [] DensityIn            [iMarker];
       delete [] PressureIn           [iMarker];
@@ -365,6 +367,7 @@ COutput::~COutput(void) {
     delete [] TotalStaticEfficiency;
     delete [] TotalTotalEfficiency;
     delete [] KineticEnergyLoss;
+    delete [] TRadius;
     delete [] TotalPressureLoss;
     delete [] MassFlowIn;
     delete [] MassFlowOut;
@@ -381,6 +384,7 @@ COutput::~COutput(void) {
     delete [] FlowAngleIn_BC;
     delete [] EntropyIn;
     delete [] EntropyIn_BC;
+    delete [] EntropyOut;
     delete [] TotalEnthalpyIn_BC;
     delete [] DensityIn;
     delete [] PressureIn;
@@ -397,6 +401,7 @@ COutput::~COutput(void) {
     delete [] MachOut;
     delete [] TurboVelocityIn;
     delete [] TurboVelocityOut;
+    delete [] TemperatureIn;
     delete [] TemperatureOut;
     delete [] TotalPressureIn;
     delete [] TotalPressureOut;

--- a/SU2_CFD/src/solver_direct_mean.cpp
+++ b/SU2_CFD/src/solver_direct_mean.cpp
@@ -1102,6 +1102,15 @@ CEulerSolver::~CEulerSolver(void) {
     delete [] AverageTurboVelocity;
   }
 
+  if(OldAverageTurboVelocity !=NULL){
+    for (iMarker = 0; iMarker < nMarker; iMarker++) {
+      for(iSpan = 0; iSpan < nSpanWiseSections + 1; iSpan++)
+        delete [] OldAverageTurboVelocity[iMarker][iSpan];
+      delete  [] OldAverageTurboVelocity[iMarker];
+    }
+    delete [] OldAverageTurboVelocity;
+  }
+
   if(ExtAverageTurboVelocity !=NULL){
     for (iMarker = 0; iMarker < nMarker; iMarker++) {
       for(iSpan = 0; iSpan < nSpanWiseSections + 1; iSpan++)
@@ -1136,6 +1145,12 @@ CEulerSolver::~CEulerSolver(void) {
     delete [] AveragePressure;
   }
 
+  if(OldAveragePressure !=NULL){
+    for (iMarker = 0; iMarker < nMarker; iMarker++)
+      delete [] OldAveragePressure[iMarker];
+    delete [] OldAveragePressure;
+  }
+
   if(RadialEquilibriumPressure !=NULL){
     for (iMarker = 0; iMarker < nMarker; iMarker++)
       delete [] RadialEquilibriumPressure[iMarker];
@@ -1152,6 +1167,12 @@ CEulerSolver::~CEulerSolver(void) {
     for (iMarker = 0; iMarker < nMarker; iMarker++)
       delete [] AverageDensity[iMarker];
     delete [] AverageDensity;
+  }
+
+  if(OldAverageDensity !=NULL){
+    for (iMarker = 0; iMarker < nMarker; iMarker++)
+      delete [] OldAverageDensity[iMarker];
+    delete [] OldAverageDensity;
   }
 
   if(ExtAverageDensity !=NULL){
@@ -1198,7 +1219,7 @@ CEulerSolver::~CEulerSolver(void) {
 
   if(TurboVelocityIn !=NULL){
     for (iMarker = 0; iMarker < nMarkerTurboPerf; iMarker++){
-      for (iSpan = 0; iSpan < nSpanWiseSections + 1; iSpan++){
+      for (iSpan = 0; iSpan < nSpanMax + 1; iSpan++){
         delete [] TurboVelocityIn[iMarker][iSpan];
       }
       delete [] TurboVelocityIn[iMarker];
@@ -1208,7 +1229,7 @@ CEulerSolver::~CEulerSolver(void) {
 
   if(TurboVelocityOut !=NULL){
     for (iMarker = 0; iMarker < nMarkerTurboPerf; iMarker++){
-      for (iSpan = 0; iSpan < nSpanWiseSections + 1; iSpan++){
+      for (iSpan = 0; iSpan < nSpanMax + 1; iSpan++){
         delete [] TurboVelocityOut[iMarker][iSpan];
       }
       delete [] TurboVelocityOut[iMarker];
@@ -1307,7 +1328,7 @@ CEulerSolver::~CEulerSolver(void) {
 
 void CEulerSolver::InitTurboContainers(CGeometry *geometry, CConfig *config){
   unsigned short iMarker, iSpan, iDim, iVar;
-  unsigned short nSpanMax    = config->GetnSpanMaxAllZones();
+  nSpanMax    = config->GetnSpanMaxAllZones();
 
 
   /*--- Initialize quantities for the average process for internal flow ---*/

--- a/SU2_CFD/src/solver_direct_mean.cpp
+++ b/SU2_CFD/src/solver_direct_mean.cpp
@@ -118,13 +118,16 @@ CEulerSolver::CEulerSolver(void) : CSolver() {
   
   AverageVelocity            = NULL;
   AverageTurboVelocity       = NULL;
+  OldAverageTurboVelocity    = NULL;
   ExtAverageTurboVelocity    = NULL;
   AverageFlux                = NULL;
   SpanTotalFlux              = NULL;
   AveragePressure            = NULL;
+  OldAveragePressure         = NULL;
   RadialEquilibriumPressure  = NULL;
   ExtAveragePressure         = NULL;
   AverageDensity             = NULL;
+  OldAverageDensity          = NULL;
   ExtAverageDensity          = NULL;
   AverageNu                  = NULL;
   AverageKine                = NULL;
@@ -293,13 +296,16 @@ CEulerSolver::CEulerSolver(CGeometry *geometry, CConfig *config, unsigned short 
 
   AverageVelocity                   = NULL;
   AverageTurboVelocity              = NULL;
+  OldAverageTurboVelocity           = NULL;
   ExtAverageTurboVelocity           = NULL;
   AverageFlux                       = NULL;
   SpanTotalFlux                     = NULL;
   AveragePressure                   = NULL;
+  OldAveragePressure                = NULL;
   RadialEquilibriumPressure         = NULL;
   ExtAveragePressure                = NULL;
   AverageDensity                    = NULL;
+  OldAverageDensity                 = NULL;
   ExtAverageDensity                 = NULL;
   AverageNu                         = NULL;
   AverageKine                       = NULL;
@@ -1102,7 +1108,7 @@ CEulerSolver::~CEulerSolver(void) {
     delete [] AverageTurboVelocity;
   }
 
-  if(OldAverageTurboVelocity !=NULL){
+  if(OldAverageTurboVelocity != NULL){
     for (iMarker = 0; iMarker < nMarker; iMarker++) {
       for(iSpan = 0; iSpan < nSpanWiseSections + 1; iSpan++)
         delete [] OldAverageTurboVelocity[iMarker][iSpan];
@@ -15034,13 +15040,16 @@ CNSSolver::CNSSolver(CGeometry *geometry, CConfig *config, unsigned short iMesh)
 
   AverageVelocity 				    = NULL;
   AverageTurboVelocity 				= NULL;
+  OldAverageTurboVelocity           = NULL;
   ExtAverageTurboVelocity 			= NULL;
   AverageFlux 						= NULL;
   SpanTotalFlux 					= NULL;
   AveragePressure  					= NULL;
+  OldAveragePressure                = NULL;
   RadialEquilibriumPressure         = NULL;
   ExtAveragePressure  				= NULL;
   AverageDensity   					= NULL;
+  OldAverageDensity                 = NULL;
   ExtAverageDensity   				= NULL;
   AverageNu                         = NULL;
   AverageKine                       = NULL;


### PR DESCRIPTION
I've noticed while using Valgrind that some of the recent pull requests have introduced a few memory issues.

Here's a summary of the changes in this PR:                                                                       

+ Sets default for `ilu_fill_in` to 0 to prevent uninitialized value bugs on destruction of `CSysMatrix`
+ Adds deallocation of some turbomachinery variables
+ Adds NULL initialization and deallocation of some of the new markers

I also found a memory issue in a weird corner case with `RefOriginMoment_X`, `_Y`, and `_Z`.  If the reference origin is defined exactly once, but no surfaces are marked for monitoring, then `RefOriginMoment_X` (and `_Y` and `_Z`) is set as an empty array.  I think that's a bug.  That bug creates problems in `CConfig::SetOutput`, (line 4284) where SU2 tries to print out the reference origin.