### PR TITLE
Removing python 2.7 from test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ branches:
         - develop
 
 python:
-    - 2.7
     - 3.6
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ notifications:
   
 branches:
     only:
-        - master
+        - develop
 
 python:
     - 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ notifications:
   
 branches:
     only:
-        - develop
+        - master
 
 python:
     - 3.6


### PR DESCRIPTION
## Proposed Changes
This PR removes python2.7 from the test matrix in travis. We have a lot of development right now and until we have found a better way to speed up regression tests, this is, I think, the best approach to remove that roadblock at the moment:

- There is no real development done in the python framework at the moment
- Usually the incompatibilities between python 2 and 3 can be resolved quite easily.
- Python 2 is marked as deprecated anyway.

If you have other thoughts let me know.

There might be other ways like the caching feature of travis, but it takes effort and time to modify our system.

## Related Work


## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [x] My contribution is commented and consistent with SU2 style.
- [x] I have added a test case that demonstrates my contribution, if necessary.
