### PR TITLE
Restarted FGMRES was running to max iters instead of restart frequency.

### DIFF
--- a/Common/src/linear_solvers_structure.cpp
+++ b/Common/src/linear_solvers_structure.cpp
@@ -589,7 +589,7 @@ unsigned long CSysSolve::BCGSTAB_LinSolver(const CSysVector & b, CSysVector & x,
 
 unsigned long CSysSolve::Solve(CSysMatrix & Jacobian, CSysVector & LinSysRes, CSysVector & LinSysSol, CGeometry *geometry, CConfig *config) {
   
-  su2double SolverTol = config->GetLinear_Solver_Error(), Residual;
+  su2double SolverTol = config->GetLinear_Solver_Error(), Residual, Norm0;
   unsigned long MaxIter = config->GetLinear_Solver_Iter();
   unsigned long IterLinSol = 0;
   CMatrixVectorProduct *mat_vec;
@@ -654,12 +654,12 @@ unsigned long CSysSolve::Solve(CSysMatrix & Jacobian, CSysVector & LinSysRes, CS
         break;
       case RESTARTED_FGMRES:
         IterLinSol = 0;
+        Norm0 = LinSysRes.norm();
         while (IterLinSol < config->GetLinear_Solver_Iter()) {
-          if (IterLinSol + config->GetLinear_Solver_Restart_Frequency() > config->GetLinear_Solver_Iter())
-            MaxIter = config->GetLinear_Solver_Iter() - IterLinSol;
+          /*--- Enforce a hard limit on total number of iterations ---*/
+          MaxIter = min(config->GetLinear_Solver_Restart_Frequency(), config->GetLinear_Solver_Iter()-IterLinSol);
           IterLinSol += FGMRES_LinSolver(LinSysRes, LinSysSol, *mat_vec, *precond, SolverTol, MaxIter, &Residual, false);
-          if (LinSysRes.norm() < SolverTol) break;
-          SolverTol = SolverTol*(1.0/LinSysRes.norm());
+          if ( Residual < SolverTol*Norm0 ) break;
         }
         break;
     }


### PR DESCRIPTION
## Proposed Changes
Restarted FGMRES was running to "LINEAR_SOLVER_ITER" once, instead of running to "LINEAR_SOLVER_RESTART_FREQUENCY" multiple times.


## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [X] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
