### PR TITLE
Fix   interpolation

### DIFF
--- a/Common/include/option_structure.hpp
+++ b/Common/include/option_structure.hpp
@@ -311,8 +311,7 @@ static const map<string, ENUM_MAT_COMPRESS> MatComp_Map = CCreateMap<string, ENU
  */
 enum ENUM_INTERPOLATOR {
   NEAREST_NEIGHBOR 	= 0,   	/*!< \brief Nearest Neigbhor interpolation */
-  ISOPARAMETRIC 	= 1,	/*!< \brief Isoparametric interpolation */
-  CONSISTCONSERVE 	= 2,	/*!< \brief Consistent & Conservative interpolation (S.A. Brown 1997). Utilizes Isoparametric interpolation. */
+  ISOPARAMETRIC 	= 1,	/*!< \brief Isoparametric interpolation, use CONSERVATIVE_INTERPOLATION=YES for conservative interpolation (S.A. Brown 1997).*/
   WEIGHTED_AVERAGE  = 3, 	/*!< \brief Sliding Mesh Approach E. Rinaldi 2015 */
   RADIAL_BASIS_FUNCTION= 4, /*!< \brief Radial basis function interpolation. */
 };
@@ -320,7 +319,6 @@ enum ENUM_INTERPOLATOR {
 static const map<string, ENUM_INTERPOLATOR> Interpolator_Map = CCreateMap<string, ENUM_INTERPOLATOR>
 ("NEAREST_NEIGHBOR", NEAREST_NEIGHBOR)
 ("ISOPARAMETRIC",    ISOPARAMETRIC)
-("CONSISTCONSERVE",  CONSISTCONSERVE)
 ("WEIGHTED_AVERAGE", WEIGHTED_AVERAGE)
 ("RADIAL_BASIS_FUNCTION", RADIAL_BASIS_FUNCTION);
 

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -1905,7 +1905,7 @@ void CConfig::SetConfig_Options(unsigned short val_iZone, unsigned short val_nZo
   
   /*  DESCRIPTION: Use conservative approach for interpolating between meshes.
   *  Options: NO, YES \ingroup Config */
-  addBoolOption("CONSERVATIVE_INTERPOLATION", ConservativeInterpolation, true);
+  addBoolOption("CONSERVATIVE_INTERPOLATION", ConservativeInterpolation, false);
 
   /*!\par KIND_INTERPOLATION \n
    * DESCRIPTION: Type of interpolation to use for multi-zone problems. \n OPTIONS: see \link Interpolator_Map \endlink

--- a/SU2_CFD/include/transfer_structure.hpp
+++ b/SU2_CFD/include/transfer_structure.hpp
@@ -268,6 +268,9 @@ public:
 class CTransfer_FlowTraction : public CTransfer {
 
 protected:
+  bool consistent_interpolation;
+  
+  void Compute_Pressure_Dimensional_Factor(CConfig *flow_config);
 
 public:
 
@@ -403,7 +406,7 @@ public:
  * \version 4.0.1 "Cardinal"
  */
 
-class CTransfer_FlowTraction_DiscAdj : public CTransfer {
+class CTransfer_FlowTraction_DiscAdj : public CTransfer_FlowTraction {
 
 protected:
 
@@ -438,30 +441,6 @@ public:
   void GetPhysical_Constants(CSolver *donor_solution, CSolver *target_solution,
                  CGeometry *donor_geometry, CGeometry *target_geometry,
                  CConfig *donor_config, CConfig *target_config);
-
-  /*!
-   * \brief Retrieve the variable that will be sent from donor mesh to target mesh.
-   * \param[in] donor_solution - Solution from the donor mesh.
-   * \param[in] donor_geometry - Geometry of the donor mesh.
-   * \param[in] donor_config - Definition of the problem at the donor mesh.
-   * \param[in] Marker_Donor - Index of the donor marker.
-   * \param[in] Vertex_Donor - Index of the donor vertex.
-   */
-  void GetDonor_Variable(CSolver *flow_solution, CGeometry *flow_geometry, CConfig *flow_config,
-               unsigned long Marker_Flow, unsigned long Vertex_Flow, unsigned long Point_Flow);
-
-  /*!
-   * \brief Set the variable that has been received from the target mesh into the target mesh.
-   * \param[in] target_solution - Solution from the target mesh.
-   * \param[in] target_geometry - Geometry of the target mesh.
-   * \param[in] target_config - Definition of the problem at the target mesh.
-   * \param[in] Marker_Target - Index of the target marker.
-   * \param[in] Vertex_Target - Index of the target vertex.
-   * \param[in] Point_Target - Index of the target point.
-   */
-  void SetTarget_Variable(CSolver *fea_solution, CGeometry *fea_geometry,
-              CConfig *fea_config, unsigned long Marker_Struct,
-              unsigned long Vertex_Struct, unsigned long Point_Struct);
 
 };
 

--- a/SU2_CFD/src/driver_structure.cpp
+++ b/SU2_CFD/src/driver_structure.cpp
@@ -2991,18 +2991,35 @@ void CDriver::Interface_Preprocessing() {
         }
         /*--- Else: interpolate ---*/
         else {
-        switch (config_container[donorZone]->GetKindInterpolation()) {
+          bool conservative_interp = config_container[donorZone]->GetConservativeInterpolation();
+          
+          /*--- Conditions for conservative interpolation are not met, we cannot fallback on the consistent approach
+                because CTransfer_FlowTraction relies on the information in config to be correct. ---*/
+          if ( conservative_interp && targetZone == 0 && structural_target )
+            SU2_MPI::Error("Conservative interpolation assumes the structural model mesh is evaluated second, somehow this has not happened.",CURRENT_FUNCTION);
+        
+          switch (config_container[donorZone]->GetKindInterpolation()) {
 
           case NEAREST_NEIGHBOR:
-            interpolator_container[donorZone][targetZone] = new CNearestNeighbor(geometry_container, config_container, donorZone, targetZone);
-            if (rank == MASTER_NODE) cout << "using a nearest-neighbor approach." << endl;
-
+            if ( conservative_interp && targetZone > 0 && structural_target ) {
+              interpolator_container[donorZone][targetZone] = new CMirror(geometry_container, config_container, donorZone, targetZone);
+              if (rank == MASTER_NODE) cout << "using a mirror approach: matching coefficients from opposite mesh." << endl;
+            }
+            else {
+              interpolator_container[donorZone][targetZone] = new CNearestNeighbor(geometry_container, config_container, donorZone, targetZone);
+              if (rank == MASTER_NODE) cout << "using a nearest-neighbor approach." << endl;
+            }
             break;
 
           case ISOPARAMETRIC:
-            interpolator_container[donorZone][targetZone] = new CIsoparametric(geometry_container, config_container, donorZone, targetZone);
-            if (rank == MASTER_NODE) cout << "using an isoparametric approach." << endl;
-
+            if ( conservative_interp && targetZone > 0 && structural_target ) {
+              interpolator_container[donorZone][targetZone] = new CMirror(geometry_container, config_container, donorZone, targetZone);
+              if (rank == MASTER_NODE) cout << "using a mirror approach: matching coefficients from opposite mesh." << endl;
+            }
+            else {
+              interpolator_container[donorZone][targetZone] = new CIsoparametric(geometry_container, config_container, donorZone, targetZone);
+              if (rank == MASTER_NODE) cout << "using an isoparametric approach." << endl;
+            }
             break;
 
           case WEIGHTED_AVERAGE:
@@ -3012,41 +3029,15 @@ void CDriver::Interface_Preprocessing() {
             break;
             
           case RADIAL_BASIS_FUNCTION:
-            if ( config_container[donorZone]->GetConservativeInterpolation() ) {
-              if( targetZone > 0 && structural_target ) {
-                interpolator_container[donorZone][targetZone] = new CMirror(geometry_container, config_container, donorZone, targetZone);
-                if (rank == MASTER_NODE) cout << "using a mirror approach: matching coefficients from opposite mesh." << endl;
-              }
-              else {
-                interpolator_container[donorZone][targetZone] = new CRadialBasisFunction(geometry_container, config_container, donorZone, targetZone);
-                if (rank == MASTER_NODE) cout << "using a radial basis function approach." << endl;
-              }
-              if ( targetZone == 0 && structural_target && rank == MASTER_NODE)
-                cout << "Conservative interpolation assumes the structure model mesh is evaluated second. Somehow this has not happened. The RBF coefficients will be calculated for both meshes, and are not guaranteed to be consistent." << endl;
+            if ( conservative_interp && targetZone > 0 && structural_target ) {
+              interpolator_container[donorZone][targetZone] = new CMirror(geometry_container, config_container, donorZone, targetZone);
+              if (rank == MASTER_NODE) cout << "using a mirror approach: matching coefficients from opposite mesh." << endl;
             }
             else {
               interpolator_container[donorZone][targetZone] = new CRadialBasisFunction(geometry_container, config_container, donorZone, targetZone);
               if (rank == MASTER_NODE) cout << "using a radial basis function approach." << endl;
             }
-            
             break;
-
-          case CONSISTCONSERVE:
-            if ( targetZone > 0 && structural_target ) {
-              interpolator_container[donorZone][targetZone] = new CMirror(geometry_container, config_container, donorZone, targetZone);
-              if (rank == MASTER_NODE) cout << "using a mirror approach: matching coefficients from opposite mesh." << endl;
-            }
-            else{
-              interpolator_container[donorZone][targetZone] = new CIsoparametric(geometry_container, config_container, donorZone, targetZone);
-              if (rank == MASTER_NODE) cout << "using an isoparametric approach." << endl;
-            }
-            if ( targetZone == 0 && structural_target ) {
-              if (rank == MASTER_NODE) cout << "Consistent and conservative interpolation assumes the structure model mesh is evaluated second. Somehow this has not happened. The isoparametric coefficients will be calculated for both meshes, and are not guaranteed to be consistent." << endl;
-            }
-
-
-            break;
-
           }
         }
 

--- a/SU2_CFD/src/transfer_physics.cpp
+++ b/SU2_CFD/src/transfer_physics.cpp
@@ -49,18 +49,7 @@ CTransfer_FlowTraction::~CTransfer_FlowTraction(void) {
 
 }
 
-void CTransfer_FlowTraction::GetPhysical_Constants(CSolver *flow_solution, CSolver *struct_solution,
-                                                         CGeometry *flow_geometry, CGeometry *struct_geometry,
-                           CConfig *flow_config, CConfig *struct_config) {
-
-  unsigned short iVar;
-
-  /*--- We have to clear the traction before applying it, because we are "adding" to node and not "setting" ---*/
-
-  for (unsigned long iPoint = 0; iPoint < struct_geometry->GetnPoint(); iPoint++) 
-    struct_solution->node[iPoint]->Clear_FlowTraction();
-
-  /*--- Redimensionalize the pressure ---*/
+void CTransfer_FlowTraction::Compute_Pressure_Dimensional_Factor(CConfig *flow_config) {
 
   su2double *Velocity_ND, *Velocity_Real;
   su2double Density_ND,  Density_Real, Velocity2_Real, Velocity2_ND;
@@ -73,12 +62,33 @@ void CTransfer_FlowTraction::GetPhysical_Constants(CSolver *flow_solution, CSolv
 
   Velocity2_Real = 0.0;
   Velocity2_ND   = 0.0;
-  for (iVar = 0; iVar < nVar; iVar++) {
+  for (unsigned short iVar = 0; iVar < nVar; iVar++) {
     Velocity2_Real += Velocity_Real[iVar]*Velocity_Real[iVar];
     Velocity2_ND   += Velocity_ND[iVar]*Velocity_ND[iVar];
   }
 
   Physical_Constants[0] = Density_Real * Velocity2_Real / ( Density_ND * Velocity2_ND );
+}
+
+void CTransfer_FlowTraction::GetPhysical_Constants(CSolver *flow_solution, CSolver *struct_solution,
+                                                         CGeometry *flow_geometry, CGeometry *struct_geometry,
+                           CConfig *flow_config, CConfig *struct_config) {
+
+  /*--- Store if consistent interpolation is in use, in which case we need to transfer stresses
+        and integrate on the structural side rather than directly transferring forces. ---*/
+  consistent_interpolation = !flow_config->GetMatchingMesh() &&
+                             !(flow_config->GetKindInterpolation() == WEIGHTED_AVERAGE) &&
+                             !flow_config->GetConservativeInterpolation();
+
+  /*--- We have to clear the traction before applying it, because we are "adding" to node and not "setting" ---*/
+
+  for (unsigned long iPoint = 0; iPoint < struct_geometry->GetnPoint(); iPoint++) 
+    struct_solution->node[iPoint]->Clear_FlowTraction();
+
+
+  /*--- Redimensionalize the pressure ---*/
+
+  Compute_Pressure_Dimensional_Factor(flow_config);
 
   /*--- Apply a ramp to the transfer of the fluid loads ---*/
 
@@ -115,7 +125,7 @@ void CTransfer_FlowTraction::GetDonor_Variable(CSolver *flow_solution, CGeometry
 
   unsigned short iVar, jVar;
   unsigned long Point_Flow;
-  su2double *Normal_Flow;
+  su2double const *Normal_Flow;
 
   // Check the kind of fluid problem
   bool compressible       = (flow_config->GetKind_Regime() == COMPRESSIBLE);
@@ -130,17 +140,25 @@ void CTransfer_FlowTraction::GetDonor_Variable(CSolver *flow_solution, CGeometry
   // Pinf: Pressure_infinite
   // div_vel: Velocity divergence
   // Dij: Dirac delta
+  // area: area of the face, needed if we transfer stress instead of force
   su2double Pn = 0.0, div_vel = 0.0;
   su2double Viscosity = 0.0;
   su2double Tau[3][3] = {{0.0, 0.0, 0.0},{0.0, 0.0, 0.0},{0.0, 0.0, 0.0}};
   su2double Grad_Vel[3][3] = {{0.0, 0.0, 0.0},{0.0, 0.0, 0.0},{0.0, 0.0, 0.0}};
   su2double delta[3][3] = {{1.0, 0.0, 0.0},{0.0,1.0,0.0},{0.0,0.0,1.0}};
+  su2double area = 0.0;
 
   su2double Pinf = flow_solution->GetPressure_Inf();
 
   Point_Flow = flow_geometry->vertex[Marker_Flow][Vertex_Flow]->GetNode();
   // Get the normal at the vertex: this normal goes inside the fluid domain.
   Normal_Flow = flow_geometry->vertex[Marker_Flow][Vertex_Flow]->GetNormal();
+  
+  if (consistent_interpolation)
+    for (iVar = 0; iVar < nVar; ++iVar) area += Normal_Flow[iVar]*Normal_Flow[iVar];
+  else
+    area = 1.0;
+  area = sqrt(area);
 
   // Retrieve the values of pressure
 
@@ -180,7 +198,7 @@ void CTransfer_FlowTraction::GetDonor_Variable(CSolver *flow_solution, CGeometry
 
   // Redimensionalize and take into account ramp transfer of the loads
   for (iVar = 0; iVar < nVar; iVar++) {
-    Donor_Variable[iVar] = Donor_Variable[iVar] * Physical_Constants[0] * Physical_Constants[1];
+    Donor_Variable[iVar] *= Physical_Constants[0] * Physical_Constants[1] / area;
   }
 
 }
@@ -189,11 +207,21 @@ void CTransfer_FlowTraction::SetTarget_Variable(CSolver *fea_solution, CGeometry
                         CConfig *fea_config, unsigned long Marker_Struct,
                         unsigned long Vertex_Struct, unsigned long Point_Struct) {
 
+  /*--- Integrate the stress on the structural side if needed ---*/
+  if (consistent_interpolation) {
+    su2double const *normal = fea_geometry->vertex[Marker_Struct][Vertex_Struct]->GetNormal();
+    
+    su2double area = 0.0;
+    for (unsigned short iVar=0; iVar<nVar; ++iVar) area += normal[iVar]*normal[iVar];
+    area = sqrt(area);
+    
+    for (unsigned short iVar=0; iVar<nVar; ++iVar) Target_Variable[iVar] *= area;
+  }
+  
   /*--- Add to the Flow traction ---*/
   fea_solution->node[Point_Struct]->Add_FlowTraction(Target_Variable);
 
 }
-
 
 
 CTransfer_StructuralDisplacements::CTransfer_StructuralDisplacements(void) : CTransfer() {
@@ -234,14 +262,7 @@ void CTransfer_StructuralDisplacements::SetTarget_Variable(CSolver *flow_solutio
                                CConfig *flow_config, unsigned long Marker_Flow,
                                unsigned long Vertex_Flow, unsigned long Point_Flow) {
 
-  su2double VarCoord[3] = {0.0, 0.0, 0.0};
-  unsigned short iVar;
-
-  for (iVar = 0; iVar < nVar; iVar++)
-    VarCoord[iVar] = Target_Variable[iVar];
-
-  flow_geometry->vertex[Marker_Flow][Vertex_Flow]->SetVarCoord(VarCoord);
-
+  flow_geometry->vertex[Marker_Flow][Vertex_Flow]->SetVarCoord(Target_Variable);
 }
 
 CTransfer_StructuralDisplacements_DiscAdj::CTransfer_StructuralDisplacements_DiscAdj(void) : CTransfer() {
@@ -294,11 +315,11 @@ void CTransfer_StructuralDisplacements_DiscAdj::SetTarget_Variable(CSolver *flow
   flow_geometry->vertex[Marker_Flow][Vertex_Flow]->SetVarCoord(VarCoord);
 }
 
-CTransfer_FlowTraction_DiscAdj::CTransfer_FlowTraction_DiscAdj(void) : CTransfer() {
+CTransfer_FlowTraction_DiscAdj::CTransfer_FlowTraction_DiscAdj(void) : CTransfer_FlowTraction() {
 
 }
 
-CTransfer_FlowTraction_DiscAdj::CTransfer_FlowTraction_DiscAdj(unsigned short val_nVar, unsigned short val_nConst, CConfig *config) : CTransfer(val_nVar, val_nConst, config) {
+CTransfer_FlowTraction_DiscAdj::CTransfer_FlowTraction_DiscAdj(unsigned short val_nVar, unsigned short val_nConst, CConfig *config) : CTransfer_FlowTraction(val_nVar, val_nConst, config) {
 
 }
 
@@ -310,121 +331,17 @@ void CTransfer_FlowTraction_DiscAdj::GetPhysical_Constants(CSolver *flow_solutio
                                                CGeometry *flow_geometry, CGeometry *struct_geometry,
                            CConfig *flow_config, CConfig *struct_config){
 
-  unsigned short iVar;
-
   /*--- We have to clear the traction before applying it, because we are "adding" to node and not "setting" ---*/
 
-  for (unsigned long iPoint = 0; iPoint < struct_geometry->GetnPoint(); iPoint++){
+  for (unsigned long iPoint = 0; iPoint < struct_geometry->GetnPoint(); iPoint++)
     struct_solution->node[iPoint]->Clear_FlowTraction();
-  }
 
   /*--- Redimensionalize the pressure ---*/
+  Compute_Pressure_Dimensional_Factor(flow_config);
 
-  su2double *Velocity_ND, *Velocity_Real;
-  su2double Density_ND,  Density_Real, Velocity2_Real, Velocity2_ND;
-
-  Velocity_Real = flow_config->GetVelocity_FreeStream();
-  Density_Real = flow_config->GetDensity_FreeStream();
-
-  Velocity_ND = flow_config->GetVelocity_FreeStreamND();
-  Density_ND = flow_config->GetDensity_FreeStreamND();
-
-  Velocity2_Real = 0.0;
-  Velocity2_ND = 0.0;
-  for (iVar = 0; iVar < nVar; iVar++){
-    Velocity2_Real += Velocity_Real[iVar]*Velocity_Real[iVar];
-    Velocity2_ND += Velocity_ND[iVar]*Velocity_ND[iVar];
-  }
-
-  Physical_Constants[0] = Density_Real*Velocity2_Real/(Density_ND*Velocity2_ND);
-
+  /*--- No ramp applied ---*/
+  Physical_Constants[1] = 1.0;
 }
-
-void CTransfer_FlowTraction_DiscAdj::GetDonor_Variable(CSolver *flow_solution, CGeometry *flow_geometry, CConfig *flow_config,
-                                     unsigned long Marker_Flow, unsigned long Vertex_Flow, unsigned long Point_Struct){
-
-
-  unsigned short iVar, jVar;
-  unsigned long Point_Flow;
-  su2double *Normal_Flow;
-
-  // Check the kind of fluid problem
-  bool compressible       = (flow_config->GetKind_Regime() == COMPRESSIBLE);
-  bool incompressible     = (flow_config->GetKind_Regime() == INCOMPRESSIBLE);
-  bool viscous_flow       = ((flow_config->GetKind_Solver() == NAVIER_STOKES) ||
-                              (flow_config->GetKind_Solver() == RANS) ||
-                              (flow_config->GetKind_Solver() == DISC_ADJ_NAVIER_STOKES) ||
-                              (flow_config->GetKind_Solver() == DISC_ADJ_RANS));
-
-  // Parameters for the calculations
-  // Pn: Pressure
-  // Pinf: Pressure_infinite
-  // div_vel: Velocity divergence
-  // Dij: Dirac delta
-  su2double Pn = 0.0, div_vel = 0.0;
-  su2double Viscosity = 0.0;
-  su2double Tau[3][3] = {{0.0, 0.0, 0.0},{0.0, 0.0, 0.0},{0.0, 0.0, 0.0}};
-  su2double Grad_Vel[3][3] = {{0.0, 0.0, 0.0},{0.0, 0.0, 0.0},{0.0, 0.0, 0.0}};
-  su2double delta[3][3] = {{1.0, 0.0, 0.0},{0.0,1.0,0.0},{0.0,0.0,1.0}};
-
-  su2double Pinf = flow_solution->GetPressure_Inf();
-
-  Point_Flow = flow_geometry->vertex[Marker_Flow][Vertex_Flow]->GetNode();
-    // Get the normal at the vertex: this normal goes inside the fluid domain.
-  Normal_Flow = flow_geometry->vertex[Marker_Flow][Vertex_Flow]->GetNormal();
-
-  // Retrieve the values of pressure
-  Pn = flow_solution->node[Point_Flow]->GetPressure();
-
-  // Calculate tn in the fluid nodes for the inviscid term --> Units of force (non-dimensional).
-  for (iVar = 0; iVar < nVar; iVar++) {
-    Donor_Variable[iVar] = -(Pn-Pinf)*Normal_Flow[iVar];
-  }
-
-  // Calculate tn in the fluid nodes for the viscous term
-
-  if ((incompressible || compressible) && viscous_flow){
-
-    Viscosity = flow_solution->node[Point_Flow]->GetLaminarViscosity();
-
-    for (iVar = 0; iVar < nVar; iVar++) {
-      for (jVar = 0 ; jVar < nVar; jVar++) {
-        Grad_Vel[iVar][jVar] = flow_solution->node[Point_Flow]->GetGradient_Primitive(iVar+1, jVar);
-      }
-    }
-
-    // Divergence of the velocity
-    div_vel = 0.0; for (iVar = 0; iVar < nVar; iVar++) div_vel += Grad_Vel[iVar][iVar];
-
-    for (iVar = 0; iVar < nVar; iVar++) {
-
-      for (jVar = 0 ; jVar < nVar; jVar++) {
-
-        // Viscous stress
-        Tau[iVar][jVar] = Viscosity*(Grad_Vel[jVar][iVar] + Grad_Vel[iVar][jVar]) - TWO3*Viscosity*div_vel*delta[iVar][jVar];
-
-        // Viscous component in the tn vector --> Units of force (non-dimensional).
-        Donor_Variable[iVar] += Tau[iVar][jVar]*Normal_Flow[jVar];
-      }
-    }
-  }
-
-  // Redimensionalize
-  for (iVar = 0; iVar < nVar; iVar++){
-    Donor_Variable[iVar] = Donor_Variable[iVar] * Physical_Constants[0];
-  }
-
-}
-
-void CTransfer_FlowTraction_DiscAdj::SetTarget_Variable(CSolver *fea_solution, CGeometry *fea_geometry,
-                        CConfig *fea_config, unsigned long Marker_Struct,
-                        unsigned long Vertex_Struct, unsigned long Point_Struct){
-
-  /*--- Add to the Flow traction ---*/
-  fea_solution->node[Point_Struct]->Add_FlowTraction(Target_Variable);
-
-}
-
 
 
 CTransfer_ConservativeVars::CTransfer_ConservativeVars(void) : CTransfer() {

--- a/SU2_CFD/src/transfer_physics.cpp
+++ b/SU2_CFD/src/transfer_physics.cpp
@@ -71,14 +71,14 @@ void CTransfer_FlowTraction::Compute_Pressure_Dimensional_Factor(CConfig *flow_c
 }
 
 void CTransfer_FlowTraction::GetPhysical_Constants(CSolver *flow_solution, CSolver *struct_solution,
-                                                         CGeometry *flow_geometry, CGeometry *struct_geometry,
-                           CConfig *flow_config, CConfig *struct_config) {
+                                                   CGeometry *flow_geometry, CGeometry *struct_geometry,
+                                                   CConfig *flow_config, CConfig *struct_config) {
 
   /*--- Store if consistent interpolation is in use, in which case we need to transfer stresses
         and integrate on the structural side rather than directly transferring forces. ---*/
-  consistent_interpolation = !flow_config->GetMatchingMesh() &&
-                             !(flow_config->GetKindInterpolation() == WEIGHTED_AVERAGE) &&
-                             !flow_config->GetConservativeInterpolation();
+  consistent_interpolation = !flow_config->GetMatchingMesh() && (
+                             !flow_config->GetConservativeInterpolation() ||
+                             (flow_config->GetKindInterpolation() == WEIGHTED_AVERAGE));
 
   /*--- We have to clear the traction before applying it, because we are "adding" to node and not "setting" ---*/
 
@@ -238,9 +238,8 @@ CTransfer_StructuralDisplacements::~CTransfer_StructuralDisplacements(void) {
 
 
 void CTransfer_StructuralDisplacements::GetPhysical_Constants(CSolver *struct_solution, CSolver *flow_solution,
-                                                         CGeometry *struct_geometry, CGeometry *flow_geometry,
-                           CConfig *struct_config, CConfig *flow_config) {
-
+                                                              CGeometry *struct_geometry, CGeometry *flow_geometry,
+                                                              CConfig *struct_config, CConfig *flow_config) {
 }
 
 void CTransfer_StructuralDisplacements::GetDonor_Variable(CSolver *struct_solution, CGeometry *struct_geometry, CConfig *struct_config,
@@ -279,9 +278,8 @@ CTransfer_StructuralDisplacements_DiscAdj::~CTransfer_StructuralDisplacements_Di
 
 
 void CTransfer_StructuralDisplacements_DiscAdj::GetPhysical_Constants(CSolver *struct_solution, CSolver *flow_solution,
-                                                         CGeometry *struct_geometry, CGeometry *flow_geometry,
-                           CConfig *struct_config, CConfig *flow_config) {
-
+                                                                      CGeometry *struct_geometry, CGeometry *flow_geometry,
+                                                                      CConfig *struct_config, CConfig *flow_config) {
 }
 
 void CTransfer_StructuralDisplacements_DiscAdj::GetDonor_Variable(CSolver *struct_solution, CGeometry *struct_geometry, CConfig *struct_config,
@@ -328,8 +326,14 @@ CTransfer_FlowTraction_DiscAdj::~CTransfer_FlowTraction_DiscAdj(void) {
 }
 
 void CTransfer_FlowTraction_DiscAdj::GetPhysical_Constants(CSolver *flow_solution, CSolver *struct_solution,
-                                               CGeometry *flow_geometry, CGeometry *struct_geometry,
-                           CConfig *flow_config, CConfig *struct_config){
+                                                           CGeometry *flow_geometry, CGeometry *struct_geometry,
+                                                           CConfig *flow_config, CConfig *struct_config){
+
+  /*--- Store if consistent interpolation is in use, in which case we need to transfer stresses
+        and integrate on the structural side rather than directly transferring forces. ---*/
+  consistent_interpolation = !flow_config->GetMatchingMesh() && (
+                             !flow_config->GetConservativeInterpolation() ||
+                             (flow_config->GetKindInterpolation() == WEIGHTED_AVERAGE));
 
   /*--- We have to clear the traction before applying it, because we are "adding" to node and not "setting" ---*/
 
@@ -358,9 +362,8 @@ CTransfer_ConservativeVars::~CTransfer_ConservativeVars(void) {
 
 
 void CTransfer_ConservativeVars::GetPhysical_Constants(CSolver *donor_solution, CSolver *target_solution,
-                                                             CGeometry *donor_geometry, CGeometry *target_geometry,
-                             CConfig *donor_config, CConfig *target_config) {
-
+                                                       CGeometry *donor_geometry, CGeometry *target_geometry,
+                                                       CConfig *donor_config, CConfig *target_config) {
 }
 
 void CTransfer_ConservativeVars::GetDonor_Variable(CSolver *donor_solution, CGeometry *donor_geometry, CConfig *donor_config,


### PR DESCRIPTION
## Proposed Changes
1 - Generalize the conservative interpolation approach for the following interpolation schemes:
NEAREST_NEIGHBOR, ISOPARAMETRIC, and RADIAL_BASIS_FUNCTION
The therefore redundant CONSISTCONSERVE option can be recovered with:
KIND_INTERPOLATION= ISOPARAMETRIC
CONSERVATIVE_INTERPOLATION= YES
If you guys think the conservative option also makes sense for the WEIGHTED_AVERAGE (sliding mesh) scheme I will put that in too (I am not familiar so left it alone).

2 - In CTransfer_FlowTraction, if not matching mesh and not conservative interpolation:
  Compute the donor variables as stresses instead of forces;
  Integrate the target variables on the structural side before transferring them.

3 - Removed a bit of code duplication in transfer_physics.cpp while I was there.

I have yet to test this for the FSI adjoint but for the direct problem it looks ok.


## Related Work
#596 


## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [X] My contribution is commented and consistent with SU2 style.
