### PR TITLE
Fix linear elasticity discrete adjoint

### DIFF
--- a/SU2_CFD/include/numerics_structure.hpp
+++ b/SU2_CFD/include/numerics_structure.hpp
@@ -4027,8 +4027,7 @@ public:
 
   void Compute_Tangent_Matrix(CElement *element_container, CConfig *config);
 
-  void Compute_Constitutive_Matrix(void);
-  using CNumerics::Compute_Constitutive_Matrix;
+  void Compute_Constitutive_Matrix(CElement *element_container, CConfig *config);
 
   void Compute_Averaged_NodalStress(CElement *element_container, CConfig *config);
 

--- a/SU2_CFD/src/integration_structure.cpp
+++ b/SU2_CFD/src/integration_structure.cpp
@@ -220,6 +220,7 @@ void CIntegration::Space_Integration_FEM(CGeometry *geometry,
     bool initial_calc = (config->GetExtIter() == 0);                  // Checks if it is the first calculation.
     bool linear_analysis = (config->GetGeometricConditions() == SMALL_DEFORMATIONS);  // Linear analysis.
     bool first_iter = (config->GetIntIter() == 0);                  // Checks if it is the first iteration
+    bool dynamic = (config->GetDynamic_Analysis() == DYNAMIC);              // Dynamic simulations.
     unsigned short IterativeScheme = config->GetKind_SpaceIteScheme_FEA();       // Iterative schemes: NEWTON_RAPHSON, MODIFIED_NEWTON_RAPHSON
     unsigned short MainSolver = config->GetContainerPosition(RunTime_EqSystem);
 
@@ -232,7 +233,7 @@ void CIntegration::Space_Integration_FEM(CGeometry *geometry,
 
     /*--- If the analysis is linear, only a the constitutive term of the stiffness matrix has to be computed ---*/
     /*--- This is done only once, at the beginning of the calculation. From then on, K is constant ---*/
-    if ((linear_analysis && initial_calc) ||
+    if ((linear_analysis && (initial_calc || dynamic)) ||
       (linear_analysis && restart && initial_calc_restart)) {
       solver_container[MainSolver]->Compute_StiffMatrix(geometry, solver_container, numerics, config);
     }

--- a/SU2_CFD/src/iteration_structure.cpp
+++ b/SU2_CFD/src/iteration_structure.cpp
@@ -2654,6 +2654,12 @@ void CDiscAdjFEAIteration::SetDependencies(CSolver *****solver_container, CGeome
 
   unsigned short iVar;
   unsigned short iMPROP = config_container[iZone]->GetnElasticityMod();
+  
+  /*--- Some numerics are only instanciated under these conditions ---*/
+  bool element_based = (config_container[iZone]->GetGeometricConditions() == LARGE_DEFORMATIONS) &&
+                        solver_container[iZone][iInst][MESH_0][FEA_SOL]->IsElementBased(),
+       de_effects    = (config_container[iZone]->GetGeometricConditions() == LARGE_DEFORMATIONS) &&
+                        config_container[iZone]->GetDE_Effects();
 
   for (iVar = 0; iVar < iMPROP; iVar++){
 
@@ -2671,7 +2677,7 @@ void CDiscAdjFEAIteration::SetDependencies(CSolver *****solver_container, CGeome
 
       /*--- Add dependencies for element-based simulations. ---*/
 
-      if (solver_container[iZone][iInst][MESH_0][FEA_SOL]->IsElementBased()){
+      if (element_based){
 
           /*--- Neo Hookean Compressible ---*/
           numerics_container[iZone][iInst][MESH_0][FEA_SOL][MAT_NHCOMP]->SetMaterial_Properties(iVar,
@@ -2703,7 +2709,7 @@ void CDiscAdjFEAIteration::SetDependencies(CSolver *****solver_container, CGeome
 
   }
 
-  if (config_container[iZone]->GetDE_Effects()){
+  if (de_effects){
 
       unsigned short nEField = solver_container[iZone][iInst][MESH_0][ADJFEA_SOL]->GetnEField();
 
@@ -2736,14 +2742,14 @@ void CDiscAdjFEAIteration::SetDependencies(CSolver *****solver_container, CGeome
           numerics_container[iZone][iInst][MESH_0][FEA_SOL][FEA_TERM]->Set_DV_Val(iDV,
                                                                            solver_container[iZone][iInst][MESH_0][ADJFEA_SOL]->GetVal_DVFEA(iDV));
 
-          if (config_container[iZone]->GetDE_Effects()){
+          if (de_effects){
             numerics_container[iZone][iInst][MESH_0][FEA_SOL][DE_TERM]->Set_DV_Val(iDV,
                                                                             solver_container[iZone][iInst][MESH_0][ADJFEA_SOL]->GetVal_DVFEA(iDV));
           }
 
       }
 
-      if (solver_container[iZone][iInst][MESH_0][FEA_SOL]->IsElementBased()){
+      if (element_based){
 
         for (unsigned short iDV = 0; iDV < nDV; iDV++){
             numerics_container[iZone][iInst][MESH_0][FEA_SOL][MAT_NHCOMP]->Set_DV_Val(iDV,

--- a/SU2_CFD/src/numerics_direct_elasticity_linear.cpp
+++ b/SU2_CFD/src/numerics_direct_elasticity_linear.cpp
@@ -52,17 +52,6 @@ CFEALinearElasticity::CFEALinearElasticity(unsigned short val_nDim, unsigned sho
     for (iVar = 0; iVar < 8; iVar++) nodalDisplacement[iVar] = new su2double[nDim];
   }
 
-  /*--- Initialize values for the material model considered ---*/
-  E   = E_i[0];  Nu  = Nu_i[0];
-  Mu     = E / (2.0*(1.0 + Nu));
-  Lambda = Nu*E/((1.0+Nu)*(1.0-2.0*Nu));
-  Kappa  = Lambda + (2/3)*Mu;
-  /*-----------------------------------------------------------*/
-
-  /*--- If it is linear elasticity, D is constant along the calculations ---*/
-
-  Compute_Constitutive_Matrix();
-
 }
 
 CFEALinearElasticity::~CFEALinearElasticity(void) {
@@ -80,6 +69,11 @@ void CFEALinearElasticity::Compute_Tangent_Matrix(CElement *element, CConfig *co
   su2double Weight, Jac_X;
 
   su2double AuxMatrix[3][6];
+  
+  /*--- Set element properties and recompute the constitutive matrix, this is needed
+        for multiple material cases and for correct differentiation ---*/
+  SetElement_Properties(element, config);
+  Compute_Constitutive_Matrix(element, config);
 
   /*--- Initialize auxiliary matrices ---*/
 
@@ -191,7 +185,7 @@ void CFEALinearElasticity::Compute_Tangent_Matrix(CElement *element, CConfig *co
 }
 
 
-void CFEALinearElasticity::Compute_Constitutive_Matrix(void) {
+void CFEALinearElasticity::Compute_Constitutive_Matrix(CElement *element_container, CConfig *config) {
 
      /*--- Compute the D Matrix (for plane stress and 2-D)---*/
 
@@ -236,6 +230,11 @@ void CFEALinearElasticity::Compute_Averaged_NodalStress(CElement *element, CConf
 
   /*--- Auxiliary vector ---*/
   su2double Strain[6], Stress[6];
+  
+  /*--- Set element properties and recompute the constitutive matrix, this is needed
+        for multiple material cases and for correct differentiation ---*/
+  SetElement_Properties(element, config);
+  Compute_Constitutive_Matrix(element, config);
 
   /*--- Initialize auxiliary matrices ---*/
 

--- a/SU2_CFD/src/numerics_direct_elasticity_linear.cpp
+++ b/SU2_CFD/src/numerics_direct_elasticity_linear.cpp
@@ -68,7 +68,7 @@ void CFEALinearElasticity::Compute_Tangent_Matrix(CElement *element, CConfig *co
 
   su2double Weight, Jac_X;
 
-  su2double AuxMatrix[3][6];
+  su2double AuxMatrix[3][6], *res_aux = new su2double[nVar];
   
   /*--- Set element properties and recompute the constitutive matrix, this is needed
         for multiple material cases and for correct differentiation ---*/
@@ -182,6 +182,25 @@ void CFEALinearElasticity::Compute_Tangent_Matrix(CElement *element, CConfig *co
     }
 
   }
+  
+  // compute residual
+  for(iNode = 0; iNode<nNode; ++iNode)
+  {
+    for(jNode = 0; jNode<nNode; ++jNode)
+    {
+      su2double *Kab = element->Get_Kab(iNode,jNode);
+      
+      for (iVar = 0; iVar < nVar; iVar++) {
+          res_aux[iVar] = 0.0;
+          for (jVar = 0; jVar < nVar; jVar++)
+            res_aux[iVar] += Kab[iVar*nVar+jVar]*
+              (element->GetCurr_Coord(jNode,jVar)-element->GetRef_Coord(jNode,jVar));
+      }
+      element->Add_Kt_a(res_aux,iNode);
+    }
+  }
+  
+  delete[] res_aux;
 }
 
 


### PR DESCRIPTION
## Proposed Changes
The RHS is defined as the residual instead of the force vector, this is required because in Solve_b the adjoints of the Jacobian are tacitly assumed to be 0, this assumption is only valid if the solution of the primal linear system is 0 and that only happens when the RHS is 0 (e.g. the residual of a converged problem).
In a nutshell linear elasticity is now done like nonlinear, i.e. compute 'delta U' instead of 'U' (even if we only need one 'delta U' in the direct solver). This led to changes in how the RHS for time domain problems is computed (I would appreciate a second pair of eyes especially on those changes).
This fix also adds support for multiple materials in linear elasticity simulations.
I will add a regression test for this if the fix is found to be good.

## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [X] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
