### PR TITLE
Bug fix for inlet profiles when two adjacent inlets share a vertex.

### DIFF
--- a/SU2_CFD/include/solver_structure.hpp
+++ b/SU2_CFD/include/solver_structure.hpp
@@ -2866,6 +2866,7 @@ public:
   virtual su2double GetInletAtVertex(su2double *val_inlet,
                                      unsigned long val_inlet_point,
                                      unsigned short val_kind_marker,
+                                     string val_marker,
                                      CGeometry *geometry,
                                      CConfig *config);
 
@@ -6313,6 +6314,7 @@ public:
   su2double GetInletAtVertex(su2double *val_inlet,
                              unsigned long val_inlet_point,
                              unsigned short val_kind_marker,
+                             string val_marker,
                              CGeometry *geometry,
                              CConfig *config);
 
@@ -8172,6 +8174,7 @@ public:
   su2double GetInletAtVertex(su2double *val_inlet,
                              unsigned long val_inlet_point,
                              unsigned short val_kind_marker,
+                             string val_marker,
                              CGeometry *geometry,
                              CConfig *config);
 
@@ -9594,6 +9597,7 @@ public:
   su2double GetInletAtVertex(su2double *val_inlet,
                              unsigned long val_inlet_point,
                              unsigned short val_kind_marker,
+                             string val_marker,
                              CGeometry *geometry,
                              CConfig *config);
 
@@ -9830,6 +9834,7 @@ public:
   su2double GetInletAtVertex(su2double *val_inlet,
                              unsigned long val_inlet_point,
                              unsigned short val_kind_marker,
+                             string val_marker,
                              CGeometry *geometry,
                              CConfig *config);
   /*!

--- a/SU2_CFD/include/solver_structure.inl
+++ b/SU2_CFD/include/solver_structure.inl
@@ -552,7 +552,7 @@ inline void CSolver::SetUniformInlet(CConfig* config, unsigned short iMarker) {}
 
 inline void CSolver::SetInletAtVertex(su2double *val_inlet, unsigned short iMarker, unsigned long iVertex) { };
 
-inline su2double CSolver::GetInletAtVertex(su2double *val_inlet, unsigned long val_inlet_point, unsigned short val_kind_marker, CGeometry *geometry, CConfig *config) { return 0; }
+inline su2double CSolver::GetInletAtVertex(su2double *val_inlet, unsigned long val_inlet_point, unsigned short val_kind_marker, string val_marker, CGeometry *geometry, CConfig *config) { return 0; }
 
 inline void CSolver::UpdateCustomBoundaryConditions(CGeometry **geometry_container, CConfig *config) { }
 

--- a/SU2_CFD/src/solver_direct_mean.cpp
+++ b/SU2_CFD/src/solver_direct_mean.cpp
@@ -8693,6 +8693,7 @@ void CEulerSolver::SetInletAtVertex(su2double *val_inlet,
 su2double CEulerSolver::GetInletAtVertex(su2double *val_inlet,
                                          unsigned long val_inlet_point,
                                          unsigned short val_kind_marker,
+                                         string val_marker,
                                          CGeometry *geometry,
                                          CConfig *config) {
   
@@ -8712,7 +8713,8 @@ su2double CEulerSolver::GetInletAtVertex(su2double *val_inlet,
   if (val_kind_marker == INLET_FLOW) {
     
     for (iMarker = 0; iMarker < config->GetnMarker_All(); iMarker++) {
-      if (config->GetMarker_All_KindBC(iMarker) == INLET_FLOW) {
+      if ((config->GetMarker_All_KindBC(iMarker) == INLET_FLOW) &&
+          (config->GetMarker_All_TagBound(iMarker) == val_marker)) {
         
         for (iVertex = 0; iVertex < nVertex[iMarker]; iVertex++){
           

--- a/SU2_CFD/src/solver_direct_mean_inc.cpp
+++ b/SU2_CFD/src/solver_direct_mean_inc.cpp
@@ -4898,6 +4898,7 @@ void CIncEulerSolver::SetInletAtVertex(su2double *val_inlet,
 su2double CIncEulerSolver::GetInletAtVertex(su2double *val_inlet,
                                             unsigned long val_inlet_point,
                                             unsigned short val_kind_marker,
+                                            string val_marker,
                                             CGeometry *geometry,
                                             CConfig *config) {
   
@@ -4917,7 +4918,8 @@ su2double CIncEulerSolver::GetInletAtVertex(su2double *val_inlet,
   if (val_kind_marker == INLET_FLOW) {
     
     for (iMarker = 0; iMarker < config->GetnMarker_All(); iMarker++) {
-      if (config->GetMarker_All_KindBC(iMarker) == INLET_FLOW) {
+      if ((config->GetMarker_All_KindBC(iMarker) == INLET_FLOW) &&
+          (config->GetMarker_All_TagBound(iMarker) == val_marker)) {
         
         for (iVertex = 0; iVertex < nVertex[iMarker]; iVertex++){
           

--- a/SU2_CFD/src/solver_direct_turbulent.cpp
+++ b/SU2_CFD/src/solver_direct_turbulent.cpp
@@ -3493,6 +3493,7 @@ void CTurbSASolver::SetInletAtVertex(su2double *val_inlet,
 su2double CTurbSASolver::GetInletAtVertex(su2double *val_inlet,
                                           unsigned long val_inlet_point,
                                           unsigned short val_kind_marker,
+                                          string val_marker,
                                           CGeometry *geometry,
                                           CConfig *config) {
 
@@ -3510,7 +3511,9 @@ su2double CTurbSASolver::GetInletAtVertex(su2double *val_inlet,
     unsigned short position = nDim+2+nDim;
 
     for (iMarker = 0; iMarker < config->GetnMarker_All(); iMarker++) {
-      if (config->GetMarker_All_KindBC(iMarker) == INLET_FLOW) {
+      if ((config->GetMarker_All_KindBC(iMarker) == INLET_FLOW) &&
+          (config->GetMarker_All_TagBound(iMarker) == val_marker)) {
+        
         for (iVertex = 0; iVertex < nVertex[iMarker]; iVertex++){
 
           iPoint = geometry->vertex[iMarker][iVertex]->GetNode();
@@ -4671,6 +4674,7 @@ void CTurbSSTSolver::SetInletAtVertex(su2double *val_inlet,
 su2double CTurbSSTSolver::GetInletAtVertex(su2double *val_inlet,
                                            unsigned long val_inlet_point,
                                            unsigned short val_kind_marker,
+                                           string val_marker,
                                            CGeometry *geometry,
                                            CConfig *config) {
 
@@ -4689,7 +4693,9 @@ su2double CTurbSSTSolver::GetInletAtVertex(su2double *val_inlet,
     unsigned short omega_position = nDim+2+nDim+1;
 
     for (iMarker = 0; iMarker < config->GetnMarker_All(); iMarker++) {
-      if (config->GetMarker_All_KindBC(iMarker) == INLET_FLOW) {
+      if ((config->GetMarker_All_KindBC(iMarker) == INLET_FLOW) &&
+          (config->GetMarker_All_TagBound(iMarker) == val_marker)) {
+        
         for (iVertex = 0; iVertex < nVertex[iMarker]; iVertex++){
 
           iPoint = geometry->vertex[iMarker][iVertex]->GetNode();

--- a/SU2_CFD/src/solver_structure.cpp
+++ b/SU2_CFD/src/solver_structure.cpp
@@ -3339,6 +3339,8 @@ void CSolver::LoadInletProfile(CGeometry **geometry,
       for (iMarker=0; iMarker < config->GetnMarker_All(); iMarker++) {
         if (config->GetMarker_All_KindBC(iMarker) == KIND_MARKER) {
 
+          Marker_Tag = config->GetMarker_All_TagBound(iMarker);
+          
           /*--- Loop through the nodes on this marker. ---*/
 
           for (iVertex = 0; iVertex < geometry[iMesh]->nVertex[iMarker]; iVertex++) {
@@ -3365,7 +3367,7 @@ void CSolver::LoadInletProfile(CGeometry **geometry,
             for (iChildren = 0; iChildren < geometry[iMesh]->node[iPoint]->GetnChildren_CV(); iChildren++) {
               Point_Fine = geometry[iMesh]->node[iPoint]->GetChildren_CV(iChildren);
               for (iVar = 0; iVar < maxCol_InletFile; iVar++) Inlet_Fine[iVar] = 0.0;
-              Area_Children = solver[iMesh-1][KIND_SOLVER]->GetInletAtVertex(Inlet_Fine, Point_Fine, KIND_MARKER, geometry[iMesh-1], config);
+              Area_Children = solver[iMesh-1][KIND_SOLVER]->GetInletAtVertex(Inlet_Fine, Point_Fine, KIND_MARKER, Marker_Tag, geometry[iMesh-1], config);
               for (iVar = 0; iVar < maxCol_InletFile; iVar++) {
                 Inlet_Values[iVar] += Inlet_Fine[iVar]*Area_Children/Area_Parent;
               }


### PR DESCRIPTION
## Proposed Changes
*Give a brief overview of your contribution here in a few sentences.*
 
Fixes a bug causing inlet profiles to fail when two adjacent inlets that share a vertex are prescribed with different values by file (especially with MG). Fixed by adding an explicit check on the marker tag for a match.

## Related Work
*Resolve any issues (bug fix or feature request), note any related PRs, or mention interactions with the work of others, if any.*

N/A

## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [X] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
