### PR TITLE
Fix given displacement BC's of FEA solver and CElasticityMovement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ install:
 
 before_script:
     # Get the test cases
-    - git clone -b develop https://github.com/su2code/TestCases.git ./TestData
+    - git clone -b fix_fea_disp_bc https://github.com/pcarruscag/TestCases.git ./TestData
     - cp -R ./TestData/* ./TestCases/
 
     # Get the tutorial cases

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ install:
 
 before_script:
     # Get the test cases
-    - git clone -b fix_fea_disp_bc https://github.com/pcarruscag/TestCases.git ./TestData
+    - git clone -b develop https://github.com/su2code/TestCases.git ./TestData
     - cp -R ./TestData/* ./TestCases/
 
     # Get the tutorial cases

--- a/Common/src/grid_movement_structure.cpp
+++ b/Common/src/grid_movement_structure.cpp
@@ -9315,14 +9315,43 @@ void CElasticityMovement::UpdateMultiGrid(CGeometry **geometry, CConfig *config)
 
 void CElasticityMovement::SetBoundaryDisplacements(CGeometry *geometry, CConfig *config){
 
-  unsigned short iMarker;
-
   /*--- Get the SU2 module. SU2_CFD will use this routine for dynamically
    deforming meshes (MARKER_FSI_INTERFACE). ---*/
 
   unsigned short Kind_SU2 = config->GetKind_SU2();
 
-  /*--- First of all, move the FSI interfaces. ---*/
+  /*--- Share halo vertex displacements across ranks using the solution vector.
+   The transfer routines do not do this, i.e. halo vertices have wrong values. ---*/
+
+  unsigned short iMarker, iDim;
+  unsigned long iNode, iVertex;
+
+  su2double VarIncrement = 1.0/su2double(config->GetGridDef_Nonlinear_Iter());
+
+  for (iMarker = 0; iMarker < config->GetnMarker_All(); iMarker++) {
+
+    if ((config->GetMarker_All_ZoneInterface(iMarker) != 0) && (Kind_SU2 == SU2_CFD)) {
+
+      for (iVertex = 0; iVertex < geometry->nVertex[iMarker]; iVertex++) {
+
+        /*--- Get node index ---*/
+        iNode = geometry->vertex[iMarker][iVertex]->GetNode();
+
+        if (geometry->node[iNode]->GetDomain()) {
+
+          /*--- Get the displacement on the vertex ---*/
+          for (iDim = 0; iDim < nDim; iDim++)
+             Solution[iDim] = geometry->vertex[iMarker][iVertex]->GetVarCoord()[iDim] * VarIncrement;
+
+          /*--- Initialize the solution vector ---*/
+          LinSysSol.SetBlock(iNode, Solution);
+        }
+      }
+    }
+  }
+  StiffMatrix.SendReceive_Solution(LinSysSol, geometry, config);
+
+  /*--- Apply displacement boundary conditions to the FSI interfaces. ---*/
 
   for (iMarker = 0; iMarker < config->GetnMarker_All(); iMarker++) {
     if ((config->GetMarker_All_ZoneInterface(iMarker) != 0) && (Kind_SU2 == SU2_CFD)) {
@@ -9358,8 +9387,6 @@ void CElasticityMovement::SetClamped_Boundary(CGeometry *geometry, CConfig *conf
   unsigned long iNode, iVertex;
   unsigned long iPoint, jPoint;
 
-  su2double valJacobian_ij_00 = 0.0;
-
   for (iVertex = 0; iVertex < geometry->nVertex[val_marker]; iVertex++) {
 
     /*--- Get node index ---*/
@@ -9386,33 +9413,18 @@ void CElasticityMovement::SetClamped_Boundary(CGeometry *geometry, CConfig *conf
 
       /*--- Delete the full row for node iNode ---*/
       for (jPoint = 0; jPoint < nPoint; jPoint++){
-
-        /*--- Check whether the block is non-zero ---*/
-        valJacobian_ij_00 = StiffMatrix.GetBlock(iNode, jPoint,0,0);
-
-        if (valJacobian_ij_00 != 0.0 ){
-          /*--- Set the rest of the row to 0 ---*/
-          if (iNode != jPoint) {
-            StiffMatrix.SetBlock(iNode,jPoint,matrixZeros);
-          }
-          /*--- And the diagonal to 1.0 ---*/
-          else{
-            StiffMatrix.SetBlock(iNode,jPoint,matrixId);
-          }
+        if (iNode != jPoint) {
+          StiffMatrix.SetBlock(iNode,jPoint,matrixZeros);
+        }
+        else{
+          StiffMatrix.SetBlock(iNode,jPoint,matrixId);
         }
       }
 
       /*--- Delete the full column for node iNode ---*/
       for (iPoint = 0; iPoint < nPoint; iPoint++){
-
-        /*--- Check whether the block is non-zero ---*/
-        valJacobian_ij_00 = StiffMatrix.GetBlock(iPoint, iNode,0,0);
-
-        if (valJacobian_ij_00 != 0.0 ){
-          /*--- Set the rest of the row to 0 ---*/
-          if (iNode != iPoint) {
-            StiffMatrix.SetBlock(iPoint,iNode,matrixZeros);
-          }
+        if (iNode != iPoint) {
+          StiffMatrix.SetBlock(iPoint,iNode,matrixZeros);
         }
       }
     }
@@ -9428,12 +9440,8 @@ void CElasticityMovement::SetMoving_Boundary(CGeometry *geometry, CConfig *confi
 
   unsigned short iDim, jDim;
 
-  su2double *VarCoord = NULL;
-
   unsigned long iNode, iVertex;
   unsigned long iPoint, jPoint;
-
-  su2double VarIncrement = 1.0/((su2double)config->GetGridDef_Nonlinear_Iter());
 
   su2double valJacobian_ij_00 = 0.0;
   su2double auxJacobian_ij[3][3] = {{0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}};
@@ -9444,44 +9452,26 @@ void CElasticityMovement::SetMoving_Boundary(CGeometry *geometry, CConfig *confi
 
     iNode = geometry->vertex[val_marker][iVertex]->GetNode();
 
-    /*--- Get the displacement on the vertex ---*/
+    /*--- Get the displacement of the node ---*/
 
     for (iDim = 0; iDim < nDim; iDim++)
-       VarCoord = geometry->vertex[val_marker][iVertex]->GetVarCoord();
+       Solution[iDim] = LinSysSol.GetBlock(iNode, iDim);
 
     if (geometry->node[iNode]->GetDomain()) {
 
-      if (nDim == 2) {
-        Solution[0] = VarCoord[0] * VarIncrement;  Solution[1] = VarCoord[1] * VarIncrement;
-        Residual[0] = VarCoord[0] * VarIncrement;  Residual[1] = VarCoord[1] * VarIncrement;
-      }
-      else {
-        Solution[0] = VarCoord[0] * VarIncrement;  Solution[1] = VarCoord[1] * VarIncrement;  Solution[2] = VarCoord[2] * VarIncrement;
-        Residual[0] = VarCoord[0] * VarIncrement;  Residual[1] = VarCoord[1] * VarIncrement;  Residual[2] = VarCoord[2] * VarIncrement;
-      }
-
       /*--- Initialize the reaction vector ---*/
 
-      LinSysRes.SetBlock(iNode, Residual);
-      LinSysSol.SetBlock(iNode, Solution);
+      LinSysRes.SetBlock(iNode, Solution);
 
       /*--- STRONG ENFORCEMENT OF THE DISPLACEMENT BOUNDARY CONDITION ---*/
 
       /*--- Delete the full row for node iNode ---*/
       for (jPoint = 0; jPoint < nPoint; jPoint++){
-
-        /*--- Check whether the block is non-zero ---*/
-        valJacobian_ij_00 = StiffMatrix.GetBlock(iNode, jPoint,0,0);
-
-        if (valJacobian_ij_00 != 0.0 ){
-          /*--- Set the rest of the row to 0 ---*/
-          if (iNode != jPoint) {
-            StiffMatrix.SetBlock(iNode,jPoint,matrixZeros);
-          }
-          /*--- And the diagonal to 1.0 ---*/
-          else{
-            StiffMatrix.SetBlock(iNode,jPoint,matrixId);
-          }
+        if (iNode != jPoint) {
+          StiffMatrix.SetBlock(iNode,jPoint,matrixZeros);
+        }
+        else{
+          StiffMatrix.SetBlock(iNode,jPoint,matrixId);
         }
       }
     }
@@ -9506,7 +9496,7 @@ void CElasticityMovement::SetMoving_Boundary(CGeometry *geometry, CConfig *confi
         for (iDim = 0; iDim < nDim; iDim++){
           Residual[iDim] = 0.0;
           for (jDim = 0; jDim < nDim; jDim++){
-            Residual[iDim] += auxJacobian_ij[iDim][jDim] * VarCoord[jDim];
+            Residual[iDim] += auxJacobian_ij[iDim][jDim] * Solution[jDim];
           }
         }
 

--- a/Common/src/grid_movement_structure.cpp
+++ b/Common/src/grid_movement_structure.cpp
@@ -9416,6 +9416,10 @@ void CElasticityMovement::SetClamped_Boundary(CGeometry *geometry, CConfig *conf
         }
       }
     }
+    else {
+      /*--- Delete the column (iPoint is halo so Send/Recv does the rest) ---*/
+      for (iPoint = 0; iPoint < nPoint; iPoint++) StiffMatrix.SetBlock(iPoint,iNode,matrixZeros);
+    }
   }
 
 }
@@ -9440,7 +9444,7 @@ void CElasticityMovement::SetMoving_Boundary(CGeometry *geometry, CConfig *confi
 
     iNode = geometry->vertex[val_marker][iVertex]->GetNode();
 
-    /*--- Get the displ;acement on the vertex ---*/
+    /*--- Get the displacement on the vertex ---*/
 
     for (iDim = 0; iDim < nDim; iDim++)
        VarCoord = geometry->vertex[val_marker][iVertex]->GetVarCoord();
@@ -9480,42 +9484,42 @@ void CElasticityMovement::SetMoving_Boundary(CGeometry *geometry, CConfig *confi
           }
         }
       }
+    }
 
-      /*--- Delete the columns for a particular node ---*/
+    /*--- Always delete the iNode column, even for halos ---*/
+    for (iPoint = 0; iPoint < nPoint; iPoint++){
 
-      for (iPoint = 0; iPoint < nPoint; iPoint++){
+      /*--- Check if the term K(iPoint, iNode) is 0 ---*/
+      valJacobian_ij_00 = StiffMatrix.GetBlock(iPoint,iNode,0,0);
 
-        /*--- Check if the term K(iPoint, iNode) is 0 ---*/
-        valJacobian_ij_00 = StiffMatrix.GetBlock(iPoint,iNode,0,0);
+      /*--- If the node iNode has a crossed dependency with the point iPoint ---*/
+      if (valJacobian_ij_00 != 0.0 ){
 
-        /*--- If the node iNode has a crossed dependency with the point iPoint ---*/
-        if (valJacobian_ij_00 != 0.0 ){
-
-          /*--- Retrieve the Jacobian term ---*/
-          for (iDim = 0; iDim < nDim; iDim++){
-            for (jDim = 0; jDim < nDim; jDim++){
-              auxJacobian_ij[iDim][jDim] = StiffMatrix.GetBlock(iPoint,iNode,iDim,jDim);
-            }
+        /*--- Retrieve the Jacobian term ---*/
+        for (iDim = 0; iDim < nDim; iDim++){
+          for (jDim = 0; jDim < nDim; jDim++){
+            auxJacobian_ij[iDim][jDim] = StiffMatrix.GetBlock(iPoint,iNode,iDim,jDim);
           }
+        }
 
-          /*--- Multiply by the imposed displacement ---*/
-          for (iDim = 0; iDim < nDim; iDim++){
-            Residual[iDim] = 0.0;
-            for (jDim = 0; jDim < nDim; jDim++){
-              Residual[iDim] += auxJacobian_ij[iDim][jDim] * VarCoord[jDim];
-            }
+        /*--- Multiply by the imposed displacement ---*/
+        for (iDim = 0; iDim < nDim; iDim++){
+          Residual[iDim] = 0.0;
+          for (jDim = 0; jDim < nDim; jDim++){
+            Residual[iDim] += auxJacobian_ij[iDim][jDim] * VarCoord[jDim];
           }
+        }
 
-          /*--- For the whole column, except the diagonal term ---*/
-          if (iNode != iPoint) {
-            /*--- The term is substracted from the residual (right hand side) ---*/
-            LinSysRes.SubtractBlock(iPoint, Residual);
-            /*--- The Jacobian term is now set to 0 ---*/
-            StiffMatrix.SetBlock(iPoint,iNode,matrixZeros);
-          }
+        /*--- For the whole column, except the diagonal term ---*/
+        if (iNode != iPoint) {
+          /*--- The term is substracted from the residual (right hand side) ---*/
+          LinSysRes.SubtractBlock(iPoint, Residual);
+          /*--- The Jacobian term is now set to 0 ---*/
+          StiffMatrix.SetBlock(iPoint,iNode,matrixZeros);
         }
       }
     }
+
   }
 
 }

--- a/SU2_CFD/src/solver_direct_elasticity.cpp
+++ b/SU2_CFD/src/solver_direct_elasticity.cpp
@@ -2653,20 +2653,14 @@ void CFEASolver::BC_DispDir(CGeometry *geometry, CSolver **solver_container, CNu
 
       /*--- Delete the full row for node iNode ---*/
       for (jPoint = 0; jPoint < nPoint; jPoint++){
-
-        /*--- Check whether the block is non-zero ---*/
-        valJacobian_ij_00 = Jacobian.GetBlock(iNode, jPoint,0,0);
-
-        if (valJacobian_ij_00 != 0.0 ){
-          if (iNode != jPoint) {
-            Jacobian.SetBlock(iNode,jPoint,mZeros_Aux);
-          }
-          else{
-            Jacobian.SetBlock(iNode,jPoint,mId_Aux);
-          }
+        if (iNode != jPoint) {
+          Jacobian.SetBlock(iNode,jPoint,mZeros_Aux);
+        }
+        else{
+          Jacobian.SetBlock(iNode,jPoint,mId_Aux);
         }
       }
-      
+
     }
 
     /*--- Always delete the iNode column, even for halos ---*/


### PR DESCRIPTION
## Proposed Changes
Problem: If a given displacement boundary was cut during partitioning the solver would give wrong results.
Reason: When "de-singularizing" the stiffness matrix the column was only being deleted by the rank that owned the corresponding node.
Fix: All ranks delete the column (and update the load vector).

Before:
![image](https://user-images.githubusercontent.com/38071223/53267067-619d9b00-36da-11e9-8feb-5e77d5c7f3ef.png)

After:
![image](https://user-images.githubusercontent.com/38071223/53267075-695d3f80-36da-11e9-93bf-2e18e2e649dc.png)

## PR Checklist
- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [X] My contribution is commented and consistent with SU2 style.
- [X] I have added a test case that demonstrates my contribution, if necessary.
