### PR TITLE
Moved complex overloads for mac to inline from cpp.

### DIFF
--- a/Common/include/ad_structure.inl
+++ b/Common/include/ad_structure.inl
@@ -201,3 +201,44 @@ namespace AD{
   inline void EndPreacc() {}
 #endif
 }
+
+/*--- If we compile under OSX we have to overload some of the operators for
+ *   complex numbers to avoid the use of the standard operators
+ *  (they use a lot of functions that are only defined for doubles) ---*/
+
+#ifdef __APPLE__
+
+namespace std{
+  
+  template<>
+  inline su2double abs(const complex<su2double>& x){
+    
+    return sqrt(x.real()*x.real() + x.imag()*x.imag());
+    
+  }
+  
+  template<>
+  inline complex<su2double> operator/(const complex<su2double>& x,
+                                      const complex<su2double>& y){
+    
+    su2double d    = (y.real()*y.real() + y.imag()*y.imag());
+    su2double real = (x.real()*y.real() + x.imag()*y.imag())/d;
+    su2double imag = (x.imag()*y.real() - x.real()*y.imag())/d;
+    
+    return complex<su2double>(real, imag);
+    
+  }
+  
+  template<>
+  inline complex<su2double> operator*(const complex<su2double>& x,
+                                      const complex<su2double>& y){
+    
+    su2double real = (x.real()*y.real() - x.imag()*y.imag());
+    su2double imag = (x.imag()*y.real() + x.real()*y.imag());
+    
+    return complex<su2double>(real, imag);
+    
+  }
+}
+#endif
+

--- a/Common/src/ad_structure.cpp
+++ b/Common/src/ad_structure.cpp
@@ -129,39 +129,3 @@ namespace AD {
   }
 #endif
 }
-
-
-/*--- If we compile under OSX we have to overload some of the operators for
- *   complex numbers to avoid the use of the standard operators
- *  (they use a lot of functions that are only defined for doubles) ---*/
-
-#ifdef __APPLE__
-
-namespace std{
-  template<>
-  su2double abs(const complex<su2double>& x){
-    return sqrt(x.real()*x.real() + x.imag()*x.imag());
-  }
-
-  template<>
-  complex<su2double> operator/(const complex<su2double>& x, const complex<su2double>& y){
-
-    su2double d    = (y.real()*y.real() + y.imag()*y.imag());
-    su2double real = (x.real()*y.real() + x.imag()*y.imag())/d;
-    su2double imag = (x.imag()*y.real() - x.real()*y.imag())/d;
-
-    return complex<su2double>(real, imag);
-
-  }
-
-  template<>
-  complex<su2double> operator*(const complex<su2double>& x, const complex<su2double>& y){
-
-    su2double real = (x.real()*y.real() - x.imag()*y.imag());
-    su2double imag = (x.imag()*y.real() + x.real()*y.imag());
-
-    return complex<su2double>(real, imag);
-
-  }
-}
-#endif


### PR DESCRIPTION
## Proposed Changes
*Give a brief overview of your contribution here in a few sentences.*
 
The latest llvm version on mac throws a compile error due to not being able to find some overloaded functions for complex numbers. Moving the overloads from the cpp file to the inline file appears to fix the linkage issue.

## Related Work
*Resolve any issues (bug fix or feature request), note any related PRs, or mention interactions with the work of others, if any.*

N/A

## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [X] My contribution is commented and consistent with SU2 style.

