### PR TITLE
Fix travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ before_install:
     - hash -r
     - conda config --set always_yes yes --set changeps1 no
     - conda update -q conda
-    - conda install -q python=$TRAVIS_PYTHON_VERSION numpy scipy mpi4py swig
+    - conda install -q -c anaconda python=$TRAVIS_PYTHON_VERSION numpy scipy mpi4py swig
 
     # to avoid interference with MPI
     - test -n $CC  && unset CC


### PR DESCRIPTION
## Proposed Changes

This is a fix for travis. Apparently the default channel for anaconda has changed as it was not able to find mpi4py anymore. 


## Related Work


## PR Checklist


- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [x] My contribution is commented and consistent with SU2 style.
- [x] I have added a test case that demonstrates my contribution, if necessary.
