### PR TITLE
Fix Commands for SOL_FSI, SOL and GEO

### DIFF
--- a/SU2_PY/SU2/run/interface.py
+++ b/SU2_PY/SU2/run/interface.py
@@ -213,7 +213,7 @@ def GEO(config):
     # must run with rank 1
     processes = konfig['NUMBER_PART']
         
-    the_Command = 'SU2_GEO ' + tempname
+    the_Command = 'SU2_GEO%s %s' % (quote, tempname)
     the_Command = build_command( the_Command , processes )
     run_command( the_Command )
     
@@ -234,7 +234,7 @@ def SOL(config):
     # must run with rank 1
     processes = konfig['NUMBER_PART']
     
-    the_Command = 'SU2_SOL ' + tempname
+    the_Command = 'SU2_SOL%s %s' % (quote, tempname)
     the_Command = build_command( the_Command , processes )
     run_command( the_Command )
     
@@ -255,7 +255,7 @@ def SOL_FSI(config):
     # must run with rank 1
     processes = konfig['NUMBER_PART']
     
-    the_Command = 'SU2_SOL ' + tempname + ' 2'
+    the_Command = 'SU2_SOL%s %s 2' % (quote, tempname)
     the_Command = build_command( the_Command , processes )
     run_command( the_Command )
     


### PR DESCRIPTION
Like for any other command in this file, build_command will add a quote on the left hand side of our command path. So we'll always need another quote on the right hand side. For some reason SOL_FSI, SOL and GEO were missing them, resulting in Errors when attempting to execute them.

## Proposed Changes
*Give a brief overview of your contribution here in a few sentences.*
 


## Related Work
*Resolve any issues (bug fix or feature request), note any related PRs, or mention interactions with the work of others, if any.*



## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [ ] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [x] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
