### PR TITLE
avoid calls to blas routines when the data type is not compatible

### DIFF
--- a/Common/include/blas_structure.hpp
+++ b/Common/include/blas_structure.hpp
@@ -101,7 +101,7 @@ public:
 
 private:
 
-#if !defined(HAVE_LIBXSMM) && !defined(HAVE_BLAS) && !defined(HAVE_MKL)
+#if !(defined(HAVE_LIBXSMM) || defined(HAVE_BLAS) || defined(HAVE_MKL)) || (defined(CODI_REVERSE_TYPE) || defined(CODI_FORWARD_TYPE))
     /* Blocking parameters for the outer kernel.  We multiply mc x kc blocks of
      the matrix A with kc x nc panels of the matrix B (this approach is referred
      to as `gebp` in the literature). */

--- a/Common/include/matrix_structure.hpp
+++ b/Common/include/matrix_structure.hpp
@@ -98,7 +98,7 @@ private:
   *LyVector, *FzVector;           /*!< \brief Arrays of the Linelet preconditioner methodology. */
   unsigned long max_nElem;
 
-#ifdef HAVE_MKL
+#if defined(HAVE_MKL) && !(defined(CODI_REVERSE_TYPE) || defined(CODI_FORWARD_TYPE))
   void * MatrixMatrixProductJitter;                   		/*!< \brief Jitter handle for MKL JIT based GEMM. */
   dgemm_jit_kernel_t MatrixMatrixProductKernel;               	/*!< \brief MKL JIT based GEMM kernel. */
   void * MatrixVectorProductJitterBetaZero;           		/*!< \brief Jitter handle for MKL JIT based GEMV. */

--- a/Common/src/fem_geometry_structure.cpp
+++ b/Common/src/fem_geometry_structure.cpp
@@ -5821,7 +5821,7 @@ void CMeshFEM_DG::MetricTermsVolumeElements(CConfig *config) {
 
       /*--- Check if LAPACK/MKL can be used to compute the inverse. ---*/
 
-#if (defined(HAVE_MKL) || defined(HAVE_LAPACK)) && !defined(CODI_REVERSE_TYPE)
+#if (defined(HAVE_MKL) || defined(HAVE_LAPACK)) && !(defined(CODI_REVERSE_TYPE) || defined(CODI_FORWARD_TYPE))
 
       /* The inverse can be computed using the Lapack routines dpotrf
          and dpotri. As the mass matrix is positive definite, a

--- a/Common/src/fem_geometry_structure.cpp
+++ b/Common/src/fem_geometry_structure.cpp
@@ -5821,7 +5821,7 @@ void CMeshFEM_DG::MetricTermsVolumeElements(CConfig *config) {
 
       /*--- Check if LAPACK/MKL can be used to compute the inverse. ---*/
 
-#if defined (HAVE_MKL) || defined(HAVE_LAPACK)
+#if (defined(HAVE_MKL) || defined(HAVE_LAPACK)) && !defined(CODI_REVERSE_TYPE)
 
       /* The inverse can be computed using the Lapack routines dpotrf
          and dpotri. As the mass matrix is positive definite, a

--- a/Common/src/matrix_structure.cpp
+++ b/Common/src/matrix_structure.cpp
@@ -76,7 +76,7 @@ CSysMatrix::CSysMatrix(void) {
   FzVector        = NULL;
   max_nElem       = 0;
 
-#ifdef HAVE_MKL
+#if defined(HAVE_MKL) && !(defined(CODI_REVERSE_TYPE) || defined(CODI_FORWARD_TYPE))
   MatrixMatrixProductJitter 		= NULL;
   MatrixVectorProductJitterBetaOne 	= NULL;
   MatrixVectorProductJitterBetaZero 	= NULL;
@@ -132,7 +132,7 @@ CSysMatrix::~CSysMatrix(void) {
   if (LyVector != NULL)   delete [] LyVector;
   if (FzVector != NULL)   delete [] FzVector;
 
-#ifdef HAVE_MKL
+#if defined(HAVE_MKL) && !(defined(CODI_REVERSE_TYPE) || defined(CODI_FORWARD_TYPE))
   if ( MatrixMatrixProductJitter != NULL ) 		mkl_jit_destroy( MatrixMatrixProductJitter );
   if ( MatrixVectorProductJitterBetaZero != NULL ) 	mkl_jit_destroy( MatrixVectorProductJitterBetaZero );
   if ( MatrixVectorProductJitterBetaOne != NULL ) 	mkl_jit_destroy( MatrixVectorProductJitterBetaOne );
@@ -228,7 +228,7 @@ void CSysMatrix::Initialize(unsigned long nPoint, unsigned long nPointDomain,
 
   /*--- Generate MKL Kernels ---*/
   
-#ifdef HAVE_MKL
+#if defined(HAVE_MKL) && !(defined(CODI_REVERSE_TYPE) || defined(CODI_FORWARD_TYPE))
   /*--- Create MKL JIT kernels if not using adjoint solvers ---*/
   if (!config->GetContinuous_Adjoint() && !config->GetDiscrete_Adjoint())
   {
@@ -564,7 +564,7 @@ void CSysMatrix::SubtractBlock_ILUMatrix(unsigned long block_i, unsigned long bl
 
 void CSysMatrix::MatrixVectorProduct(su2double *matrix, su2double *vector, su2double *product) {
 
-#ifdef HAVE_MKL
+#if defined(HAVE_MKL) && !(defined(CODI_REVERSE_TYPE) || defined(CODI_FORWARD_TYPE))
   // NOTE: matrix/vector swapped due to column major kernel -- manual "CBLAS" setup.
   if (useMKL) 
   {
@@ -586,7 +586,7 @@ void CSysMatrix::MatrixVectorProduct(su2double *matrix, su2double *vector, su2do
 
 void CSysMatrix::MatrixMatrixProduct(su2double *matrix_a, su2double *matrix_b, su2double *product) {
 
-#ifdef HAVE_MKL
+#if defined(HAVE_MKL) && !(defined(CODI_REVERSE_TYPE) || defined(CODI_FORWARD_TYPE))
   if (useMKL)
   {
     MatrixMatrixProductKernel( MatrixMatrixProductJitter, matrix_a, matrix_b, product );
@@ -832,7 +832,7 @@ void CSysMatrix::Gauss_Elimination_ILUMatrix(unsigned long block_i, su2double* r
   }
   else {
 
-#ifdef HAVE_MKL
+#if defined(HAVE_MKL) && !(defined(CODI_REVERSE_TYPE) || defined(CODI_FORWARD_TYPE))
   if (useMKL) {
       // With MKL_DIRECT_CALL enabled, this is significantly faster than native code on Intel Architectures.
       lapack_int * ipiv = new lapack_int [ nVar ];
@@ -1200,7 +1200,7 @@ void CSysMatrix::MatrixVectorProduct(const CSysVector & vec, CSysVector & prod, 
     for (index = row_ptr[row_i]; index < row_ptr[row_i+1]; index++) {
       vec_begin = col_ind[index]*nVar; // offset to beginning of block col_ind[index]
       mat_begin = (index*nVar*nVar); // offset to beginning of matrix block[row_i][col_ind[indx]]
-#ifdef HAVE_MKL
+#if defined(HAVE_MKL) && !(defined(CODI_REVERSE_TYPE) || defined(CODI_FORWARD_TYPE))
       if (useMKL) 
       {
         MatrixVectorProductKernelBetaOne( MatrixVectorProductJitterBetaOne, (double *)&vec[ vec_begin ], (double *)&matrix[ mat_begin ], (double *)&prod[ prod_begin ] );

--- a/Common/src/wall_model.cpp
+++ b/Common/src/wall_model.cpp
@@ -183,7 +183,7 @@ void CWallModel1DEQ::WallShearStressAndHeatFlux(const su2double tExchange,
     // Solve the matrix problem to get the velocity field
     // rhs returned the solution
     //********LAPACK CALL*******
-#if (defined(HAVE_MKL) || defined(HAVE_LAPACK)) && !defined(CODI_REVERSE_TYPE)
+#if (defined(HAVE_MKL) || defined(HAVE_LAPACK)) && !(defined(CODI_REVERSE_TYPE) || defined(CODI_FORWARD_TYPE))
     int info, nrhs = 1;
 
     dgtsv_(&numPoints,&nrhs,lower.data(),diagonal.data(),upper.data(),rhs.data(),&numPoints, &info);
@@ -262,7 +262,7 @@ void CWallModel1DEQ::WallShearStressAndHeatFlux(const su2double tExchange,
     
     // Solve the matrix problem to get the temperature field
     // *******LAPACK CALL********
-#if (defined(HAVE_MKL) || defined(HAVE_LAPACK)) && !defined(CODI_REVERSE_TYPE)
+#if (defined(HAVE_MKL) || defined(HAVE_LAPACK)) && !(defined(CODI_REVERSE_TYPE) || defined(CODI_FORWARD_TYPE))
     dgtsv_(&numPoints,&nrhs,lower.data(),diagonal.data(),upper.data(),rhs.data(),&numPoints, &info);
     if (info != 0)
       SU2_MPI::Error("Unsuccessful call to dgtsv_", CURRENT_FUNCTION);

--- a/Common/src/wall_model.cpp
+++ b/Common/src/wall_model.cpp
@@ -183,7 +183,7 @@ void CWallModel1DEQ::WallShearStressAndHeatFlux(const su2double tExchange,
     // Solve the matrix problem to get the velocity field
     // rhs returned the solution
     //********LAPACK CALL*******
-#if defined (HAVE_MKL) || defined(HAVE_LAPACK)
+#if (defined(HAVE_MKL) || defined(HAVE_LAPACK)) && !defined(CODI_REVERSE_TYPE)
     int info, nrhs = 1;
 
     dgtsv_(&numPoints,&nrhs,lower.data(),diagonal.data(),upper.data(),rhs.data(),&numPoints, &info);
@@ -262,7 +262,7 @@ void CWallModel1DEQ::WallShearStressAndHeatFlux(const su2double tExchange,
     
     // Solve the matrix problem to get the temperature field
     // *******LAPACK CALL********
-#if defined (HAVE_MKL) || defined(HAVE_LAPACK)
+#if (defined(HAVE_MKL) || defined(HAVE_LAPACK)) && !defined(CODI_REVERSE_TYPE)
     dgtsv_(&numPoints,&nrhs,lower.data(),diagonal.data(),upper.data(),rhs.data(),&numPoints, &info);
     if (info != 0)
       SU2_MPI::Error("Unsuccessful call to dgtsv_", CURRENT_FUNCTION);


### PR DESCRIPTION
## Proposed Changes
Avoid calls to external functions when compiling in AD and the datatype becomes incompatible.
(The HAVE_LAPACK flag is compatible with AD in the RBF interpolation but not in the HOM feature).
@vdweide please have a look at this.

## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [X ] I am submitting my contribution to the develop branch.
- [X ] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [X ] My contribution is commented and consistent with SU2 style.
