### PR TITLE
Change dynamic viscosity in FD hybrid central / upwind blending to kinematic viscosity

### DIFF
--- a/SU2_CFD/src/variable_direct_mean.cpp
+++ b/SU2_CFD/src/variable_direct_mean.cpp
@@ -677,7 +677,7 @@ void CNSVariable::SetRoe_Dissipation_FD(su2double val_wall_dist){
   
   static const su2double k2 = pow(0.41,2.0);
   
-  su2double uijuij = 0, r_d;
+  su2double uijuij = 0;
   unsigned short iDim, jDim;
   
   AD::StartPreacc();
@@ -697,7 +697,9 @@ void CNSVariable::SetRoe_Dissipation_FD(su2double val_wall_dist){
   uijuij=sqrt(fabs(uijuij));
   uijuij=max(uijuij,1e-10);
 
-  r_d = (GetEddyViscosity()+GetLaminarViscosity())/(uijuij*k2*pow(val_wall_dist, 2.0));
+  const su2double nu = GetLaminarViscosity()/GetDensity();
+  const su2double nu_t = GetEddyViscosity()/GetDensity();
+  const su2double r_d = (nu + nu_t)/(uijuij*k2*pow(val_wall_dist, 2.0));
   
   Roe_Dissipation = 1.0-tanh(pow(8.0*r_d,3.0));
   


### PR DESCRIPTION
## Proposed Changes
In both [the original paper on DDES](https://doi.org/10.1007/s00162-006-0015-0) and [the paper](https://doi.org/10.2514/6.2017-4284) by @EduardoMolina on hybrid RANS/LES in SU2, the calculation for `r_d` uses kinematic viscosity.  In SU2, the dynamic viscosity is currently used.  This leads to poor behavior if density is not close to 1.  This PR exchanges the dynamic viscosity for the kinematic viscosity.

## Related Work
This is part of the changes originally proposed in PR #552

## PR Checklist

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [x] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
