### PR TITLE
Small fix affecting MPI+MG+RANS

### DIFF
--- a/Common/src/geometry_structure.cpp
+++ b/Common/src/geometry_structure.cpp
@@ -764,7 +764,7 @@ void CGeometry::InitiateComms(CGeometry *geometry,
   unsigned short COUNT_PER_POINT = 0;
   unsigned short MPI_TYPE        = 0;
   
-  unsigned long iPoint, offset, buf_offset;
+  unsigned long iPoint, msg_offset, buf_offset;
   
   int iMessage, iSend, nSend;
   
@@ -827,9 +827,9 @@ void CGeometry::InitiateComms(CGeometry *geometry,
     
     for (iMessage = 0; iMessage < nP2PSend; iMessage++) {
       
-      /*--- Compute our location in the send buffer. ---*/
+      /*--- Get the offset in the buffer for the start of this message. ---*/
       
-      offset = nPoint_P2PSend[iMessage];
+      msg_offset = nPoint_P2PSend[iMessage];
       
       /*--- Total count can include multiple pieces of data per element. ---*/
       
@@ -839,11 +839,11 @@ void CGeometry::InitiateComms(CGeometry *geometry,
         
         /*--- Get the local index for this communicated data. ---*/
         
-        iPoint = geometry->Local_Point_P2PSend[offset + iSend];
+        iPoint = geometry->Local_Point_P2PSend[msg_offset + iSend];
         
         /*--- Compute the offset in the recv buffer for this point. ---*/
         
-        buf_offset = (offset + iSend)*countPerPoint;
+        buf_offset = (msg_offset + iSend)*countPerPoint;
         
         switch (commType) {
           case COORDINATES:
@@ -872,7 +872,7 @@ void CGeometry::InitiateComms(CGeometry *geometry,
             bufDSend[buf_offset] = node[iPoint]->GetMaxLength();
             break;
           case NEIGHBORS:
-            bufSSend[buf_offset] = geometry->node[iPoint]->GetnPoint();
+            bufSSend[buf_offset] = geometry->node[iPoint]->GetnNeighbor();
             break;
           default:
             SU2_MPI::Error("Unrecognized quantity for point-to-point MPI comms.",
@@ -897,7 +897,7 @@ void CGeometry::CompleteComms(CGeometry *geometry,
   /*--- Local variables ---*/
   
   unsigned short iDim;
-  unsigned long iPoint, iRecv, nRecv, offset, buf_offset;
+  unsigned long iPoint, iRecv, nRecv, msg_offset, buf_offset;
   
   int ind, source, iMessage, jRecv;
   SU2_MPI::Status status;
@@ -929,9 +929,9 @@ void CGeometry::CompleteComms(CGeometry *geometry,
       
       jRecv = P2PRecv2Neighbor[source];
       
-      /*--- Get the point offset for the start of this message. ---*/
-      
-      offset = nPoint_P2PRecv[jRecv];
+      /*--- Get the offset in the buffer for the start of this message. ---*/
+
+      msg_offset = nPoint_P2PRecv[jRecv];
       
       /*--- Get the number of packets to be received in this message. ---*/
       
@@ -941,11 +941,11 @@ void CGeometry::CompleteComms(CGeometry *geometry,
         
         /*--- Get the local index for this communicated data. ---*/
         
-        iPoint = geometry->Local_Point_P2PRecv[offset + iRecv];
+        iPoint = geometry->Local_Point_P2PRecv[msg_offset + iRecv];
         
         /*--- Compute the total offset in the recv buffer for this point. ---*/
         
-        buf_offset = (offset + iRecv)*countPerPoint;
+        buf_offset = (msg_offset + iRecv)*countPerPoint;
         
         /*--- Store the data correctly depending on the quantity. ---*/
         

--- a/Common/src/linear_algebra/CSysMatrix.cpp
+++ b/Common/src/linear_algebra/CSysMatrix.cpp
@@ -392,7 +392,7 @@ void CSysMatrix<ScalarType>::InitiateComms(CSysVector<OtherType> & x,
   unsigned short COUNT_PER_POINT = 0;
   unsigned short MPI_TYPE        = 0;
 
-  unsigned long iPoint, offset, buf_offset;
+  unsigned long iPoint, msg_offset, buf_offset;
 
   int iMessage, iSend, nSend;
 
@@ -447,9 +447,9 @@ void CSysMatrix<ScalarType>::InitiateComms(CSysVector<OtherType> & x,
 
         case SOLUTION_MATRIX:
 
-          /*--- Compute our location in the send buffer. ---*/
+          /*--- Get the offset for the start of this message. ---*/
 
-          offset = geometry->nPoint_P2PSend[iMessage];
+          msg_offset = geometry->nPoint_P2PSend[iMessage];
 
           /*--- Total count can include multiple pieces of data per point. ---*/
 
@@ -460,11 +460,11 @@ void CSysMatrix<ScalarType>::InitiateComms(CSysVector<OtherType> & x,
 
             /*--- Get the local index for this communicated data. ---*/
 
-            iPoint = geometry->Local_Point_P2PSend[offset + iSend];
+            iPoint = geometry->Local_Point_P2PSend[msg_offset + iSend];
 
             /*--- Compute the offset in the recv buffer for this point. ---*/
 
-            buf_offset = (offset + iSend)*geometry->countPerPoint;
+            buf_offset = (msg_offset + iSend)*geometry->countPerPoint;
 
             /*--- Load the buffer with the data to be sent. ---*/
 
@@ -483,9 +483,9 @@ void CSysMatrix<ScalarType>::InitiateComms(CSysVector<OtherType> & x,
 
           bufDSend = geometry->bufD_P2PRecv;
 
-          /*--- Compute our location in the send buffer. ---*/
+          /*--- Get the offset for the start of this message. ---*/
 
-          offset = geometry->nPoint_P2PRecv[iMessage];
+          msg_offset = geometry->nPoint_P2PRecv[iMessage];
 
           /*--- Total count can include multiple pieces of data per point. ---*/
 
@@ -498,11 +498,11 @@ void CSysMatrix<ScalarType>::InitiateComms(CSysVector<OtherType> & x,
              again use the recv structure to find the send point, since
              the usual recv points are now the senders in reverse mode. ---*/
 
-            iPoint = geometry->Local_Point_P2PRecv[offset + iSend];
+            iPoint = geometry->Local_Point_P2PRecv[msg_offset + iSend];
 
             /*--- Compute the offset in the recv buffer for this point. ---*/
 
-            buf_offset = (offset + iSend)*geometry->countPerPoint;
+            buf_offset = (msg_offset + iSend)*geometry->countPerPoint;
 
             /*--- Load the buffer with the data to be sent. ---*/
 
@@ -539,7 +539,7 @@ void CSysMatrix<ScalarType>::CompleteComms(CSysVector<OtherType> & x,
   /*--- Local variables ---*/
 
   unsigned short iVar;
-  unsigned long iPoint, iRecv, nRecv, offset, buf_offset;
+  unsigned long iPoint, iRecv, nRecv, msg_offset, buf_offset;
 
   int ind, source, iMessage, jRecv;
   SU2_MPI::Status status;
@@ -572,9 +572,9 @@ void CSysMatrix<ScalarType>::CompleteComms(CSysVector<OtherType> & x,
 
           jRecv = geometry->P2PRecv2Neighbor[source];
 
-          /*--- Get the point offset for the start of this message. ---*/
+          /*--- Get the offset for the start of this message. ---*/
 
-          offset = geometry->nPoint_P2PRecv[jRecv];
+          msg_offset = geometry->nPoint_P2PRecv[jRecv];
 
           /*--- Get the number of packets to be received in this message. ---*/
 
@@ -585,11 +585,11 @@ void CSysMatrix<ScalarType>::CompleteComms(CSysVector<OtherType> & x,
 
             /*--- Get the local index for this communicated data. ---*/
 
-            iPoint = geometry->Local_Point_P2PRecv[offset + iRecv];
+            iPoint = geometry->Local_Point_P2PRecv[msg_offset + iRecv];
 
             /*--- Compute the offset in the recv buffer for this point. ---*/
 
-            buf_offset = (offset + iRecv)*geometry->countPerPoint;
+            buf_offset = (msg_offset + iRecv)*geometry->countPerPoint;
 
             /*--- Store the data correctly depending on the quantity. ---*/
 
@@ -611,9 +611,9 @@ void CSysMatrix<ScalarType>::CompleteComms(CSysVector<OtherType> & x,
 
           jRecv = geometry->P2PSend2Neighbor[source];
 
-          /*--- Get the point offset for the start of this message. ---*/
+          /*--- Get the offset for the start of this message. ---*/
 
-          offset = geometry->nPoint_P2PSend[jRecv];
+          msg_offset = geometry->nPoint_P2PSend[jRecv];
 
           /*--- Get the number of packets to be received in this message. ---*/
 
@@ -624,11 +624,11 @@ void CSysMatrix<ScalarType>::CompleteComms(CSysVector<OtherType> & x,
 
             /*--- Get the local index for this communicated data. ---*/
 
-            iPoint = geometry->Local_Point_P2PSend[offset + iRecv];
+            iPoint = geometry->Local_Point_P2PSend[msg_offset + iRecv];
 
             /*--- Compute the offset in the recv buffer for this point. ---*/
 
-            buf_offset = (offset + iRecv)*geometry->countPerPoint;
+            buf_offset = (msg_offset + iRecv)*geometry->countPerPoint;
 
 
             for (iVar = 0; iVar < nVar; iVar++)

--- a/SU2_CFD/src/solver_structure.cpp
+++ b/SU2_CFD/src/solver_structure.cpp
@@ -262,7 +262,7 @@ void CSolver::InitiatePeriodicComms(CGeometry *geometry,
   
   int iMessage, iSend, nSend;
 
-  unsigned long iPoint, jPoint, offset, buf_offset, iPeriodic, Neighbor_Point;
+  unsigned long iPoint, jPoint, msg_offset, buf_offset, iPeriodic, Neighbor_Point;
   
   su2double *Diff      = new su2double[nVar];
   su2double *Und_Lapl  = new su2double[nVar];
@@ -386,9 +386,9 @@ void CSolver::InitiatePeriodicComms(CGeometry *geometry,
     
     for (iMessage = 0; iMessage < geometry->nPeriodicSend; iMessage++) {
       
-      /*--- Get our location in the send buffer. ---*/
+      /*--- Get the offset in the buffer for the start of this message. ---*/
       
-      offset = geometry->nPoint_PeriodicSend[iMessage];
+      msg_offset = geometry->nPoint_PeriodicSend[iMessage];
       
       /*--- Get the number of periodic points we need to
        communicate on the current periodic marker. ---*/
@@ -401,8 +401,8 @@ void CSolver::InitiatePeriodicComms(CGeometry *geometry,
         /*--- Get the local index for this communicated data. We need
          both the node and periodic face index (for rotations). ---*/
         
-        iPoint    = geometry->Local_Point_PeriodicSend[offset + iSend];
-        iPeriodic = geometry->Local_Marker_PeriodicSend[offset + iSend];
+        iPoint    = geometry->Local_Point_PeriodicSend[msg_offset  + iSend];
+        iPeriodic = geometry->Local_Marker_PeriodicSend[msg_offset + iSend];
         
         /*--- Retrieve the supplied periodic information. ---*/
         
@@ -440,7 +440,7 @@ void CSolver::InitiatePeriodicComms(CGeometry *geometry,
         
         /*--- Compute the offset in the recv buffer for this point. ---*/
         
-        buf_offset = (offset + iSend)*geometry->countPerPeriodicPoint;
+        buf_offset = (msg_offset + iSend)*geometry->countPerPeriodicPoint;
         
         /*--- Load the send buffers depending on the particular value
          that has been requested for communication. ---*/
@@ -1450,7 +1450,7 @@ void CSolver::CompletePeriodicComms(CGeometry *geometry,
   unsigned short nPeriodic = config->GetnMarker_Periodic();
   unsigned short iDim, jDim, iVar, jVar, iPeriodic, nNeighbor;
   
-  unsigned long iPoint, iRecv, nRecv, offset, buf_offset, total_index;
+  unsigned long iPoint, iRecv, nRecv, msg_offset, buf_offset, total_index;
   
   int source, iMessage, jRecv;
   
@@ -1492,9 +1492,9 @@ void CSolver::CompletePeriodicComms(CGeometry *geometry,
       
       jRecv = geometry->PeriodicRecv2Neighbor[source];
       
-      /*--- Get the point offset for the start of this message. ---*/
+      /*--- Get the offset in the buffer for the start of this message. ---*/
       
-      offset = geometry->nPoint_PeriodicRecv[jRecv];
+      msg_offset = geometry->nPoint_PeriodicRecv[jRecv];
       
       /*--- Get the number of packets to be received in this message. ---*/
       
@@ -1505,8 +1505,8 @@ void CSolver::CompletePeriodicComms(CGeometry *geometry,
         
         /*--- Get the local index for this communicated data. ---*/
         
-        iPoint    = geometry->Local_Point_PeriodicRecv[offset + iRecv];
-        iPeriodic = geometry->Local_Marker_PeriodicRecv[offset + iRecv];
+        iPoint    = geometry->Local_Point_PeriodicRecv[msg_offset  + iRecv];
+        iPeriodic = geometry->Local_Marker_PeriodicRecv[msg_offset + iRecv];
         
         /*--- While all periodic face data was accumulated, we only store
          the values for the current pair of periodic faces. This is slightly
@@ -1518,7 +1518,7 @@ void CSolver::CompletePeriodicComms(CGeometry *geometry,
           
           /*--- Compute the offset in the recv buffer for this point. ---*/
           
-          buf_offset = (offset + iRecv)*geometry->countPerPeriodicPoint;
+          buf_offset = (msg_offset + iRecv)*geometry->countPerPeriodicPoint;
           
           /*--- Store the data correctly depending on the quantity. ---*/
           
@@ -1822,7 +1822,7 @@ void CSolver::InitiateComms(CGeometry *geometry,
   unsigned short COUNT_PER_POINT = 0;
   unsigned short MPI_TYPE        = 0;
   
-  unsigned long iPoint, offset, buf_offset;
+  unsigned long iPoint, msg_offset, buf_offset;
   
   int iMessage, iSend, nSend;
   
@@ -1914,9 +1914,9 @@ void CSolver::InitiateComms(CGeometry *geometry,
     
     for (iMessage = 0; iMessage < geometry->nP2PSend; iMessage++) {
       
-      /*--- Compute our location in the send buffer. ---*/
+      /*--- Get the offset in the buffer for the start of this message. ---*/
       
-      offset = geometry->nPoint_P2PSend[iMessage];
+      msg_offset = geometry->nPoint_P2PSend[iMessage];
       
       /*--- Total count can include multiple pieces of data per element. ---*/
       
@@ -1927,11 +1927,11 @@ void CSolver::InitiateComms(CGeometry *geometry,
         
         /*--- Get the local index for this communicated data. ---*/
         
-        iPoint = geometry->Local_Point_P2PSend[offset + iSend];
+        iPoint = geometry->Local_Point_P2PSend[msg_offset + iSend];
         
         /*--- Compute the offset in the recv buffer for this point. ---*/
         
-        buf_offset = (offset + iSend)*geometry->countPerPoint;
+        buf_offset = (msg_offset + iSend)*geometry->countPerPoint;
         
         switch (commType) {
           case SOLUTION:
@@ -2032,7 +2032,7 @@ void CSolver::CompleteComms(CGeometry *geometry,
   /*--- Local variables ---*/
   
   unsigned short iDim, iVar;
-  unsigned long iPoint, iRecv, nRecv, offset, buf_offset;
+  unsigned long iPoint, iRecv, nRecv, msg_offset, buf_offset;
   
   int ind, source, iMessage, jRecv;
   SU2_MPI::Status status;
@@ -2062,9 +2062,9 @@ void CSolver::CompleteComms(CGeometry *geometry,
       
       jRecv = geometry->P2PRecv2Neighbor[source];
       
-      /*--- Get the point offset for the start of this message. ---*/
+      /*--- Get the offset in the buffer for the start of this message. ---*/
       
-      offset = geometry->nPoint_P2PRecv[jRecv];
+      msg_offset = geometry->nPoint_P2PRecv[jRecv];
       
       /*--- Get the number of packets to be received in this message. ---*/
       
@@ -2075,11 +2075,11 @@ void CSolver::CompleteComms(CGeometry *geometry,
         
         /*--- Get the local index for this communicated data. ---*/
         
-        iPoint = geometry->Local_Point_P2PRecv[offset + iRecv];
+        iPoint = geometry->Local_Point_P2PRecv[msg_offset + iRecv];
         
         /*--- Compute the offset in the recv buffer for this point. ---*/
         
-        buf_offset = (offset + iRecv)*geometry->countPerPoint;
+        buf_offset = (msg_offset + iRecv)*geometry->countPerPoint;
         
         /*--- Store the data correctly depending on the quantity. ---*/
         

--- a/SU2_CFD/src/solver_structure.cpp
+++ b/SU2_CFD/src/solver_structure.cpp
@@ -2095,7 +2095,7 @@ void CSolver::CompleteComms(CGeometry *geometry,
           case SOLUTION_EDDY:
             for (iVar = 0; iVar < nVar; iVar++)
               node[iPoint]->SetSolution(iVar, bufDRecv[buf_offset+iVar]);
-            node[iPoint]->SetmuT(bufDRecv[offset+nVar]);
+            node[iPoint]->SetmuT(bufDRecv[buf_offset+nVar]);
             break;
           case UNDIVIDED_LAPLACIAN:
             for (iVar = 0; iVar < nVar; iVar++)

--- a/TestCases/parallel_regression.py
+++ b/TestCases/parallel_regression.py
@@ -291,7 +291,7 @@ def main():
     turb_naca0012_sst_restart_mg.cfg_file  = "turb_NACA0012_sst_multigrid_restart.cfg"
     turb_naca0012_sst_restart_mg.test_iter = 20
     turb_naca0012_sst_restart_mg.ntest_vals = 5
-    turb_naca0012_sst_restart_mg.test_vals = [-6.437367, -4.558626, 1.231779, -0.007820, 0.081480] #last 5 columns
+    turb_naca0012_sst_restart_mg.test_vals = [-6.437400, -4.558626, 1.231779, -0.007820, 0.081480] #last 5 columns
     turb_naca0012_sst_restart_mg.su2_exec  = "parallel_computation.py -f"
     turb_naca0012_sst_restart_mg.timeout   = 3200
     turb_naca0012_sst_restart_mg.tol       = 0.000001


### PR DESCRIPTION
## Proposed Changes
A small typo was causing the eddy viscosity to not be communicated properly.
Thanks @economon for pointing me in the right direction.

## PR Checklist
- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [X] My contribution is commented and consistent with SU2 style.
- [X] I have added a test case that demonstrates my contribution, if necessary.
