### PR TITLE
Feature error message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ compiler:
 notifications:
     email:
         recipients:
-            - su2code-dev@lists.stanford.edu
+            - e.t.a.vanderweide@utwente.nl
   
 branches:
     only:
-        - develop
+        - feature_error_message
 
 python:
     - 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Continous Integration setup for SU2.
 # Tests on the develop branch in both serial and parallel.
 
-dist: bionic
+dist: xenial
 sudo: required
 
 language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Continous Integration setup for SU2.
 # Tests on the develop branch in both serial and parallel.
 
-dist: xenial
+dist: trusty
 sudo: required
 
 language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Continous Integration setup for SU2.
 # Tests on the develop branch in both serial and parallel.
 
-dist: trusty
+dist: bionic
 sudo: required
 
 language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ compiler:
 notifications:
     email:
         recipients:
-            - e.t.a.vanderweide@utwente.nl
+            - su2code-dev@lists.stanford.edu
   
 branches:
     only:
-        - feature_error_message
+        - develop
 
 python:
     - 2.7

--- a/Common/include/mpi_structure.hpp
+++ b/Common/include/mpi_structure.hpp
@@ -92,11 +92,14 @@ public:
   typedef MPI_Datatype Datatype;
   typedef MPI_Op       Op;
   typedef MPI_Comm     Comm;
+  typedef MPI_Win      Win;
   
 protected:
   
-  static int Rank, Size;
+  static int Rank, Size, MinRankError;
   static Comm currentComm;
+  static bool winMinRankErrorInUse;
+  static Win  winMinRankError;
   
 public:
   

--- a/Common/include/mpi_structure.hpp
+++ b/Common/include/mpi_structure.hpp
@@ -45,6 +45,7 @@
 
 #include "./datatype_structure.hpp"
 #include <stdlib.h>
+#include <unistd.h>
 
 #ifdef HAVE_MPI
 

--- a/Common/include/mpi_structure.inl
+++ b/Common/include/mpi_structure.inl
@@ -64,6 +64,12 @@ inline void CBaseMPIWrapper::SetComm(Comm newComm){
   currentComm = newComm;
   MPI_Comm_rank(currentComm, &Rank);  
   MPI_Comm_size(currentComm, &Size);
+
+  if( winMinRankErrorInUse ) MPI_Win_free(&winMinRankError);
+  MinRankError = Size;
+  MPI_Win_create(&MinRankError, sizeof(int), sizeof(int), MPI_INFO_NULL,
+                 currentComm, &winMinRankError);
+  winMinRankErrorInUse = true;
 }
 
 inline CBaseMPIWrapper::Comm CBaseMPIWrapper::GetComm(){
@@ -74,6 +80,11 @@ inline void CBaseMPIWrapper::Init(int *argc, char ***argv) {
   MPI_Init(argc,argv);
   MPI_Comm_rank(currentComm, &Rank);    
   MPI_Comm_size(currentComm, &Size);  
+
+  MinRankError = Size;
+  MPI_Win_create(&MinRankError, sizeof(int), sizeof(int), MPI_INFO_NULL,
+                 currentComm, &winMinRankError);
+  winMinRankErrorInUse = true;
 }
 
 inline void CBaseMPIWrapper::Buffer_attach(void *buffer, int size){
@@ -93,6 +104,7 @@ inline void CBaseMPIWrapper::Comm_size(Comm comm, int *size){
 }
 
 inline void CBaseMPIWrapper::Finalize(){
+  if( winMinRankErrorInUse ) MPI_Win_free(&winMinRankError);
   MPI_Finalize();
 }
 
@@ -208,12 +220,23 @@ inline void CMediMPIWrapper::Init(int *argc, char ***argv) {
   MediTool::init();
   AMPI_Comm_rank(convertComm(currentComm), &Rank);    
   AMPI_Comm_size(convertComm(currentComm), &Size);  
+
+  MinRankError = Size;
+  MPI_Win_create(&MinRankError, sizeof(int), sizeof(int), MPI_INFO_NULL,
+                 currentComm, &winMinRankError);
+  winMinRankErrorInUse = true;
 }
 
 inline void CMediMPIWrapper::SetComm(Comm newComm){
   currentComm = newComm;
   AMPI_Comm_rank(convertComm(currentComm), &Rank);  
   AMPI_Comm_size(convertComm(currentComm), &Size);
+
+  if( winMinRankErrorInUse ) MPI_Win_free(&winMinRankError);
+  MinRankError = Size;
+  MPI_Win_create(&MinRankError, sizeof(int), sizeof(int), MPI_INFO_NULL,
+                 currentComm, &winMinRankError);
+  winMinRankErrorInUse = true;
 }
 
 inline AMPI_Comm CMediMPIWrapper::convertComm(MPI_Comm comm) {
@@ -281,6 +304,7 @@ inline void CMediMPIWrapper::Comm_size(Comm comm, int *size){
 }
 
 inline void CMediMPIWrapper::Finalize(){
+  if( winMinRankErrorInUse ) MPI_Win_free(&winMinRankError);
   AMPI_Finalize();
 }
 

--- a/Common/include/mpi_structure.inl
+++ b/Common/include/mpi_structure.inl
@@ -43,15 +43,14 @@ inline void CBaseMPIWrapper::Error(std::string ErrorMsg, std::string FunctionNam
 
   /* Set MinRankError to Rank, as the error message is called on this rank. */
   MinRankError = Rank;
+  int flag = 0;
 
+#ifdef HAVE_MPI_NB_COLLECTIVE
   /* Find out whether the error call is collective via MPI_Ibarrier. */
   Request barrierRequest;
   MPI_Ibarrier(currentComm, &barrierRequest);
 
   /* Try to complete the non-blocking barrier call for half a second. */
-  int flag = 0;
-
-#ifdef HAVE_NB_COL
   double startTime = MPI_Wtime();
   while( true ) {
 

--- a/Common/include/mpi_structure.inl
+++ b/Common/include/mpi_structure.inl
@@ -49,8 +49,10 @@ inline void CBaseMPIWrapper::Error(std::string ErrorMsg, std::string FunctionNam
   MPI_Ibarrier(currentComm, &barrierRequest);
 
   /* Try to complete the non-blocking barrier call for half a second. */
+  int flag = 0;
+
+#ifdef HAVE_NB_COL
   double startTime = MPI_Wtime();
-  int flag;
   while( true ) {
 
     MPI_Test(&barrierRequest, &flag, MPI_STATUS_IGNORE);
@@ -59,6 +61,9 @@ inline void CBaseMPIWrapper::Error(std::string ErrorMsg, std::string FunctionNam
     double currentTime = MPI_Wtime();
     if(currentTime > startTime + 0.5) break;
   }
+#else
+  sleep(1);
+#endif
 
   if( flag ) {
     /* The barrier is completed and hence the error call is collective.

--- a/Common/include/mpi_structure.inl
+++ b/Common/include/mpi_structure.inl
@@ -45,12 +45,12 @@ inline void CBaseMPIWrapper::Error(std::string ErrorMsg, std::string FunctionNam
   MinRankError = Rank;
   int flag = 0;
 
-#ifdef HAVE_MPI_NB_COLLECTIVE
+#if MPI_VERSION >= 3
   /* Find out whether the error call is collective via MPI_Ibarrier. */
   Request barrierRequest;
   MPI_Ibarrier(currentComm, &barrierRequest);
 
-  /* Try to complete the non-blocking barrier call for half a second. */
+  /* Try to complete the non-blocking barrier call for a second. */
   double startTime = MPI_Wtime();
   while( true ) {
 
@@ -58,9 +58,11 @@ inline void CBaseMPIWrapper::Error(std::string ErrorMsg, std::string FunctionNam
     if( flag ) break;
 
     double currentTime = MPI_Wtime();
-    if(currentTime > startTime + 0.5) break;
+    if(currentTime > startTime + 1.0) break;
   }
 #else
+  /* MPI_Ibarrier function is not supported. Simply wait for one
+     second to give other ranks the opportunity to reach this point. */
   sleep(1);
 #endif
 

--- a/Common/src/mpi_structure.cpp
+++ b/Common/src/mpi_structure.cpp
@@ -42,6 +42,12 @@ int CBaseMPIWrapper::Size = 1;
 CBaseMPIWrapper::Comm CBaseMPIWrapper::currentComm = MPI_COMM_WORLD;
 
 #ifdef HAVE_MPI
+int  CBaseMPIWrapper::MinRankError;
+bool CBaseMPIWrapper::winMinRankErrorInUse = false;
+CBaseMPIWrapper::Win CBaseMPIWrapper::winMinRankError;
+#endif
+
+#ifdef HAVE_MPI
 #if defined CODI_REVERSE_TYPE || defined CODI_FORWARD_TYPE
 //AMPI_ADOUBLE_TYPE* AMPI_ADOUBLE;
 #include <medi/medi.cpp>


### PR DESCRIPTION
## Proposed Changes
This small PR modifies the error handling, such that the error message is also written when the call to the error handler is not collective. The function CBaseMPIWrapper::Error is not so small anymore, so it may be an idea to move it to the .cpp file instead of inlining it.
 
## Related Work
N/A



## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [ X] I am submitting my contribution to the develop branch.
- [ X] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [ X] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
