### PR TITLE
Fix NTS duplicate calc

### DIFF
--- a/Common/include/dual_grid_structure.hpp
+++ b/Common/include/dual_grid_structure.hpp
@@ -173,6 +173,7 @@ private:
   unsigned long GlobalIndex;          /*!< \brief Global index in the parallel simulation. */
   unsigned short nNeighbor;           /*!< \brief Number of neighbors. */
   bool Flip_Orientation;              /*!< \brief Flip the orientation of the normal. */
+  su2double MaxLength;                /*!< \brief The maximum cell-center to cell-center length. */
 
 public:
 	
@@ -402,6 +403,12 @@ public:
 	 */
 	su2double GetVolume(void);
 	
+	/*!
+	 * \brief Get the maximum cell-center to cell-center length.
+	 * \return The maximum cell-center to cell-center length.
+	 */
+	su2double GetMaxLength(void);
+
 	/*! 
 	 * \brief Get information about the movement of the node.
 	 * \return <code>TRUE</code> if the point is going to be moved; otherwise <code>FALSE</code>.
@@ -566,7 +573,13 @@ public:
 	 * \param[in] val_Volume - Value of the volume.
 	 */
 	void SetVolume(su2double val_Volume);
-	
+
+        /*!
+         * \brief Set the max cell-center to cell-center length.
+         * \param[in] val_max_length - Value of the max length
+         */
+        void SetMaxLength(su2double val_max_length);
+
 	/*! 
 	 * \brief Set if a element is going to be moved on the deformation process.
 	 * \param[in] val_move - true or false depending if the point will be moved.

--- a/Common/include/dual_grid_structure.hpp
+++ b/Common/include/dual_grid_structure.hpp
@@ -574,11 +574,11 @@ public:
 	 */
 	void SetVolume(su2double val_Volume);
 
-        /*!
-         * \brief Set the max cell-center to cell-center length.
-         * \param[in] val_max_length - Value of the max length
-         */
-        void SetMaxLength(su2double val_max_length);
+  /*!
+   * \brief Set the max cell-center to cell-center length.
+   * \param[in] val_max_length - Value of the max length
+   */
+  void SetMaxLength(su2double val_max_length);
 
 	/*! 
 	 * \brief Set if a element is going to be moved on the deformation process.

--- a/Common/include/dual_grid_structure.inl
+++ b/Common/include/dual_grid_structure.inl
@@ -80,6 +80,8 @@ inline unsigned long CPoint::GetPoint(unsigned short val_point) { return Point[v
 
 inline su2double CPoint::GetVolume (void) { return Volume[0]; }
 
+inline su2double CPoint::GetMaxLength(void) {return MaxLength;}
+
 inline bool CPoint::GetMove (void) { return Move; }
 
 inline bool CPoint::GetBoundary(void) { return Boundary; }
@@ -97,6 +99,8 @@ inline bool CPoint::GetSolidBoundary(void) { return SolidBoundary; }
 inline void CPoint::AddVolume (su2double val_Volume) { Volume[0] += val_Volume; }
 
 inline void CPoint::SetVolume (su2double val_Volume) { Volume[0] = val_Volume; }
+
+inline void CPoint::SetMaxLength(su2double val_max_length) { MaxLength = val_max_length; }
 
 inline void CPoint::SetMove(bool val_move) { Move = val_move; }
 

--- a/Common/include/geometry_structure.hpp
+++ b/Common/include/geometry_structure.hpp
@@ -492,6 +492,11 @@ public:
 
   /*!
    * \brief A virtual member.
+   */
+  virtual void SetMaxLength(void);
+
+  /*!
+   * \brief A virtual member.
    * \param[in] config - Definition of the particular problem.
    * \param[in] action - Allocate or not the new elements.
    */
@@ -1737,6 +1742,11 @@ void UpdateTurboVertex(CConfig *config,unsigned short val_iZone, unsigned short 
 	 * \param[in] action - Allocate or not the new elements.
 	 */
 	void SetBoundControlVolume(CConfig *config, unsigned short action);
+
+        /*!
+         * \brief Set the maximum cell-center to cell-center distance for CVs.
+         */
+        void SetMaxLength(void);
 
 	/*! 
 	 * \brief Set the Tecplot file.

--- a/Common/include/geometry_structure.hpp
+++ b/Common/include/geometry_structure.hpp
@@ -1743,10 +1743,10 @@ void UpdateTurboVertex(CConfig *config,unsigned short val_iZone, unsigned short 
 	 */
 	void SetBoundControlVolume(CConfig *config, unsigned short action);
 
-        /*!
-         * \brief Set the maximum cell-center to cell-center distance for CVs.
-         */
-        void SetMaxLength(void);
+  /*!
+   * \brief Set the maximum cell-center to cell-center distance for CVs.
+   */
+  void SetMaxLength(void);
 
 	/*! 
 	 * \brief Set the Tecplot file.

--- a/Common/include/geometry_structure.hpp
+++ b/Common/include/geometry_structure.hpp
@@ -492,8 +492,9 @@ public:
 
   /*!
    * \brief A virtual member.
+   * \param[in] config - Definition of the particular problem.
    */
-  virtual void SetMaxLength(void);
+  virtual void SetMaxLength(CConfig* config);
 
   /*!
    * \brief A virtual member.
@@ -743,6 +744,12 @@ public:
     * \param[in] config - Definition of the particular problem.
     */
   virtual void Set_MPI_OldCoord(CConfig *config);
+
+  /*!
+   * \brief A virtual member.
+   * \param[in] config - Definition of the particular problem.
+   */
+  virtual void Set_MPI_MaxLength(CConfig *config);
 
 	/*!
 	 * \brief A virtual member.
@@ -1745,8 +1752,9 @@ void UpdateTurboVertex(CConfig *config,unsigned short val_iZone, unsigned short 
 
   /*!
    * \brief Set the maximum cell-center to cell-center distance for CVs.
+   * \param[in] config - Definition of the particular problem.
    */
-  void SetMaxLength(void);
+  void SetMaxLength(CConfig* config);
 
 	/*! 
 	 * \brief Set the Tecplot file.
@@ -1832,6 +1840,12 @@ void UpdateTurboVertex(CConfig *config,unsigned short val_iZone, unsigned short 
    */
   void Set_MPI_OldCoord(CConfig *config);
   
+  /*!
+   * \brief Perform the MPI communication for the max grid spacing.
+   * \param[in] config - Definition of the particular problem.
+   */
+  void Set_MPI_MaxLength(CConfig *config);
+
   /*!
    * \brief Set the periodic boundary conditions.
    * \param[in] config - Definition of the particular problem.

--- a/Common/include/geometry_structure.inl
+++ b/Common/include/geometry_structure.inl
@@ -249,6 +249,8 @@ inline void CGeometry::SetVertex(CGeometry *fine_grid, CConfig *config) { }
 
 inline void CGeometry::SetCoord_CG(void) { }
 
+inline void CGeometry::SetMaxLength(void) { }
+
 inline void CGeometry::SetControlVolume(CConfig *config, unsigned short action) { }
 
 inline void CGeometry::SetControlVolume(CConfig *config, CGeometry *geometry, unsigned short action) { }

--- a/Common/include/geometry_structure.inl
+++ b/Common/include/geometry_structure.inl
@@ -105,6 +105,8 @@ inline void CGeometry::Set_MPI_GridVel(CConfig *config) { }
 
 inline void CGeometry::Set_MPI_OldCoord(CConfig *config) { } 
 
+inline void CGeometry::Set_MPI_MaxLength(CConfig *config) { }
+
 inline void CGeometry::SetPeriodicBoundary(CConfig *config) { }
 
 inline void CGeometry::SetPeriodicBoundary(CGeometry *geometry, CConfig *config) { }
@@ -249,7 +251,7 @@ inline void CGeometry::SetVertex(CGeometry *fine_grid, CConfig *config) { }
 
 inline void CGeometry::SetCoord_CG(void) { }
 
-inline void CGeometry::SetMaxLength(void) { }
+inline void CGeometry::SetMaxLength(CConfig* config) { }
 
 inline void CGeometry::SetControlVolume(CConfig *config, unsigned short action) { }
 

--- a/Common/src/geometry_structure.cpp
+++ b/Common/src/geometry_structure.cpp
@@ -14972,8 +14972,8 @@ void CPhysicalGeometry::SetMaxLength(CConfig* config) {
      * then set the max using the AD datatype. ---*/
 
     passivedouble passive_max_delta=0;
-    unsigned short max_neighbor;
-    for (unsigned short iNeigh = 0;iNeigh < nNeigh; iNeigh++) {
+    unsigned short max_neighbor = 0;
+    for (unsigned short iNeigh = 0; iNeigh < nNeigh; iNeigh++) {
 
       /*-- Calculate the cell-center to cell-center length ---*/
 
@@ -14982,7 +14982,7 @@ void CPhysicalGeometry::SetMaxLength(CConfig* config) {
 
       passivedouble delta_aux = 0;
       for (unsigned short iDim = 0;iDim < nDim; iDim++){
-        delta_aux += pow((Coord_j[iDim]-Coord_i[iDim]), 2.);
+        delta_aux += pow(SU2_TYPE::GetValue(Coord_j[iDim])-SU2_TYPE::GetValue(Coord_i[iDim]), 2.);
       }
 
       /*--- Only keep the maximum length ---*/
@@ -17510,7 +17510,7 @@ void CPhysicalGeometry::Set_MPI_OldCoord(CConfig *config) {
 
 void CPhysicalGeometry::Set_MPI_MaxLength(CConfig *config) {
 
-  unsigned short iDim, iMarker, iPeriodic_Index, MarkerS, MarkerR;
+  unsigned short iMarker, MarkerS, MarkerR;
   unsigned long iVertex, iPoint, nVertexS, nVertexR, nBufferS, nBufferR;
   su2double *Buffer_Receive = NULL, *Buffer_Send = NULL;
 

--- a/Common/src/geometry_structure.cpp
+++ b/Common/src/geometry_structure.cpp
@@ -1381,6 +1381,7 @@ void CGeometry::UpdateGeometry(CGeometry **geometry_container, CConfig *config) 
   geometry_container[MESH_0]->SetCoord_CG();
   geometry_container[MESH_0]->SetControlVolume(config, UPDATE);
   geometry_container[MESH_0]->SetBoundControlVolume(config, UPDATE);
+  geometry_container[MESH_0]->SetMaxLength();
   
   for (iMesh = 1; iMesh <= config->GetnMGLevels(); iMesh++) {
     /*--- Update the control volume structures ---*/
@@ -14955,6 +14956,34 @@ void CPhysicalGeometry::SetBoundControlVolume(CConfig *config, unsigned short ac
       if (Area == 0.0) for (iDim = 0; iDim < nDim; iDim++) NormalFace[iDim] = EPS*EPS;
     }
   
+}
+
+void CPhysicalGeometry::SetMaxLength(void) {
+
+  for (unsigned long iPoint = 0; iPoint < nPointDomain; iPoint++){
+    const unsigned short nNeigh = node[iPoint]->GetnPoint();
+    const su2double* Coord_i = node[iPoint]->GetCoord();
+
+    su2double max_delta=0;
+    for (unsigned short iNeigh = 0;iNeigh < nNeigh; iNeigh++) {
+
+      /*-- Calculate the cell-center to cell-center length ---*/
+
+      const unsigned long jPoint  = node[iPoint]->GetPoint(iNeigh);
+      const su2double* Coord_j = node[jPoint]->GetCoord();
+
+      su2double delta_aux = 0;
+      for (unsigned short iDim = 0;iDim < nDim; iDim++){
+        delta_aux += pow((Coord_j[iDim]-Coord_i[iDim]), 2.);
+      }
+
+      /*--- Only keep the maximum length ---*/
+
+      max_delta = max(max_delta, sqrt(delta_aux));
+    }
+
+    node[iPoint]->SetMaxLength(max_delta);
+  }
 }
 
 void CPhysicalGeometry::MatchInterface(CConfig *config) {

--- a/Common/src/grid_movement_structure.cpp
+++ b/Common/src/grid_movement_structure.cpp
@@ -109,6 +109,7 @@ void CVolumetricMovement::UpdateDualGrid(CGeometry *geometry, CConfig *config) {
 	geometry->SetCoord_CG();
 	geometry->SetControlVolume(config, UPDATE);
 	geometry->SetBoundControlVolume(config, UPDATE);
+  geometry->SetMaxLength();
   
 }
 
@@ -9282,6 +9283,7 @@ void CElasticityMovement::UpdateDualGrid(CGeometry *geometry, CConfig *config){
   geometry->SetCoord_CG();
   geometry->SetControlVolume(config, UPDATE);
   geometry->SetBoundControlVolume(config, UPDATE);
+  geometry->SetMaxLength();
 
 }
 

--- a/Common/src/grid_movement_structure.cpp
+++ b/Common/src/grid_movement_structure.cpp
@@ -109,7 +109,7 @@ void CVolumetricMovement::UpdateDualGrid(CGeometry *geometry, CConfig *config) {
 	geometry->SetCoord_CG();
 	geometry->SetControlVolume(config, UPDATE);
 	geometry->SetBoundControlVolume(config, UPDATE);
-  geometry->SetMaxLength();
+  geometry->SetMaxLength(config);
   
 }
 
@@ -9283,7 +9283,7 @@ void CElasticityMovement::UpdateDualGrid(CGeometry *geometry, CConfig *config){
   geometry->SetCoord_CG();
   geometry->SetControlVolume(config, UPDATE);
   geometry->SetBoundControlVolume(config, UPDATE);
-  geometry->SetMaxLength();
+  geometry->SetMaxLength(config);
 
 }
 

--- a/SU2_CFD/include/numerics_structure.hpp
+++ b/SU2_CFD/include/numerics_structure.hpp
@@ -1552,17 +1552,21 @@ public:
   virtual void SetTauWall(su2double val_tauwall_i, su2double val_tauwall_j);
   
   /*!
-   * \brief
-   * \param[in] Coord_i -
-   * \param[in] Coord_j -
-   * \param[in] Dissipation_i -
-   * \param[in] Dissipation_j -
-   * \param[in] Dissipation_ij -
-   * \param[in] Sensor_i -
-   * \param[in] Sensor_j -
+   * \brief - Calculate the central/upwind blending function for a face
+   *
+   * At its simplest level, this function will calculate the average
+   * value of the "Roe dissipation" or central/upwind blending function
+   * at a face. If Ducros shock sensors are used, then this method will
+   * also adjust the central/upwind blending to account for shocks.
+   *
+   * \param[in] Dissipation_i - Value of the blending function at point i
+   * \param[in] Dissipation_j - Value of the bledning function at point j
+   * \param[in] Sensor_i - Shock sensor at point i
+   * \param[in] Sensor_j - Shock sensor at point j
+   * \param[out] Dissipation_ij - Blending parameter at face
    */
-  void SetRoe_Dissipation(su2double *Coord_i, su2double *Coord_j,
-                          const su2double Dissipation_i, const su2double Dissipation_j,
+  void SetRoe_Dissipation(const su2double Dissipation_i,
+                          const su2double Dissipation_j,
                           const su2double Sensor_i, const su2double Sensor_j,
                           su2double& Dissipation_ij, CConfig *config);
   

--- a/SU2_CFD/src/driver_structure.cpp
+++ b/SU2_CFD/src/driver_structure.cpp
@@ -859,7 +859,7 @@ void CDriver::Geometrical_Preprocessing() {
       /*--- Compute the max length. ---*/
 
       if ((rank == MASTER_NODE) && (!fea)) cout << "Finding max control volume width." << endl;
-      geometry_container[iZone][iInst][MESH_0]->SetMaxLength();
+      geometry_container[iZone][iInst][MESH_0]->SetMaxLength(config_container[iZone]);
 
       /*--- Visualize a dual control volume if requested ---*/
 
@@ -927,7 +927,7 @@ void CDriver::Geometrical_Preprocessing() {
 
         /*--- Compute the max length. ---*/
 
-        geometry_container[iZone][iInst][iMGlevel]->SetMaxLength();
+        geometry_container[iZone][iInst][iMGlevel]->SetMaxLength(config_container[iZone]);
 
         /*--- Find closest neighbor to a surface point ---*/
 

--- a/SU2_CFD/src/driver_structure.cpp
+++ b/SU2_CFD/src/driver_structure.cpp
@@ -856,6 +856,11 @@ void CDriver::Geometrical_Preprocessing() {
       geometry_container[iZone][iInst][MESH_0]->SetControlVolume(config_container[iZone], ALLOCATE);
       geometry_container[iZone][iInst][MESH_0]->SetBoundControlVolume(config_container[iZone], ALLOCATE);
 
+      /*--- Compute the max length. ---*/
+
+      if ((rank == MASTER_NODE) && (!fea)) cout << "Finding max control volume width." << endl;
+      geometry_container[iZone][iInst][MESH_0]->SetMaxLength();
+
       /*--- Visualize a dual control volume if requested ---*/
 
       if ((config_container[iZone]->GetVisualize_CV() >= 0) &&
@@ -919,6 +924,10 @@ void CDriver::Geometrical_Preprocessing() {
         geometry_container[iZone][iInst][iMGlevel]->SetControlVolume(config_container[iZone], geometry_container[iZone][iInst][iMGlevel-1], ALLOCATE);
         geometry_container[iZone][iInst][iMGlevel]->SetBoundControlVolume(config_container[iZone], geometry_container[iZone][iInst][iMGlevel-1], ALLOCATE);
         geometry_container[iZone][iInst][iMGlevel]->SetCoord(geometry_container[iZone][iInst][iMGlevel-1]);
+
+        /*--- Compute the max length. ---*/
+
+        geometry_container[iZone][iInst][iMGlevel]->SetMaxLength();
 
         /*--- Find closest neighbor to a surface point ---*/
 

--- a/SU2_CFD/src/numerics_direct_mean.cpp
+++ b/SU2_CFD/src/numerics_direct_mean.cpp
@@ -1080,7 +1080,7 @@ void CUpwSLAU_Flow::ComputeResidual(su2double *val_residual, su2double **val_Jac
   }
     
   if (slau_low_diss){
-    SetRoe_Dissipation(Coord_i, Coord_j, Dissipation_i, Dissipation_j, Sensor_i, Sensor_j, Dissipation_ij, config);
+    SetRoe_Dissipation(Dissipation_i, Dissipation_j, Sensor_i, Sensor_j, Dissipation_ij, config);
   }
   
   pF = 0.5 * (Pressure_i + Pressure_j) + 0.5 * (BetaL - BetaR) * (Pressure_i - Pressure_j) + Dissipation_ij*(1.0 - Chi) * (BetaL + BetaR - 1.0) *  0.5 * (Pressure_i + Pressure_j);
@@ -1277,7 +1277,7 @@ void CUpwSLAU2_Flow::ComputeResidual(su2double *val_residual, su2double **val_Ja
   }
   
   if (slau_low_dissipation){
-    SetRoe_Dissipation(Coord_i, Coord_j, Dissipation_i, Dissipation_j, Sensor_i, Sensor_j, Dissipation_ij, config);
+    SetRoe_Dissipation(Dissipation_i, Dissipation_j, Sensor_i, Sensor_j, Dissipation_ij, config);
   }
   
   /*--- Pressure Flux ---*/
@@ -2941,7 +2941,7 @@ void CUpwRoe_Flow::ComputeResidual(su2double *val_residual, su2double **val_Jaco
     Diff_U[iVar] = U_j[iVar]-U_i[iVar];
   
   if (roe_low_dissipation)
-    SetRoe_Dissipation(Coord_i, Coord_j, Dissipation_i, Dissipation_j, Sensor_i, Sensor_j, Dissipation_ij, config);
+    SetRoe_Dissipation(Dissipation_i, Dissipation_j, Sensor_i, Sensor_j, Dissipation_ij, config);
   
   /*--- Roe's Flux approximation ---*/
   

--- a/SU2_CFD/src/numerics_structure.cpp
+++ b/SU2_CFD/src/numerics_structure.cpp
@@ -2746,18 +2746,28 @@ void CNumerics::CreateBasis(su2double *val_Normal) {
   }
 }
 
-void CNumerics::SetRoe_Dissipation(su2double *Coord_i, su2double *Coord_j,
-                                      const su2double Dissipation_i, const su2double Dissipation_j,
-                                      const su2double Sensor_i, const su2double Sensor_j,
-                                      su2double& Dissipation_ij, CConfig *config){
-  unsigned short iDim;
+void CNumerics::SetRoe_Dissipation(const su2double Dissipation_i,
+                                   const su2double Dissipation_j,
+                                   const su2double Sensor_i,
+                                   const su2double Sensor_j,
+                                   su2double& Dissipation_ij,
+                                   CConfig *config) {
+
+  /*--- Check for valid input ---*/
+
+  assert((Dissipation_i >= 0) && (Dissipation_i <= 1));
+  assert((Dissipation_j >= 0) && (Dissipation_j <= 1));
+  assert((Sensor_i >= 0) && (Sensor_i <= 1));
+  assert((Sensor_j >= 0) && (Sensor_j <= 1));
+
   unsigned short roe_low_diss = config->GetKind_RoeLowDiss();
+
+  /*--- A minimum level of upwinding is used to enhance stability ---*/
+
+  const su2double Min_Dissipation = 0.05;
   
-  su2double Ducros_ij, Delta, Aaux, phi1, phi2;
-  static const su2double ch1 = 3.0, ch2 = 1.0, phi_max = 1.0;
-  static const su2double Const_DES = 5.0;
-  
-  su2double phi_hybrid_i, phi_hybrid_j;
+  const su2double Mean_Dissipation = 0.5*(Dissipation_i + Dissipation_j);
+  const su2double Mean_Sensor = 0.5*(Sensor_i + Sensor_j);
   
   if (roe_low_diss == FD || roe_low_diss == FD_DUCROS){
 
@@ -2766,6 +2776,8 @@ void CNumerics::SetRoe_Dissipation(su2double *Coord_i, su2double *Coord_j,
     if (roe_low_diss == FD_DUCROS){
       
       /*--- See Jonhsen et al. JCP 229 (2010) pag. 1234 ---*/
+
+      su2double Ducros_ij;
       
       if (0.5*(Sensor_i + Sensor_j) > 0.65)
         Ducros_ij = 1.0;
@@ -2774,30 +2786,26 @@ void CNumerics::SetRoe_Dissipation(su2double *Coord_i, su2double *Coord_j,
       
       Dissipation_ij = max(Ducros_ij, Dissipation_ij);
     }
-  }
-  else if (roe_low_diss == NTS || roe_low_diss == NTS_DUCROS){
 
-    Delta = 0.0;
-    for (iDim=0;iDim<nDim;++iDim)
-        Delta += pow((Coord_j[iDim]-Coord_i[iDim]),2.);
-    Delta=sqrt(Delta);
+  } else if (roe_low_diss == NTS) {
+    
+    Dissipation_ij = max(Min_Dissipation, Mean_Dissipation);
 
-    Aaux = ch2 * max(((Const_DES*Delta)/(Dissipation_i)) - 0.5, 0.0);
-    phi_hybrid_i = phi_max * tanh(pow(Aaux,ch1));
-    
-    Aaux = ch2 * max(((Const_DES*Delta)/(Dissipation_j)) - 0.5, 0.0);
-    phi_hybrid_j = phi_max * tanh(pow(Aaux,ch1));
-    
-    if (roe_low_diss == NTS){
-      Dissipation_ij = max(0.5*(phi_hybrid_i+phi_hybrid_j),0.05);
-    } else if (roe_low_diss == NTS_DUCROS){
-      
-      phi1 = 0.5*(Sensor_i+Sensor_j);
-      phi2 = 0.5*(phi_hybrid_i+phi_hybrid_j);
-      
-      Dissipation_ij = min(max(phi1 + phi2 - (phi1*phi2),0.05),1.0);
-      
-    }
+  } else if (roe_low_diss == NTS_DUCROS) {
+
+    /*--- See Xiao et al. INT J HEAT FLUID FL 51 (2015) pag. 141
+     * https://doi.org/10.1016/j.ijheatfluidflow.2014.10.007 ---*/
+
+    const su2double phi1 = Mean_Sensor;
+    const su2double phi2 = Mean_Dissipation;
+
+    Dissipation_ij = max(Min_Dissipation, phi1 + phi2 - (phi1*phi2));
+
+  } else {
+
+    SU2_MPI::Error("Unrecognized upwind/central blending scheme!",
+                   CURRENT_FUNCTION);
+
   }
 
 }

--- a/SU2_CFD/src/solver_direct_mean.cpp
+++ b/SU2_CFD/src/solver_direct_mean.cpp
@@ -17548,6 +17548,7 @@ void CNSSolver::SetRoe_Dissipation(CGeometry *geometry, CConfig *config){
     } else if (kind_roe_dissipation == NTS || kind_roe_dissipation == NTS_DUCROS) {
 
       const su2double delta = geometry->node[iPoint]->GetMaxLength();
+      assert(delta > 0); // Delta must be initialized and non-negative
       node[iPoint]->SetRoe_Dissipation_NTS(delta, config->GetConst_DES());
     }
   }

--- a/SU2_CFD/src/solver_direct_mean.cpp
+++ b/SU2_CFD/src/solver_direct_mean.cpp
@@ -14054,7 +14054,7 @@ void CEulerSolver::LoadRestart(CGeometry **geometry, CSolver ***solver, CConfig 
     geometry[MESH_0]->SetCoord_CG();
     geometry[MESH_0]->SetControlVolume(config, UPDATE);
     geometry[MESH_0]->SetBoundControlVolume(config, UPDATE);
-    geometry[MESH_0]->SetMaxLength();
+    geometry[MESH_0]->SetMaxLength(config);
 
     /*--- Update the multigrid structure after setting up the finest grid,
      including computing the grid velocities on the coarser levels. ---*/
@@ -14065,7 +14065,7 @@ void CEulerSolver::LoadRestart(CGeometry **geometry, CSolver ***solver, CConfig 
       geometry[iMesh]->SetBoundControlVolume(config, geometry[iMeshFine],UPDATE);
       geometry[iMesh]->SetCoord(geometry[iMeshFine]);
       geometry[iMesh]->SetRestricted_GridVelocity(geometry[iMeshFine], config);
-      geometry[iMesh]->SetMaxLength();
+      geometry[iMesh]->SetMaxLength(config);
       }
     }
 
@@ -14083,7 +14083,7 @@ void CEulerSolver::LoadRestart(CGeometry **geometry, CSolver ***solver, CConfig 
     geometry[MESH_0]->SetCoord_CG();
     geometry[MESH_0]->SetControlVolume(config, UPDATE);
     geometry[MESH_0]->SetBoundControlVolume(config, UPDATE);
-    geometry[MESH_0]->SetMaxLength();
+    geometry[MESH_0]->SetMaxLength(config);
 
     /*--- Update the multigrid structure after setting up the finest grid,
      including computing the grid velocities on the coarser levels. ---*/
@@ -14093,7 +14093,7 @@ void CEulerSolver::LoadRestart(CGeometry **geometry, CSolver ***solver, CConfig 
       geometry[iMesh]->SetControlVolume(config, geometry[iMeshFine], UPDATE);
       geometry[iMesh]->SetBoundControlVolume(config, geometry[iMeshFine],UPDATE);
       geometry[iMesh]->SetCoord(geometry[iMeshFine]);
-      geometry[iMesh]->SetMaxLength();
+      geometry[iMesh]->SetMaxLength(config);
     }
   }
   

--- a/SU2_CFD/src/solver_direct_mean.cpp
+++ b/SU2_CFD/src/solver_direct_mean.cpp
@@ -14054,6 +14054,7 @@ void CEulerSolver::LoadRestart(CGeometry **geometry, CSolver ***solver, CConfig 
     geometry[MESH_0]->SetCoord_CG();
     geometry[MESH_0]->SetControlVolume(config, UPDATE);
     geometry[MESH_0]->SetBoundControlVolume(config, UPDATE);
+    geometry[MESH_0]->SetMaxLength();
 
     /*--- Update the multigrid structure after setting up the finest grid,
      including computing the grid velocities on the coarser levels. ---*/
@@ -14064,6 +14065,7 @@ void CEulerSolver::LoadRestart(CGeometry **geometry, CSolver ***solver, CConfig 
       geometry[iMesh]->SetBoundControlVolume(config, geometry[iMeshFine],UPDATE);
       geometry[iMesh]->SetCoord(geometry[iMeshFine]);
       geometry[iMesh]->SetRestricted_GridVelocity(geometry[iMeshFine], config);
+      geometry[iMesh]->SetMaxLength();
       }
     }
 
@@ -14081,6 +14083,7 @@ void CEulerSolver::LoadRestart(CGeometry **geometry, CSolver ***solver, CConfig 
     geometry[MESH_0]->SetCoord_CG();
     geometry[MESH_0]->SetControlVolume(config, UPDATE);
     geometry[MESH_0]->SetBoundControlVolume(config, UPDATE);
+    geometry[MESH_0]->SetMaxLength();
 
     /*--- Update the multigrid structure after setting up the finest grid,
      including computing the grid velocities on the coarser levels. ---*/
@@ -14090,6 +14093,7 @@ void CEulerSolver::LoadRestart(CGeometry **geometry, CSolver ***solver, CConfig 
       geometry[iMesh]->SetControlVolume(config, geometry[iMeshFine], UPDATE);
       geometry[iMesh]->SetBoundControlVolume(config, geometry[iMeshFine],UPDATE);
       geometry[iMesh]->SetCoord(geometry[iMeshFine]);
+      geometry[iMesh]->SetMaxLength();
     }
   }
   
@@ -17540,17 +17544,10 @@ void CNSSolver::SetRoe_Dissipation(CGeometry *geometry, CConfig *config){
       }
       
       node[iPoint]->SetRoe_Dissipation_FD(wall_distance);
-    }
-    
-    if (kind_roe_dissipation == NTS || kind_roe_dissipation == NTS_DUCROS){
-      /*--- XXX: This grid length does not match the original paper.
-       * Here we use the volume-based grid length,
-       *    delta = (delta_x * delta_y * delta_z)^(1/3)
-       * as an approximation for Travin's max-based grid length,
-       *    delta = max(delta_x, delta_y, delta_z)
-       * Since the volume is already computed, using the volume is much faster.
-       * ---*/
-      const su2double delta = pow(geometry->node[iPoint]->GetVolume(), 1.0/3);
+
+    } else if (kind_roe_dissipation == NTS || kind_roe_dissipation == NTS_DUCROS) {
+
+      const su2double delta = geometry->node[iPoint]->GetMaxLength();
       node[iPoint]->SetRoe_Dissipation_NTS(delta, config->GetConst_DES());
     }
   }

--- a/SU2_CFD/src/solver_direct_mean_inc.cpp
+++ b/SU2_CFD/src/solver_direct_mean_inc.cpp
@@ -6773,6 +6773,7 @@ void CIncEulerSolver::LoadRestart(CGeometry **geometry, CSolver ***solver, CConf
     geometry[MESH_0]->SetCoord_CG();
     geometry[MESH_0]->SetControlVolume(config, UPDATE);
     geometry[MESH_0]->SetBoundControlVolume(config, UPDATE);
+    geometry[MESH_0]->SetMaxLength();
     
     /*--- Update the multigrid structure after setting up the finest grid,
      including computing the grid velocities on the coarser levels. ---*/

--- a/SU2_CFD/src/solver_direct_mean_inc.cpp
+++ b/SU2_CFD/src/solver_direct_mean_inc.cpp
@@ -6773,7 +6773,7 @@ void CIncEulerSolver::LoadRestart(CGeometry **geometry, CSolver ***solver, CConf
     geometry[MESH_0]->SetCoord_CG();
     geometry[MESH_0]->SetControlVolume(config, UPDATE);
     geometry[MESH_0]->SetBoundControlVolume(config, UPDATE);
-    geometry[MESH_0]->SetMaxLength();
+    geometry[MESH_0]->SetMaxLength(config);
     
     /*--- Update the multigrid structure after setting up the finest grid,
      including computing the grid velocities on the coarser levels. ---*/
@@ -6783,6 +6783,7 @@ void CIncEulerSolver::LoadRestart(CGeometry **geometry, CSolver ***solver, CConf
       geometry[iMesh]->SetControlVolume(config, geometry[iMeshFine], UPDATE);
       geometry[iMesh]->SetBoundControlVolume(config, geometry[iMeshFine],UPDATE);
       geometry[iMesh]->SetCoord(geometry[iMeshFine]);
+      geometry[iMesh]->SetMaxLength(config);
     }
   }
   

--- a/SU2_CFD/src/solver_direct_turbulent.cpp
+++ b/SU2_CFD/src/solver_direct_turbulent.cpp
@@ -3335,19 +3335,8 @@ void CTurbSASolver::SetDES_LengthScale(CSolver **solver, CGeometry *geometry, CC
         Spalart
         1997
         ---*/
-        maxDelta=0.;      
-        for (iNeigh = 0;iNeigh < nNeigh; iNeigh++){
-          jPoint  = geometry->node[iPoint]->GetPoint(iNeigh);
-          coord_j = geometry->node[jPoint]->GetCoord();
-          
-          deltaAux = 0.;
-          for (iDim = 0;iDim < nDim; iDim++){
-            deltaAux += pow((coord_j[iDim]-coord_i[iDim]),2.);
-          }
-          
-          maxDelta = max(maxDelta,sqrt(deltaAux));
-        }
         
+        maxDelta = geometry->node[iPoint]->GetMaxLength();
         distDES         = constDES * maxDelta;
         lengthScale = min(distDES,wallDistance);
                 
@@ -3359,18 +3348,7 @@ void CTurbSASolver::SetDES_LengthScale(CSolver **solver, CGeometry *geometry, CC
          Theoretical and Computational Fluid Dynamics - 2006
          ---*/
             
-        maxDelta = 0.0;      
-        for (iNeigh = 0;iNeigh < nNeigh; iNeigh++){
-          jPoint  = geometry->node[iPoint]->GetPoint(iNeigh);
-          coord_j = geometry->node[jPoint]->GetCoord();
-        
-          deltaAux = 0.0;
-          for (iDim = 0; iDim < nDim; iDim++){
-            deltaAux += pow((coord_j[iDim]-coord_i[iDim]),2.);
-          }
-          
-          maxDelta = max(maxDelta,sqrt(deltaAux));
-        }
+        maxDelta = geometry->node[iPoint]->GetMaxLength();
         
         r_d = (kinematicViscosityTurb+kinematicViscosity)/(uijuij*k2*pow(wallDistance, 2.0));
         f_d = 1.0-tanh(pow(8.0*r_d,3.0));
@@ -3385,17 +3363,14 @@ void CTurbSASolver::SetDES_LengthScale(CSolver **solver, CGeometry *geometry, CC
          Theoretical and Computational Fluid Dynamics - 2012
          ---*/
         
-        deltaDDES = 0.0;
         for (iNeigh = 0; iNeigh < nNeigh; iNeigh++){
             jPoint = geometry->node[iPoint]->GetPoint(iNeigh);
             coord_j = geometry->node[jPoint]->GetCoord();
-            deltaAuxDDES = 0.0;
             for ( iDim = 0; iDim < nDim; iDim++){
               deltaAux       = abs(coord_j[iDim] - coord_i[iDim]);
               delta[iDim]     = max(delta[iDim], deltaAux);
-              deltaAuxDDES += pow((coord_j[iDim]-coord_i[iDim]),2.);
             }
-            deltaDDES = max(deltaDDES,sqrt(deltaAuxDDES));
+            deltaDDES = geometry->node[iPoint]->GetMaxLength();
         }
         
         omega = sqrt(vorticity[0]*vorticity[0] + 
@@ -3444,12 +3419,10 @@ void CTurbSASolver::SetDES_LengthScale(CSolver **solver, CGeometry *geometry, CC
         for (iNeigh = 0;iNeigh < nNeigh; iNeigh++){
           jPoint = geometry->node[iPoint]->GetPoint(iNeigh);
           coord_j = geometry->node[jPoint]->GetCoord();
-          deltaAuxDDES = 0.0;
           for (iDim = 0; iDim < nDim; iDim++){
             delta[iDim] = fabs(coord_j[iDim] - coord_i[iDim]);            
-            deltaAuxDDES += pow((coord_j[iDim]-coord_i[iDim]),2.);
           }
-          deltaDDES=max(deltaDDES,sqrt(deltaAuxDDES));
+          deltaDDES = geometry->node[iPoint]->GetMaxLength();
           ln[0] = delta[1]*ratioOmega[2] - delta[2]*ratioOmega[1];
           ln[1] = delta[2]*ratioOmega[0] - delta[0]*ratioOmega[2];
           ln[2] = delta[0]*ratioOmega[1] - delta[1]*ratioOmega[0];

--- a/SU2_CFD/src/solver_direct_turbulent.cpp
+++ b/SU2_CFD/src/solver_direct_turbulent.cpp
@@ -3283,7 +3283,7 @@ void CTurbSASolver::SetDES_LengthScale(CSolver **solver, CGeometry *geometry, CC
       eddyViscosity = 0.0, kinematicViscosityTurb = 0.0, wallDistance = 0.0, lengthScale = 0.0;
   
   su2double maxDelta = 0.0, deltaAux = 0.0, distDES = 0.0, uijuij = 0.0, k2 = 0.0, r_d = 0.0, f_d = 0.0,
-      deltaDDES = 0.0, deltaAuxDDES = 0.0, omega = 0.0, ln_max = 0.0, ln[3] = {0.0, 0.0, 0.0},
+      deltaDDES = 0.0, omega = 0.0, ln_max = 0.0, ln[3] = {0.0, 0.0, 0.0},
       aux_ln = 0.0, f_kh = 0.0;
   
   su2double nu_hat, fw_star = 0.424, cv1_3 = pow(7.1, 3.0); k2 = pow(0.41, 2.0);

--- a/SU2_CFD/src/variable_direct_mean.cpp
+++ b/SU2_CFD/src/variable_direct_mean.cpp
@@ -648,7 +648,7 @@ void CNSVariable::SetRoe_Dissipation_NTS(su2double val_delta,
    * ---*/
 
   for (iDim = 0; iDim < 3; iDim++){
-    Omega_2 += 2.0*Vorticity[iDim]*Vorticity[iDim];
+    Omega_2 += Vorticity[iDim]*Vorticity[iDim];
   }
   Omega = sqrt(Omega_2);
   


### PR DESCRIPTION
## Proposed Changes

This pull request is two related changes:

1. While "fixing" the NTS central/upwind blending function in PR #532, I accidentally introduced a bug.  Some steps in the calculation were repeated twice. The main purpose of this pull request is to remedy the bug.
2. I moved the calculation of the maximum cell width to the `CPhysicalGeometry` class.  This makes inclusion in the central/upwind blending easier. For DES and DDES, the cell lengthscale is not dependent on the flow.  So there's no need to compute it every iteration in the flow solver.
 

## Related Work

This is a subset of the changes originally proposed in PR #552. The discussion and validation there still apply here.  This pull request is not a new set of changes, but rather a smaller portion of PR #552.


## PR Checklist

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [x] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
