### PR TITLE
Feature internal channels

### DIFF
--- a/Common/include/config_structure.hpp
+++ b/Common/include/config_structure.hpp
@@ -515,7 +515,7 @@ private:
   Kind_DV_FEA;				/*!< \brief Kind of Design Variable for FEA problems.*/
   unsigned short Kind_Turb_Model;			/*!< \brief Turbulent model definition. */
   unsigned short Kind_Trans_Model,			/*!< \brief Transition model definition. */
-  Kind_ActDisk, Kind_Engine_Inflow, Kind_Inlet, *Kind_Inc_Inlet, *Kind_Data_Riemann, *Kind_Data_Giles;           /*!< \brief Kind of inlet boundary treatment. */
+  Kind_ActDisk, Kind_Engine_Inflow, Kind_Outlet, Kind_Inlet, *Kind_Inc_Inlet, *Kind_Data_Riemann, *Kind_Data_Giles;           /*!< \brief Kind of inlet boundary treatment. */
   unsigned short nInc_Inlet;  /*!< \brief Number of inlet boundary treatment types listed. */
   bool Inc_Inlet_UseNormal;    /*!< \brief Flag for whether to use the local normal as the flow direction for an incompressible pressure inlet. */
   su2double Linear_Solver_Error;		/*!< \brief Min error of the linear solver for the implicit formulation. */
@@ -4371,6 +4371,12 @@ public:
    * \return Kind of inlet boundary condition.
    */
   unsigned short GetKind_Inlet(void);
+  
+  /*!
+   * \brief Get the kind of outlet boundary condition treatment.
+   * \return Kind of outlet boundary condition.
+   */
+  unsigned short GetKind_Outlet(void);
   
   /*!
    * \brief Get the type of incompressible inlet from the list.

--- a/Common/include/config_structure.inl
+++ b/Common/include/config_structure.inl
@@ -1129,6 +1129,8 @@ inline unsigned short CConfig::GetKind_ConvNumScheme_Heat(void) {	return Kind_Co
 
 inline unsigned short CConfig::GetKind_Inlet(void) { return Kind_Inlet; }
 
+inline unsigned short CConfig::GetKind_Outlet(void) { return Kind_Outlet; }
+
 inline unsigned short CConfig::GetnInc_Inlet(void) { return nInc_Inlet;}
 
 inline bool CConfig::GetInc_Inlet_UseNormal(void) { return Inc_Inlet_UseNormal;}

--- a/Common/include/option_structure.hpp
+++ b/Common/include/option_structure.hpp
@@ -1161,14 +1161,27 @@ enum INLET_TYPE {
   MASS_FLOW = 2,           /*!< \brief User specifies density and velocity (mass flow). */
   INPUT_FILE = 3,           /*!< \brief User specifies an input file. */
   VELOCITY_INLET = 4,       /*!< \brief Velocity inlet for an incompressible flow. */
-  PRESSURE_INLET = 5        /*!< \brief Total pressure inlet for an incompressible flow. */
+  PRESSURE_INLET = 5,        /*!< \brief Total pressure inlet for an incompressible flow. */
+  SURFACE_OUTLET = 6              /*!< \brief Extract value from a surface. */
 };
 static const map<string, INLET_TYPE> Inlet_Map = CCreateMap<string, INLET_TYPE>
 ("TOTAL_CONDITIONS", TOTAL_CONDITIONS)
 ("MASS_FLOW", MASS_FLOW)
 ("INPUT_FILE", INPUT_FILE)
 ("VELOCITY_INLET", VELOCITY_INLET)
-("PRESSURE_INLET", PRESSURE_INLET);
+("PRESSURE_INLET", PRESSURE_INLET)
+("SURFACE_OUTLET", SURFACE_OUTLET);
+
+/*!
+ * \brief types outlet boundary treatments
+ */
+enum OUTLET_TYPE {
+  PRESSURE_OUTLET = 1,        /*!< \brief Total pressure inlet for an incompressible flow. */
+  SURFACE_INLET = 2              /*!< \brief Extract value from a surface. */
+};
+static const map<string, OUTLET_TYPE> Outlet_Map = CCreateMap<string, OUTLET_TYPE>
+("PRESSURE_OUTLET", PRESSURE_OUTLET)
+("SURFACE_INLET", SURFACE_INLET);
 
 /*!
  * \brief types engine inflow boundary treatments

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -915,6 +915,9 @@ void CConfig::SetConfig_Options(unsigned short val_iZone, unsigned short val_nZo
   /*!\brief INLET_TYPE  \n DESCRIPTION: Inlet boundary type \n OPTIONS: see \link Inlet_Map \endlink \n DEFAULT: TOTAL_CONDITIONS \ingroup Config*/
   addEnumOption("INLET_TYPE", Kind_Inlet, Inlet_Map, TOTAL_CONDITIONS);
 
+  /*!\brief OUTLET_TYPE  \n DESCRIPTION: Outlet boundary type \n OPTIONS: see \link Outl;et_Map \endlink \n DEFAULT: PRESSURE_OUTLET \ingroup Config*/
+  addEnumOption("OUTLET_TYPE", Kind_Outlet, Outlet_Map, PRESSURE_OUTLET);
+
   /*!\brief MARKER_INLET  \n DESCRIPTION: Inlet boundary marker(s) with the following formats,
    Total Conditions: (inlet marker, total temp, total pressure, flow_direction_x,
    flow_direction_y, flow_direction_z, ... ) where flow_direction is

--- a/SU2_CFD/src/output_structure.cpp
+++ b/SU2_CFD/src/output_structure.cpp
@@ -4557,7 +4557,7 @@ void COutput::SetConvHistory_Body(ofstream *ConvHist_file,
 
     /*--- We need to evaluate some of the objective functions to write the value on the history file ---*/
     
-    if (((iExtIter % (config[val_iZone]->GetWrt_Sol_Freq())) == 0) ||
+    if (((iExtIter % (config[val_iZone]->GetWrt_Sol_Freq()/10)) == 0) ||
         ((!config[val_iZone]->GetFixed_CL_Mode()) && (iExtIter == (config[val_iZone]->GetnExtIter()-1))) ||
         /*--- If CL mode we need to compute the complete solution at two very particular iterations ---*/
         ((config[val_iZone]->GetFixed_CL_Mode()) && (iExtIter == (config[val_iZone]->GetnExtIter()-2))) ||
@@ -4575,13 +4575,6 @@ void COutput::SetConvHistory_Body(ofstream *ConvHist_file,
           if (config[val_iZone]->GetnMarker_Analyze() != 0) {
             SpecialOutput_AnalyzeSurface(solver_container[val_iZone][MESH_0][FLOW_SOL],
                                          geometry[val_iZone][MESH_0], config[ZONE_0], output_files);
-          }
-
-          /*--- For specific applications, evaluate and plot the surface. ---*/
-
-          if (config[val_iZone]->GetnMarker_Analyze() != 0) {
-            SpecialOutput_Distortion(solver_container[val_iZone][MESH_0][FLOW_SOL],
-                                     geometry[val_iZone][MESH_0], config[ZONE_0], output_files);
           }
 
           /*--- For specific applications, evaluate and plot the surface. ---*/

--- a/SU2_IDE/Xcode/SU2_CFD.xcodeproj/xcuserdata/fpalacios.xcuserdatad/xcschemes/SU2_CFD.xcscheme
+++ b/SU2_IDE/Xcode/SU2_CFD.xcodeproj/xcuserdata/fpalacios.xcuserdatad/xcschemes/SU2_CFD.xcscheme
@@ -49,7 +49,7 @@
       language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "YES"
-      customWorkingDirectory = "/Users/fpalacios/Desktop/naca0012"
+      customWorkingDirectory = "/Users/fpalacios/TestCases/rans/channel"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
@@ -66,7 +66,7 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "inv_NACA0012.cfg"
+            argument = "propeller.cfg"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/SU2_IDE/Xcode/SU2_CFD.xcodeproj/xcuserdata/fpalacios.xcuserdatad/xcschemes/SU2_CFD.xcscheme
+++ b/SU2_IDE/Xcode/SU2_CFD.xcodeproj/xcuserdata/fpalacios.xcuserdatad/xcschemes/SU2_CFD.xcscheme
@@ -49,7 +49,7 @@
       language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "YES"
-      customWorkingDirectory = "/Users/fpalacios/TestCases/rans/channel"
+      customWorkingDirectory = "/Users/fpalacios/Desktop/naca0012"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
@@ -66,7 +66,7 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "propeller.cfg"
+            argument = "inv_NACA0012.cfg"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -518,7 +518,7 @@ MARKER_NEARFIELD= ( NONE )
 % Zone interface boundary marker(s) (NONE = no marker)
 MARKER_INTERFACE= ( NONE )
 %
-% Inlet boundary type (TOTAL_CONDITIONS, MASS_FLOW)
+% Inlet boundary type (TOTAL_CONDITIONS, MASS_FLOW, SURFACE_OUTLET)
 INLET_TYPE= TOTAL_CONDITIONS
 %
 % Inlet boundary marker(s) with the following formats (NONE = no marker)
@@ -532,6 +532,9 @@ INLET_TYPE= TOTAL_CONDITIONS
 %           flow_direction_y, flow_direction_z, ... ) where flow_direction is
 %           a unit vector.
 MARKER_INLET= ( NONE )
+%
+% Outlet boundary type (PRESSURE_OUTLET, SURFACE_INLET)
+OUTLET_TYPE= PRESSURE_OUTLET
 %
 % Outlet boundary marker(s) (NONE = no marker)
 % Format: ( outlet marker, back pressure (static), ... )


### PR DESCRIPTION
## Proposed Changes
This implementation allows the connection of an inlet surface with an outlet surface (e.g. to simulate internal channels inside a model). In order to do so, it has been necessary to create an option OUTLET_TYPE that will be used in the future (e.g. to add a mass flow driver for the outlet - currently only static pressure is implemented - ).

To sum up, to connect an inlet with an outlet you should type the following:

% Inlet boundary type (TOTAL_CONDITIONS, MASS_FLOW, SURFACE_OUTLET)
 INLET_TYPE= SURFACE_OUTLET
% Outlet boundary type (PRESSURE_OUTLET, SURFACE_INLET)
OUTLET_TYPE= SURFACE_INLET

In the future, we should be able to specify pressure losses inside the "pipe" that connect the surfaces.
 
## Related Work
This is a new implementation that solves passive flow control problems where we are not interested in creating a complicated mesh inside the main volume to define the internal channels/pipes.


## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [X] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
