### PR TITLE
Bugfix SU2_SOL segfault for multiple zones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ compiler:
 notifications:
     email:
         recipients:
-            - su2code-dev@lists.stanford.edu
+            - tobias.kattmann@de.bosch.com
   
 branches:
     only:
-        - develop
+        - fix_SU2SOL_segfault
 
 python:
     - 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ compiler:
 notifications:
     email:
         recipients:
-            - tobias.kattmann@de.bosch.com
+            - su2code-dev@lists.stanford.edu
   
 branches:
     only:
-        - fix_SU2SOL_segfault
+        - develop
 
 python:
     - 2.7

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -3642,7 +3642,7 @@ void CConfig::SetPostprocessing(unsigned short val_software, unsigned short val_
 
       if (Unst_AdjointIter- long(nExtIter) < 0){
         SU2_MPI::Error(string("Invalid iteration number requested for unsteady adjoint.\n" ) +
-                       string("Make sure EXT_ITER is larger or equal than UNST_ADJ_ITER."),
+                       string("Make sure EXT_ITER is larger or equal than UNST_ADJOINT_ITER."),
                        CURRENT_FUNCTION);
       }
 

--- a/SU2_CFD/src/solver_structure.cpp
+++ b/SU2_CFD/src/solver_structure.cpp
@@ -3936,6 +3936,7 @@ void CBaselineSolver::LoadRestart(CGeometry **geometry, CSolver ***solver, CConf
   bool adjoint = ( config->GetContinuous_Adjoint() || config->GetDiscrete_Adjoint() ); 
   unsigned short iZone = config->GetiZone();
   unsigned short nZone = config->GetnZone();
+  unsigned short iInst = config->GetiInst();
   bool grid_movement  = config->GetGrid_Movement();
   bool steady_restart = config->GetSteadyRestart();
   unsigned short turb_model = config->GetKind_Turb_Model();
@@ -3946,7 +3947,7 @@ void CBaselineSolver::LoadRestart(CGeometry **geometry, CSolver ***solver, CConf
 
   /*--- Skip coordinates ---*/
 
-  unsigned short skipVars = geometry[iZone]->GetnDim();
+  unsigned short skipVars = geometry[iInst]->GetnDim();
 
   /*--- Retrieve filename from config ---*/
 
@@ -3984,9 +3985,9 @@ void CBaselineSolver::LoadRestart(CGeometry **geometry, CSolver ***solver, CConf
   /*--- Read the restart data from either an ASCII or binary SU2 file. ---*/
 
   if (config->GetRead_Binary_Restart()) {
-    Read_SU2_Restart_Binary(geometry[iZone], config, filename);
+    Read_SU2_Restart_Binary(geometry[iInst], config, filename);
   } else {
-    Read_SU2_Restart_ASCII(geometry[iZone], config, filename);
+    Read_SU2_Restart_ASCII(geometry[iInst], config, filename);
   }
 
   int counter = 0;
@@ -3994,12 +3995,12 @@ void CBaselineSolver::LoadRestart(CGeometry **geometry, CSolver ***solver, CConf
 
   /*--- Load data from the restart into correct containers. ---*/
 
-  for (iPoint_Global = 0; iPoint_Global < geometry[iZone]->GetGlobal_nPointDomain(); iPoint_Global++ ) {
+  for (iPoint_Global = 0; iPoint_Global < geometry[iInst]->GetGlobal_nPointDomain(); iPoint_Global++ ) {
 
     /*--- Retrieve local index. If this node from the restart file lives
      on the current processor, we will load and instantiate the vars. ---*/
 
-    iPoint_Local = geometry[iZone]->GetGlobal_to_Local_Point(iPoint_Global);
+    iPoint_Local = geometry[iInst]->GetGlobal_to_Local_Point(iPoint_Global);
 
     if (iPoint_Local > -1) {
       
@@ -4041,8 +4042,8 @@ void CBaselineSolver::LoadRestart(CGeometry **geometry, CSolver ***solver, CConf
         }
 
         for (iDim = 0; iDim < nDim; iDim++) {
-          geometry[iZone]->node[iPoint_Local]->SetCoord(iDim, Coord[iDim]);
-          geometry[iZone]->node[iPoint_Local]->SetGridVel(iDim, GridVel[iDim]);
+          geometry[iInst]->node[iPoint_Local]->SetCoord(iDim, Coord[iDim]);
+          geometry[iInst]->node[iPoint_Local]->SetGridVel(iDim, GridVel[iDim]);
         }
       }
 
@@ -4054,7 +4055,7 @@ void CBaselineSolver::LoadRestart(CGeometry **geometry, CSolver ***solver, CConf
 
   /*--- MPI solution ---*/
   
-  Set_MPI_Solution(geometry[iZone], config);
+  Set_MPI_Solution(geometry[iInst], config);
   
   /*--- Update the geometry for flows on dynamic meshes ---*/
   
@@ -4062,8 +4063,8 @@ void CBaselineSolver::LoadRestart(CGeometry **geometry, CSolver ***solver, CConf
     
     /*--- Communicate the new coordinates and grid velocities at the halos ---*/
     
-    geometry[iZone]->Set_MPI_Coord(config);
-    geometry[iZone]->Set_MPI_GridVel(config);
+    geometry[iInst]->Set_MPI_Coord(config);
+    geometry[iInst]->Set_MPI_GridVel(config);
 
   }
   

--- a/SU2_SOL/src/SU2_SOL.cpp
+++ b/SU2_SOL/src/SU2_SOL.cpp
@@ -339,7 +339,7 @@ int main(int argc, char *argv[]) {
                   solver_container[iZone][INST_0] = new CBaselineSolver(geometry_container[iZone][INST_0], config_container[iZone]);
                   SolutionInstantiated[iZone] = true;
                 }
-                  solver_container[iZone][INST_0]->LoadRestart(&geometry_container[iZone][INST_0], &solver_container[iZone], config_container[iZone], SU2_TYPE::Int(MESH_0), true);
+                  solver_container[iZone][INST_0]->LoadRestart(geometry_container[iZone], &solver_container[iZone], config_container[iZone], SU2_TYPE::Int(MESH_0), true);
               }
 
               if (rank == MASTER_NODE)
@@ -364,7 +364,7 @@ int main(int argc, char *argv[]) {
 
           /*--- Either instantiate the solution class or load a restart file. ---*/
           solver_container[iZone][iInst] = new CBaselineSolver(geometry_container[iZone][iInst], config_container[iZone]);
-          solver_container[iZone][iInst]->LoadRestart(&geometry_container[iZone][iInst], &solver_container[iZone], config_container[iZone], SU2_TYPE::Int(MESH_0), true);
+          solver_container[iZone][iInst]->LoadRestart(geometry_container[iZone], &solver_container[iZone], config_container[iZone], SU2_TYPE::Int(MESH_0), true);
 
           /*--- Print progress in solution writing to the screen. ---*/
           if (rank == MASTER_NODE) {
@@ -424,7 +424,7 @@ int main(int argc, char *argv[]) {
                   solver_container[iZone][INST_0] = new CBaselineSolver(geometry_container[iZone][INST_0], config_container[iZone]);
                   SolutionInstantiated = true;
                 }
-                solver_container[iZone][INST_0]->LoadRestart(&geometry_container[iZone][INST_0], &solver_container[iZone], config_container[iZone], SU2_TYPE::Int(MESH_0), true);
+                solver_container[iZone][INST_0]->LoadRestart(geometry_container[iZone], &solver_container[iZone], config_container[iZone], SU2_TYPE::Int(MESH_0), true);
               }
 
               if (rank == MASTER_NODE)
@@ -445,7 +445,7 @@ int main(int argc, char *argv[]) {
       for (iZone = 0; iZone < nZone; iZone++) {
         /*--- Definition of the solution class ---*/
         solver_container[iZone][INST_0] = new CBaselineSolver(geometry_container[iZone][INST_0], config_container[iZone]);
-        solver_container[iZone][INST_0]->LoadRestart(&geometry_container[iZone][INST_0], &solver_container[iZone], config_container[iZone], SU2_TYPE::Int(MESH_0), true);
+        solver_container[iZone][INST_0]->LoadRestart(geometry_container[iZone], &solver_container[iZone], config_container[iZone], SU2_TYPE::Int(MESH_0), true);
       }
 
       output->SetBaselineResult_Files(solver_container, geometry_container, config_container, 0, nZone);

--- a/preconfigure.py
+++ b/preconfigure.py
@@ -67,6 +67,8 @@ def main():
                       help="Enable mpi support", dest="mpi_enabled", default=False)
     parser.add_option("--enable-PY_WRAPPER", action="store_true",
                       help="Enable Python wrapper compilation", dest="py_wrapper_enabled", default=False)
+    parser.add_option("--disable-tecio", action="store_true",
+                      help="Disable Tecplot binary support", dest="tecio_disabled", default=False)
     parser.add_option("--disable-normal", action="store_true",
                       help="Disable normal mode support", dest="normal_mode", default=False)
     parser.add_option("-c" , "--check", action="store_true",
@@ -118,6 +120,7 @@ def main():
                   conf_environ,
                   options.mpi_enabled,
                   options.py_wrapper_enabled,
+                  options.tecio_disabled,
                   modes,
                   made_adolc,
                   made_codi)
@@ -402,6 +405,7 @@ def configure(argument_dict,
               conf_environ,
               mpi_support,
               py_wrapper,
+              tecio,
               modes,
               made_adolc,
               made_codi):
@@ -418,6 +422,8 @@ def configure(argument_dict,
         configure_base = configure_base + ' --enable-mpi'
     if py_wrapper:
         configure_base = configure_base + ' --enable-PY_WRAPPER'
+    if tecio:
+        configure_base = configure_base + ' --disable-tecio'
 
     build_dirs = ''
 


### PR DESCRIPTION
## Proposed Changes
Hi all,
 
a wrong index (iZone vs iInst) caused the SU2_SOL module to segfault if nZone > nInst.  The geometry container is called with the wrong index in the `CBaseLineSolver::LoadRestart` routine. In SU2_SOL.cpp `&geometry_container[iZone][INST_0]` to `geometry_container[iZone]` are interchangeable, I just thought the 2nd formulation is used more often throughout the code. I cannot guarante though that it now runs for multiple instances, but as far as I know there is no such testcase.

Testcase: The PR does not come with a Testcase which would catch the error in the future. In testcases started with parallel_computation.py the SU2_SOL module is called and fails for multizone cases (e.g. Jones_rst.cfg which I tested on) but if the residuals fit the case passes. That circumstance is not tackled in this PR but I heard that this is a know issue. I briefly chatted with @rsanfer about that and I offer my help if this is approached. 

Additionally I fixed an error message to contain the correct config-option and added a --disable-tecio option to the preconfigure.py script as it is convenient for me as I build on compute nodes which cannot access the necessary X11 libraries and I couldn't get it to work with tecio enabled :(   

If there are comments or requests for changing s.th. let me know. 

Best Regards, Tobi

## Related Work
Please see issue https://github.com/su2code/SU2/issues/568 for more information. There the error is described more detailed there.

## PR Checklist

- [ X ] I am submitting my contribution to the develop branch.
- [ X ] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [ X ] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
