### PR TITLE
adding implicit check to prevent segfault

### DIFF
--- a/SU2_CFD/src/numerics_direct_mean.cpp
+++ b/SU2_CFD/src/numerics_direct_mean.cpp
@@ -1,4 +1,4 @@
-/*!
+﻿/*!
  * \file numerics_direct_mean.cpp
  * \brief This file contains the numerical methods for compressible flow.
  * \author F. Palacios, T. Economon
@@ -3274,9 +3274,11 @@ void CUpwRoe_Flow::ComputeResidual(su2double *val_residual, su2double **val_Jaco
   if (RoeSoundSpeed2 <= 0.0) {
     for (iVar = 0; iVar < nVar; iVar++) {
       val_residual[iVar] = 0.0;
-      for (jVar = 0; jVar < nVar; jVar++) {
-        val_Jacobian_i[iVar][iVar] = 0.0;
-        val_Jacobian_j[iVar][iVar] = 0.0;
+      if (implicit){
+        for (jVar = 0; jVar < nVar; jVar++) {
+          val_Jacobian_i[iVar][iVar] = 0.0;
+          val_Jacobian_j[iVar][iVar] = 0.0;
+        }
       }
     }
     AD::SetPreaccOut(val_residual, nVar);

--- a/SU2_CFD/src/numerics_direct_mean.cpp
+++ b/SU2_CFD/src/numerics_direct_mean.cpp
@@ -3276,8 +3276,8 @@ void CUpwRoe_Flow::ComputeResidual(su2double *val_residual, su2double **val_Jaco
       val_residual[iVar] = 0.0;
       if (implicit){
         for (jVar = 0; jVar < nVar; jVar++) {
-          val_Jacobian_i[iVar][iVar] = 0.0;
-          val_Jacobian_j[iVar][iVar] = 0.0;
+          val_Jacobian_i[iVar][jVar] = 0.0;
+          val_Jacobian_j[iVar][jVar] = 0.0;
         }
       }
     }


### PR DESCRIPTION
## Proposed Changes
Adding an implicit flag to prevent segfault while running Roe scheme explicitly.
 
## Related Work
N/A

## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [x ] I am submitting my contribution to the develop branch.
- [x ] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [ x] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
