### PR TITLE
Feature bugfix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ compiler:
 notifications:
     email:
         recipients:
-            - su2code-dev@lists.stanford.edu
+            - ruben.sanchez@scicomp.uni-kl.de
   
 branches:
     only:
-        - develop
+        - feature_bugfix
 
 python:
     - 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ compiler:
 notifications:
     email:
         recipients:
-            - ruben.sanchez@scicomp.uni-kl.de
+            - su2code-dev@lists.stanford.edu
   
 branches:
     only:
-        - feature_bugfix
+        - develop
 
 python:
     - 2.7

--- a/SU2_CFD/src/numerics_direct_mean_inc.cpp
+++ b/SU2_CFD/src/numerics_direct_mean_inc.cpp
@@ -139,8 +139,8 @@ void CUpwFDSInc_Flow::ComputeResidual(su2double *val_residual, su2double **val_J
   MeandRhodT = 0.0; dRhodT_i = 0.0; dRhodT_j = 0.0;
   if (variable_density) {
     MeandRhodT = -MeanDensity/MeanTemperature;
-    dRhodT_i   = -Density_i/Temperature_i;
-    dRhodT_j   = -Density_j/Temperature_j;
+    dRhodT_i   = -DensityInc_i/Temperature_i;
+    dRhodT_j   = -DensityInc_j/Temperature_j;
   }
 
   /*--- Compute ProjFlux_i ---*/

--- a/SU2_CFD/src/solver_direct_mean_inc.cpp
+++ b/SU2_CFD/src/solver_direct_mean_inc.cpp
@@ -8286,8 +8286,6 @@ void CIncNSSolver::Friction_Forces(CGeometry *geometry, CConfig *config) {
     Surface_CMx[iMarker_Monitoring]        += Surface_CMx_Visc[iMarker_Monitoring];
     Surface_CMy[iMarker_Monitoring]        += Surface_CMy_Visc[iMarker_Monitoring];
     Surface_CMz[iMarker_Monitoring]        += Surface_CMz_Visc[iMarker_Monitoring];
-    Surface_HF_Visc[iMarker_Monitoring]    += Surface_CMy_Visc[iMarker_Monitoring];
-    Surface_MaxHF_Visc[iMarker_Monitoring] += Surface_CMz_Visc[iMarker_Monitoring];
   }
 
 }


### PR DESCRIPTION
## Proposed Changes
This PR fixes a couple of bugs identified in the incompressible solver:
- In the computation of the FDS fluxes, we need to use DensityInc_i and DensityInc_j in the computation of the preconditioner, instead of Density_i/Density_j, which are not initialized in the function.
- The per-surface output for heatflux and max heatflux was receiving information from an incorrect container.

## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [x] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.