### PR TITLE
CMake support for SU2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,147 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(
+  SU2
+  VERSION 6.2.0
+  LANGUAGES CXX C)
+set(SU2_VERSION_NAME "Falcon" CACHE INTERNAL "")
+
+list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_SOURCE_DIR}/cmake)
+include(cmake/ConfigureExternals.cmake)
+
+su2_option(SU2_BUILD_CFD SETUP ON OFF BOOL "Build the SU2_CFD executable")
+su2_option(SU2_BUILD_DOT SETUP ON OFF BOOL "Build the SU2_DOT executable")
+su2_option(SU2_BUILD_MSH SETUP ON OFF BOOL "Build the SU2_MSH executable")
+su2_option(SU2_BUILD_DEF SETUP ON OFF BOOL "Build the SU2_DEF executable")
+su2_option(SU2_BUILD_SOL SETUP ON OFF BOOL "Build the SU2_SOL executable")
+su2_option(SU2_BUILD_GEO SETUP ON OFF BOOL "Build the SU2_GEO executable")
+su2_option(SU2_BUILD_PY_WRAPPER SETUP OFF OFF BOOL "Wrap the SU2 code with Python")
+set(SU2_BUILD_PY ON CACHE INTERNAL "")
+
+if(NOT SU2_BUILD_NORMAL)
+  if(NOT SU2_BUILD_REVERSE)
+    su2_option(SU2_BUILD_DOT HIDE)
+  endif()
+  su2_option(SU2_BUILD_MSH HIDE)
+  su2_option(SU2_BUILD_DEF HIDE)
+  su2_option(SU2_BUILD_SOL HIDE)
+  su2_option(SU2_BUILD_GEO HIDE)
+  su2_option(SU2_BUILD_PY HIDE)
+endif()
+
+if(SU2_BUILD_DIRECTDIFF)
+  su2_option(SU2_BUILD_PY_WRAPPER HIDE)
+endif()
+
+add_subdirectory(Common)
+
+if(SU2_BUILD_PY)
+  add_subdirectory(SU2_PY)
+endif()
+
+if(SU2_BUILD_CFD)
+  add_subdirectory(SU2_CFD)
+endif()
+
+if(SU2_BUILD_DOT)
+  add_subdirectory(SU2_DOT)
+endif()
+
+if(SU2_BUILD_MSH)
+  add_subdirectory(SU2_MSH)
+endif()
+
+if(SU2_BUILD_DEF)
+  add_subdirectory(SU2_DEF)
+endif()
+
+if(SU2_BUILD_SOL)
+  add_subdirectory(SU2_SOL)
+endif()
+
+if(SU2_BUILD_GEO)
+  add_subdirectory(SU2_GEO)
+endif()
+
+if(SU2_BUILD_PY_WRAPPER)
+  add_subdirectory(SU2_PY/pySU2)
+endif()
+
+message(
+  STATUS
+    "
+-------------------------------------------------------------------------
+|    ___ _   _ ___                                                      |
+|   / __| | | |_  )   Release ${SU2_VERSION} '${SU2_VERSION_NAME}'                            |
+|   \\__ \\ |_| |/ /                                                      |
+|   |___/\\___//___|   Suite                                             |
+|                                                                       |
+-------------------------------------------------------------------------
+| The current SU2 release has been coordinated by the                   |
+| SU2 International Developers Society <www.su2devsociety.org>          |
+| with selected contributions from the open-source community.           |
+-------------------------------------------------------------------------
+| The main research teams contributing to the current release are:      |
+| - Prof. Juan J. Alonso's group at Stanford University.                |
+| - Prof. Piero Colonna's group at Delft University of Technology.      |
+| - Prof. Nicolas R. Gauger's group at Kaiserslautern U. of Technology. |
+| - Prof. Alberto Guardone's group at Polytechnic University of Milan.  |
+| - Prof. Rafael Palacios' group at Imperial College London.            |
+| - Prof. Vincent Terrapon's group at the University of Liege.          |
+| - Prof. Edwin van der Weide's group at the University of Twente.      |
+| - Lab. of New Concepts in Aeronautics at Tech. Inst. of Aeronautics.  |
+-------------------------------------------------------------------------
+| Copyright 2012-2019, Francisco D. Palacios, Thomas D. Economon,       |
+|                      Tim Albring, and the SU2 contributors.           |
+|                                                                       |
+| SU2 is free software; you can redistribute it and/or                  |
+| modify it under the terms of the GNU Lesser General Public            |
+| License as published by the Free Software Foundation; either          |
+| version 2.1 of the License, or (at your option) any later version.    |
+|                                                                       |
+| SU2 is distributed in the hope that it will be useful,                |
+| but WITHOUT ANY WARRANTY; without even the implied warranty of        |
+| MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      |
+| Lesser General Public License for more details.                       |
+|                                                                       |
+| You should have received a copy of the GNU Lesser General Public      |
+| License along with SU2. If not, see <http://www.gnu.org/licenses/>.   |
+-------------------------------------------------------------------------
+
+Build Configuration Summary:
+
+    Source code location: ${CMAKE_SOURCE_DIR}
+    Install location:     ${CMAKE_INSTALL_PREFIX}
+    Version:              ${SU2_VERSION}
+    C++ Compiler:         ${CMAKE_CXX_COMPILER}
+    C Compiler:           ${CMAKE_C_COMPILER}
+    MPI support:          ${SU2_ENABLE_MPI}
+    Metis support:        ${SU2_ENABLE_METIS}
+    Parmetis support:     ${SU2_ENABLE_PARMETIS}
+    TecIO support:        ${SU2_ENABLE_TECIO}
+    CGNS support:         ${SU2_ENABLE_CGNS}
+    Mutation++ support:   ${SU2_ENABLE_MUTATIONPP}
+    MKL support:          ${SU2_ENABLE_MKL}
+    Datatype support:
+        double            ${SU2_BUILD_NORMAL}
+        codi_reverse      ${SU2_BUILD_REVERSE}
+        codi_forward      ${SU2_BUILD_DIRECTDIFF}
+
+    Build SU2_CFD:        ${SU2_BUILD_CFD}
+    Build SU2_DOT:        ${SU2_BUILD_DOT}
+    Build SU2_MSH:        ${SU2_BUILD_MSH}
+    Build SU2_DEF:        ${SU2_BUILD_DEF}
+    Build SU2_SOL:        ${SU2_BUILD_SOL}
+    Build SU2_GEO:        ${SU2_BUILD_GEO}
+    Build Py Wrapper:     ${SU2_BUILD_PY_WRAPPER}
+
+Please be sure to add the \$SU2_HOME and \$SU2_RUN environment variables,
+and update your \$PATH (and \$PYTHONPATH if applicable) with \$SU2_RUN.
+
+Based on the input to this configuration, add these lines to your .bashrc file:
+
+export SU2_RUN=\"${CMAKE_INSTALL_PREFIX}/bin\"
+export SU2_HOME=\"${CMAKE_SOURCE_DIR}\"
+export PATH=\$PATH:\$SU2_RUN
+export PYTHONPATH=\$PYTHONPATH:\$SU2_RUN
+")

--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -1,0 +1,149 @@
+project(SU2_common CXX)
+
+include(${CMAKE_SOURCE_DIR}/cmake/functions.cmake)
+
+set(SOURCES
+    include/datatypes/primitive_structure.hpp
+    include/datatypes/primitive_structure.inl
+    # include/datatypes/complex_structure.hpp
+    # include/datatypes/complex_structure.inl
+    include/ad_structure.hpp
+    include/ad_structure.inl
+    include/fem_cgns_elements.hpp
+    include/config_structure.hpp
+    include/config_structure.hpp
+    include/config_structure.inl
+    include/blas_structure.hpp
+    include/dual_grid_structure.hpp
+    include/dual_grid_structure.inl
+    include/fem_geometry_structure.hpp
+    include/fem_geometry_structure.inl
+    include/fem_standard_element.hpp
+    include/fem_standard_element.inl
+    include/geometry_structure.hpp
+    include/geometry_structure.inl
+    include/CMultiGridQueue.hpp
+    include/CMeshReaderFVM.hpp
+    include/CSU2ASCIIMeshReaderFVM.hpp
+    include/CCGNSMeshReaderFVM.hpp
+    include/CRectangularMeshReaderFVM.hpp
+    include/CBoxMeshReaderFVM.hpp
+    include/graph_coloring_structure.hpp
+    include/grid_adaptation_structure.hpp
+    include/grid_adaptation_structure.inl
+    include/grid_movement_structure.hpp
+    include/grid_movement_structure.inl
+    include/option_structure.hpp
+    include/primal_grid_structure.hpp
+    include/primal_grid_structure.inl
+    include/mpi_structure.hpp
+    include/mpi_structure.inl
+    include/datatype_structure.hpp
+    include/datatype_structure.inl
+    include/interpolation_structure.hpp
+    include/fem_gauss_jacobi_quadrature.hpp
+    include/fem_gauss_jacobi_quadrature.inl
+    include/gauss_structure.hpp
+    include/gauss_structure.inl
+    include/element_structure.hpp
+    include/element_structure.inl
+    include/adt_structure.hpp
+    include/adt_structure.inl
+    include/wall_model.hpp
+    include/wall_model.inl
+    include/toolboxes/printing_toolbox.hpp
+    include/toolboxes/CLinearPartitioner.hpp
+    include/toolboxes/MMS/CVerificationSolution.hpp
+    include/toolboxes/MMS/CVerificationSolution.inl
+    include/toolboxes/MMS/CIncTGVSolution.hpp
+    include/toolboxes/MMS/CInviscidVortexSolution.hpp
+    include/toolboxes/MMS/CMMSIncEulerSolution.hpp
+    include/toolboxes/MMS/CMMSIncNSSolution.hpp
+    include/toolboxes/MMS/CMMSNSTwoHalfCirclesSolution.hpp
+    include/toolboxes/MMS/CMMSNSTwoHalfSpheresSolution.hpp
+    include/toolboxes/MMS/CMMSNSUnitQuadSolution.hpp
+    include/toolboxes/MMS/CMMSNSUnitQuadSolutionWallBC.hpp
+    include/toolboxes/MMS/CNSUnitQuadSolution.hpp
+    include/toolboxes/MMS/CRinglebSolution.hpp
+    include/toolboxes/MMS/CTGVSolution.hpp
+    include/toolboxes/MMS/CUserDefinedSolution.hpp
+    include/linear_algebra/CSysVector.hpp
+    include/linear_algebra/CSysMatrix.hpp
+    include/linear_algebra/CSysMatrix.inl
+    include/linear_algebra/CMatrixVectorProduct.hpp
+    include/linear_algebra/CPreconditioner.hpp
+    include/linear_algebra/CSysSolve.hpp
+    include/linear_algebra/CSysSolve_b.hpp
+    src/fem_cgns_elements.cpp
+    src/config_structure.cpp
+    src/blas_structure.cpp
+    src/dual_grid_structure.cpp
+    src/fem_geometry_structure.cpp
+    src/fem_integration_rules.cpp
+    src/fem_standard_element.cpp
+    src/fem_wall_distance.cpp
+    src/fem_work_estimate_metis.cpp
+    src/geometry_structure.cpp
+    src/CMultiGridQueue.cpp
+    src/CMeshReaderFVM.cpp
+    src/CSU2ASCIIMeshReaderFVM.cpp
+    src/CCGNSMeshReaderFVM.cpp
+    src/CRectangularMeshReaderFVM.cpp
+    src/CBoxMeshReaderFVM.cpp
+    src/geometry_structure_fem_part.cpp
+    src/graph_coloring_structure.cpp
+    src/grid_adaptation_structure.cpp
+    src/grid_movement_structure.cpp
+    src/primal_grid_structure.cpp
+    src/mpi_structure.cpp
+    src/ad_structure.cpp
+    src/fem_gauss_jacobi_quadrature.cpp
+    src/gauss_structure.cpp
+    src/element_structure.cpp
+    src/element_linear.cpp
+    src/interpolation_structure.cpp
+    src/adt_structure.cpp
+    src/wall_model.cpp
+    src/toolboxes/printing_toolbox.cpp
+    src/toolboxes/signal_processing_toolbox.cpp
+    src/toolboxes/CLinearPartitioner.cpp
+    src/toolboxes/MMS/CVerificationSolution.cpp
+    src/toolboxes/MMS/CIncTGVSolution.cpp
+    src/toolboxes/MMS/CInviscidVortexSolution.cpp
+    src/toolboxes/MMS/CMMSIncEulerSolution.cpp
+    src/toolboxes/MMS/CMMSIncNSSolution.cpp
+    src/toolboxes/MMS/CMMSNSTwoHalfCirclesSolution.cpp
+    src/toolboxes/MMS/CMMSNSTwoHalfSpheresSolution.cpp
+    src/toolboxes/MMS/CMMSNSUnitQuadSolution.cpp
+    src/toolboxes/MMS/CMMSNSUnitQuadSolutionWallBC.cpp
+    src/toolboxes/MMS/CNSUnitQuadSolution.cpp
+    src/toolboxes/MMS/CRinglebSolution.cpp
+    src/toolboxes/MMS/CTGVSolution.cpp
+    src/toolboxes/MMS/CUserDefinedSolution.cpp
+    src/linear_algebra/CSysVector.cpp
+    src/linear_algebra/CSysMatrix.cpp
+    src/linear_algebra/CSysSolve.cpp
+    src/linear_algebra/CSysSolve_b.cpp
+    src/linear_algebra/CPastixWrapper.cpp)
+
+if(SU2_BUILD_NORMAL)
+  set(TARGET_NAME SU2)
+elseif(SU2_BUILD_DIRECTDIFF)
+  set(TARGET_NAME SU2_DIRECTDIFF)
+elseif(SU2_BUILD_REVERSE)
+  set(TARGET_NAME SU2_AD)
+else()
+  message(
+    FATAL_ERROR "Invalid SU2 build type, neither normal, directdiff or reverse")
+endif()
+
+add_library(${TARGET_NAME} STATIC ${SOURCES})
+target_include_directories(${TARGET_NAME} PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
+
+if(SU2_BUILD_NORMAL)
+  su2_setup_target(${TARGET_NAME})
+else()
+  su2_setup_target(${TARGET_NAME} LIBS WITH_CODI)
+endif()
+
+add_library(SU2::SU2 ALIAS ${TARGET_NAME})

--- a/SU2_CFD/CMakeLists.txt
+++ b/SU2_CFD/CMakeLists.txt
@@ -1,0 +1,143 @@
+project(SU2_CFD CXX)
+
+include(${CMAKE_SOURCE_DIR}/cmake/functions.cmake)
+
+set(SU2_CORE_SOURCES
+    src/definition_structure.cpp
+    src/fluid_model.cpp
+    src/fluid_model_pig.cpp
+    src/fluid_model_pvdw.cpp
+    src/fluid_model_ppr.cpp
+    src/fluid_model_inc.cpp
+    src/integration_structure.cpp
+    src/integration_time.cpp
+    src/drivers/CMultizoneDriver.cpp
+    src/drivers/CSinglezoneDriver.cpp
+    src/drivers/CDiscAdjSinglezoneDriver.cpp
+    src/drivers/CDiscAdjMultizoneDriver.cpp
+    src/drivers/CDriver.cpp
+    src/drivers/CDummyDriver.cpp
+    src/iteration_structure.cpp
+    src/numerics_adjoint_mean.cpp
+    src/numerics_adjoint_turbulent.cpp
+    src/numerics_direct_heat.cpp
+    src/numerics_direct_mean.cpp
+    src/numerics_direct_mean_inc.cpp
+    src/numerics_direct_transition.cpp
+    src/numerics_direct_turbulent.cpp
+    src/numerics_direct_elasticity_nonlinear.cpp
+    src/numerics_direct_elasticity_linear.cpp
+    src/numerics_direct_elasticity.cpp
+    src/numerics/CFEAMeshElasticity.cpp
+    src/numerics_structure.cpp
+    src/numerics_template.cpp
+    src/output/filewriter/CCSVFileWriter.cpp
+    src/output/filewriter/CFEMDataSorter.cpp
+    src/output/filewriter/CFVMDataSorter.cpp
+    src/output/filewriter/CParallelDataSorter.cpp
+    src/output/filewriter/CParallelFileWriter.cpp
+    src/output/filewriter/CParaviewBinaryFileWriter.cpp
+    src/output/filewriter/CParaviewFileWriter.cpp
+    src/output/filewriter/CSurfaceFEMDataSorter.cpp
+    src/output/filewriter/CSurfaceFVMDataSorter.cpp
+    src/output/filewriter/CSU2BinaryFileWriter.cpp
+    src/output/filewriter/CSU2FileWriter.cpp
+    src/output/filewriter/CSU2MeshFileWriter.cpp
+    src/output/filewriter/CTecplotFileWriter.cpp
+    src/output/filewriter/CTecplotBinaryFileWriter.cpp
+    src/output/COutput.cpp
+    src/output/output_physics.cpp
+    src/output/CMeshOutput.cpp
+    src/output/CElasticityOutput.cpp
+    src/output/CFlowOutput.cpp
+    src/output/CFlowCompOutput.cpp
+    src/output/CFlowCompFEMOutput.cpp
+    src/output/CFlowIncOutput.cpp
+    src/output/CHeatOutput.cpp
+    src/output/CBaselineOutput.cpp
+    src/output/CAdjElasticityOutput.cpp
+    src/output/CAdjHeatOutput.cpp
+    src/output/CAdjFlowCompOutput.cpp
+    src/output/CAdjFlowIncOutput.cpp
+    src/output/CMultizoneOutput.cpp
+    src/output/output_structure_legacy.cpp
+    src/python_wrapper_structure.cpp
+    src/solver_adjoint_mean.cpp
+    src/solver_adjoint_turbulent.cpp
+    src/solver_adjoint_discrete.cpp
+    src/solver_adjoint_elasticity.cpp
+    src/solvers/CDiscAdjMeshSolver.cpp
+    src/solver_direct_heat.cpp
+    src/solver_direct_mean.cpp
+    src/solver_direct_mean_fem.cpp
+    src/solver_direct_mean_inc.cpp
+    src/solver_direct_transition.cpp
+    src/solver_direct_turbulent.cpp
+    src/solver_direct_elasticity.cpp
+    src/solvers/CMeshSolver.cpp
+    src/solver_structure.cpp
+    src/solver_template.cpp
+    src/interfaces/CInterface.cpp
+    src/interfaces/cfd/CConservativeVarsInterface.cpp
+    src/interfaces/cfd/CMixingPlaneInterface.cpp
+    src/interfaces/cfd/CSlidingInterface.cpp
+    src/interfaces/cht/CConjugateHeatInterface.cpp
+    src/interfaces/fsi/CDisplacementsInterface.cpp
+    src/interfaces/fsi/CFlowTractionInterface.cpp
+    src/interfaces/fsi/CDiscAdjFlowTractionInterface.cpp
+    src/interfaces/fsi/CDisplacementsInterfaceLegacy.cpp
+    src/interfaces/fsi/CDiscAdjDisplacementsInterfaceLegacy.cpp
+    src/transport_model.cpp
+    src/variables/CFEABoundVariable.cpp
+    src/variables/CDiscAdjMeshBoundVariable.cpp
+    src/variables/CMeshBoundVariable.cpp
+    src/variables/CMeshElement.cpp
+    src/variables/CMeshVariable.cpp
+    src/variables/CHeatFVMVariable.cpp
+    src/variables/CVariable.cpp
+    src/variables/CAdjNSVariable.cpp
+    src/variables/CTurbSSTVariable.cpp
+    src/variables/CAdjTurbVariable.cpp
+    src/variables/CTransLMVariable.cpp
+    src/variables/CDiscAdjFEABoundVariable.cpp
+    src/variables/CDiscAdjFEAVariable.cpp
+    src/variables/CIncEulerVariable.cpp
+    src/variables/CTurbVariable.cpp
+    src/variables/CNSVariable.cpp
+    src/variables/CBaselineVariable.cpp
+    src/variables/CTurbSAVariable.cpp
+    src/variables/CFEAVariable.cpp
+    src/variables/CAdjEulerVariable.cpp
+    src/variables/CDiscAdjVariable.cpp
+    src/variables/CIncNSVariable.cpp
+    src/variables/CEulerVariable.cpp)
+
+set(SU2_CFD_SOURCES include/SU2_CFD.hpp src/SU2_CFD.cpp)
+
+if(SU2_BUILD_NORMAL)
+  set(SU2_CORE_LIB SU2Core)
+  set(SU2_CFD_EXE SU2_CFD)
+elseif(SU2_BUILD_DIRECTDIFF)
+  set(SU2_CORE_LIB SU2Core_DIRECTDIFF)
+  set(SU2_CFD_EXE SU2_CFD_DIRECTDIFF)
+elseif(SU2_BUILD_REVERSE)
+  set(SU2_CORE_LIB SU2Core_AD)
+  set(SU2_CFD_EXE SU2_CFD_AD)
+else()
+  message(
+    FATAL_ERROR "Invalid SU2 build type, neither normal, directdiff or reverse")
+endif()
+
+add_library(${SU2_CORE_LIB} STATIC ${SU2_CORE_SOURCES})
+target_include_directories(${SU2_CORE_LIB} PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
+add_library(SU2::SU2Core ALIAS ${SU2_CORE_LIB})
+
+add_executable(${SU2_CFD_EXE} ${SU2_CFD_SOURCES})
+
+if (SU2_BUILD_NORMAL)
+  su2_setup_target(${SU2_CORE_LIB})
+  su2_setup_target(${SU2_CFD_EXE} LIBS SU2::SU2Core SU2::SU2 WITH_THREADS)
+else()
+  su2_setup_target(${SU2_CORE_LIB} LIBS WITH_CODI)
+  su2_setup_target(${SU2_CFD_EXE} LIBS SU2::SU2Core SU2::SU2 WITH_THREADS WITH_CODI)
+endif()

--- a/SU2_DEF/CMakeLists.txt
+++ b/SU2_DEF/CMakeLists.txt
@@ -1,0 +1,13 @@
+project(SU2_DEF CXX)
+
+if(NOT SU2_BUILD_CFD)
+  message(FATAL_ERROR "SU2_DEF requires SU2_CFD to be built")
+endif()
+
+include(${CMAKE_SOURCE_DIR}/cmake/functions.cmake)
+
+
+set(SU2_DEF_SOURCES include/SU2_DEF.hpp src/SU2_DEF.cpp)
+
+add_executable(SU2_DEF ${SU2_DEF_SOURCES})
+su2_setup_target(SU2_DEF LIBS SU2::SU2Core SU2::SU2 WITH_THREADS)

--- a/SU2_DOT/CMakeLists.txt
+++ b/SU2_DOT/CMakeLists.txt
@@ -1,0 +1,25 @@
+project(SU2_DOT CXX)
+
+if(NOT SU2_BUILD_CFD)
+  message(FATAL_ERROR "SU2_DOT requires SU2_CFD to be built")
+endif()
+
+include(${CMAKE_SOURCE_DIR}/cmake/functions.cmake)
+
+set(SU2_DOT_SOURCES include/SU2_DOT.hpp src/SU2_DOT.cpp)
+
+if(SU2_BUILD_NORMAL)
+  set(SU2_DOT_EXECUTABLE SU2_DOT)
+elseif(SU2_BUILD_REVERSE)
+  set(SU2_DOT_EXECUTABLE SU2_DOT_AD)
+else()
+  message(FATAL_ERROR "SU2_DOT can only be built in normal or reverse mode")
+endif()
+
+add_executable(${SU2_DOT_EXECUTABLE} ${SU2_DOT_SOURCES})
+
+if(SU2_BUILD_NORMAL)
+  su2_setup_target(${SU2_DOT_EXECUTABLE} LIBS SU2::SU2Core SU2::SU2 WITH_THREADS)
+else()
+  su2_setup_target(${SU2_DOT_EXECUTABLE} LIBS SU2::SU2Core SU2::SU2 WITH_THREADS WITH_CODI)
+endif()

--- a/SU2_GEO/CMakeLists.txt
+++ b/SU2_GEO/CMakeLists.txt
@@ -1,0 +1,9 @@
+project(SU2_GEO CXX)
+
+include(${CMAKE_SOURCE_DIR}/cmake/functions.cmake)
+
+
+set(SU2_GEO_SOURCES include/SU2_GEO.hpp src/SU2_GEO.cpp)
+
+add_executable(SU2_GEO ${SU2_GEO_SOURCES})
+su2_setup_target(SU2_GEO LIBS SU2::SU2)

--- a/SU2_MSH/CMakeLists.txt
+++ b/SU2_MSH/CMakeLists.txt
@@ -1,0 +1,8 @@
+project(SU2_MSH CXX)
+
+include(${CMAKE_SOURCE_DIR}/cmake/functions.cmake)
+
+set(SU2_MSH_SOURCES include/SU2_MSH.hpp src/SU2_MSH.cpp)
+
+add_executable(SU2_MSH ${SU2_MSH_SOURCES})
+su2_setup_target(SU2_MSH LIBS SU2::SU2)

--- a/SU2_PY/CMakeLists.txt
+++ b/SU2_PY/CMakeLists.txt
@@ -1,0 +1,24 @@
+project(SU2_PY)
+
+set(SU2_PY_SCRIPTS
+    continuous_adjoint.py
+    compute_uncertainty.py
+    finite_differences.py
+    mesh_deformation.py
+    parallel_computation.py
+    parallel_computation_fsi.py
+    package_tests.py
+    shape_optimization.py
+    merge_solution.py
+    set_ffd_design_var.py
+    compute_polar.py
+    compute_multipoint.py
+    discrete_adjoint.py
+    direct_differentiation.py
+    fsi_computation.py
+    SU2_CFD.py)
+
+add_library(SU2_PY INTERFACE)
+target_include_directories(SU2_PY INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+install(FILES ${SU2_PY_SCRIPTS} DESTINATION bin)
+install(DIRECTORY SU2 FSI DESTINATION bin)

--- a/SU2_PY/pySU2/CMakeLists.txt
+++ b/SU2_PY/pySU2/CMakeLists.txt
@@ -1,0 +1,62 @@
+project(pySU2)
+
+cmake_policy(SET CMP0078 NEW)
+cmake_policy(SET CMP0086 NEW)
+
+include(${CMAKE_SOURCE_DIR}/cmake/functions.cmake)
+
+find_package(Python REQUIRED COMPONENTS Development)
+find_package(SWIG REQUIRED)
+include(UseSWIG)
+
+if(SU2_ENABLE_MPI)
+  find_package(MPI4PY REQUIRED)
+else()
+  set(MPI4PY_INCLUDE_DIR "")
+endif()
+
+set(LINK_LIBS SU2::SU2Core SU2::SU2 Python::Python)
+if(SU2_BUILD_NORMAL)
+  set(SWIG_SRC ${CMAKE_CURRENT_LIST_DIR}/pySU2.i)
+  set(pysu2_LIB pysu2)
+elseif(SU2_BUILD_REVERSE)
+  set(SWIG_SRC ${CMAKE_CURRENT_LIST_DIR}/pySU2ad.i)
+  set(pysu2_LIB pysu2ad)
+  list(APPEND LINK_LIBS WITH_CODI)
+else()
+  message(FATAL_ERROR "pySU2 can only be built in normal or reverse mode")
+endif()
+
+# compile SWIG wrapper with C++
+set_property(SOURCE ${SWIG_SRC} PROPERTY CPLUSPLUS ON)
+set_property(SOURCE ${SWIG_SRC} PROPERTY SWIG_MODULE_NAME ${pysu2_LIB})
+
+# need to pull include directories and compile definitions manually
+# since this is not a real cmake target
+su2_get_compile_options(
+  INCLUDES I
+  DEFINITIONS D
+  LIBS SU2::SU2Core SU2::SU2)
+set_property(SOURCE ${SWIG_SRC} PROPERTY COMPILE_DEFINITIONS ${D})
+set_property(SOURCE ${SWIG_SRC} PROPERTY INCLUDE_DIRECTORIES ${I} ${MPI4PY_INCLUDE_DIR})
+
+if(SU2_BUILD_REVERSE)
+  # need this to make 'using namespace ...;' work https://github.com/swig/swig/issues/1068
+  # though compile times seem to increase by a lot
+  set_property(SOURCE ${SWIG_SRC} PROPERTY COMPILE_OPTIONS -includeall)
+endif()
+
+swig_add_library(
+  ${pysu2_LIB}
+  TYPE SHARED
+  LANGUAGE python
+  SOURCES ${SWIG_SRC})
+
+if(SU2_ENABLE_MPI)
+  list(APPEND LINK_LIBS mpi4py::mpi4py)
+endif()
+
+su2_setup_target(${pysu2_LIB} LIBS ${LINK_LIBS})
+add_library(SU2::pySU2 ALIAS ${pysu2_LIB})
+
+install(FILES "$<TARGET_FILE_DIR:${pysu2_LIB}>/${pysu2_LIB}.py" DESTINATION bin)

--- a/SU2_SOL/CMakeLists.txt
+++ b/SU2_SOL/CMakeLists.txt
@@ -1,0 +1,12 @@
+project(SU2_SOL CXX)
+
+if(NOT SU2_BUILD_CFD)
+  message(FATAL_ERROR "SU2_SOL requires SU2_CFD to be built")
+endif()
+
+include(${CMAKE_SOURCE_DIR}/cmake/functions.cmake)
+
+set(SU2_SOL_SOURCES include/SU2_SOL.hpp src/SU2_SOL.cpp)
+
+add_executable(SU2_SOL ${SU2_SOL_SOURCES})
+su2_setup_target(SU2_SOL LIBS SU2::SU2Core SU2::SU2 WITH_THREADS)

--- a/cmake-format.yaml
+++ b/cmake-format.yaml
@@ -1,0 +1,40 @@
+line_width: 120
+tab_size: 2
+max_subgroups_hwrap: 2
+max_pargs_hwrap: 6
+separate_ctrl_name_with_space: false
+separate_fn_name_with_space: false
+dangle_parens: false
+dangle_align: prefix
+min_prefix_chars: 4
+max_prefix_chars: 10
+max_lines_hwrap: 2
+line_ending: unix
+command_case: canonical
+keyword_case: upper
+additional_commands:
+  foo:
+    flags:
+    - BAR
+    - BAZ
+    kwargs:
+      HEADERS: '*'
+      SOURCES: '*'
+      DEPENDS: '*'
+always_wrap: []
+enable_sort: true
+autosort: false
+hashruler_min_length: 10
+per_command: {}
+layout_passes: {}
+bullet_char: '*'
+enum_char: .
+enable_markup: true
+first_comment_is_literal: false
+literal_comment_pattern: null
+fence_pattern: ^\s*([`~]{3}[`~]*)(.*)$
+ruler_pattern: ^\s*[^\w\s]{3}.*[^\w\s]{3}$
+canonicalize_hashrulers: true
+emit_byteorder_mark: false
+input_encoding: utf-8
+output_encoding: utf-8

--- a/cmake/CheckLinkerFlag.cmake
+++ b/cmake/CheckLinkerFlag.cmake
@@ -1,0 +1,70 @@
+# Original: https://gist.github.com/multiplemonomials/9cc2c4343a4bdd93689520ce64098b84
+
+# CheckLinkerFlag
+# ------------------
+#
+# Checks whether a compiler supports a given linker flag.
+#
+
+include(CheckCSourceCompiles)
+include(CheckCXXSourceCompiles)
+include(CheckFortranSourceCompiles)
+
+include(CMakeCheckCompilerFlagCommonPatterns)
+
+# FLAG: the linker flag to check LANGUAGE: the language to test it on.  C, CXX, or Fortran RESULT: return variable
+
+macro(check_linker_flag FLAG LANGUAGE RESULT)
+  if(NOT DEFINED ${RESULT})
+    set(OLD_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+    set(CMAKE_REQUIRED_FLAGS "${FLAG}")
+    # Normalize locale during test compilation.
+    set(_CheckLinkerFlag_LOCALE_VARS LC_ALL LC_MESSAGES LANG)
+    foreach(v ${_CheckLinkerFlag_LOCALE_VARS})
+      set(_CheckLinkerFlag_SAVED_${v} "$ENV{${v}}")
+      set(ENV{${v}} C)
+    endforeach()
+
+    check_compiler_flag_common_patterns(_CheckLinkerFlag_COMMON_PATTERNS)
+
+    if("${LANGUAGE}" STREQUAL C)
+
+      check_c_source_compiles(
+        "int main(void) { return 0; }"
+        ${RESULT}
+        # Some compilers do not fail with a bad flag
+        FAIL_REGEX
+        "command line option .* is valid for .* but not for C" # GNU
+        ${_CheckLinkerFlag_COMMON_PATTERNS})
+    elseif("${LANGUAGE}" STREQUAL CXX)
+      check_cxx_source_compiles(
+        "int main(void) { return 0; }"
+        ${RESULT}
+        # Some compilers do not fail with a bad flag
+        FAIL_REGEX
+        "command line option .* is valid for .* but not for C++" # GNU
+        ${_CheckLinkerFlag_COMMON_PATTERNS})
+    elseif("${LANGUAGE}" STREQUAL Fortran)
+      check_fortran_source_compiles(
+        "program test
+			print *, \'Hello, world\'
+			end program test"
+        ${RESULT}
+        # Some compilers do not fail with a bad flag
+        FAIL_REGEX
+        "command line option .* is valid for .* but not for Fortran" # GNU
+        ${_CheckLinkerFlag_COMMON_PATTERNS})
+    else()
+      message(FATAL_ERROR "Invalid LANGUAGE argument ${LANGUAGE}")
+    endif()
+
+    foreach(v ${_CheckCCompilerFlag_LOCALE_VARS})
+      set(ENV{${v}} ${_CheckCCompilerFlag_SAVED_${v}})
+      unset(_CheckCCompilerFlag_SAVED_${v})
+    endforeach()
+    unset(_CheckCCompilerFlag_LOCALE_VARS)
+    unset(_CheckCCompilerFlag_COMMON_PATTERNS)
+
+    set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_DEFINITIONS}")
+  endif()
+endmacro(check_linker_flag)

--- a/cmake/ConfigureCGNS.cmake
+++ b/cmake/ConfigureCGNS.cmake
@@ -1,0 +1,11 @@
+include(${CMAKE_CURRENT_LIST_DIR}/functions.cmake)
+
+set(SU2_ENABLE_CGNS
+    OFF
+    CACHE BOOL "Build SU2 with CGNS support")
+
+if(SU2_ENABLE_CGNS)
+  message(STATUS "<<< Configuring library with CGNS support >>>")
+  add_subdirectory(${CMAKE_SOURCE_DIR}/externals/cgns)
+  su2_add_dependency(CGNS TARGETS CGNS::CGNS DEFINITIONS HAVE_CGNS=1)
+endif()

--- a/cmake/ConfigureCLI11.cmake
+++ b/cmake/ConfigureCLI11.cmake
@@ -1,0 +1,2 @@
+include(${CMAKE_CURRENT_LIST_DIR}/functions.cmake)
+su2_add_dependency(CLI11 INCLUDES ${CMAKE_SOURCE_DIR}/externals/CLI11)

--- a/cmake/ConfigureCodi.cmake
+++ b/cmake/ConfigureCodi.cmake
@@ -1,0 +1,87 @@
+include(${CMAKE_CURRENT_LIST_DIR}/functions.cmake)
+
+set(SU2_ENABLE_CODI
+    "no"
+    CACHE STRING "Build executables with codi datatype")
+set_property(CACHE SU2_ENABLE_CODI PROPERTY STRINGS "no" "reverse" "forward")
+set(SU2_CODI_CPPFLAGS
+    ""
+    CACHE STRING "Specific Codi C Preprocessor flags to use")
+
+if(SU2_ENABLE_CODI STREQUAL "forward")
+  set(SU2_BUILD_NORMAL
+      OFF
+      CACHE INTERNAL "")
+  set(SU2_BUILD_DIRECTDIFF
+      ON
+      CACHE INTERNAL "")
+  set(SU2_BUILD_REVERSE
+      OFF
+      CACHE INTERNAL "")
+elseif(SU2_ENABLE_CODI STREQUAL "reverse")
+  set(SU2_BUILD_NORMAL
+      OFF
+      CACHE INTERNAL "")
+  set(SU2_BUILD_DIRECTDIFF
+      OFF
+      CACHE INTERNAL "")
+  set(SU2_BUILD_REVERSE
+      ON
+      CACHE INTERNAL "")
+elseif(SU2_ENABLE_CODI STREQUAL "no")
+  set(SU2_BUILD_NORMAL
+      ON
+      CACHE INTERNAL "")
+  set(SU2_BUILD_DIRECTDIFF
+      OFF
+      CACHE INTERNAL "")
+  set(SU2_BUILD_REVERSE
+      OFF
+      CACHE INTERNAL "")
+else()
+  message(FATAL_ERROR "Invalid SU2_ENABLE_CODI value ${SU2_ENABLE_CODI}, expected one of no, reverse, forward")
+endif()
+
+if(SU2_BUILD_DIRECTDIFF OR SU2_BUILD_REVERSE)
+  message(STATUS "<<< Configuring library with Codi ${SU2_ENABLE_CODI} support >>>")
+
+  set(CODIheader ${CMAKE_SOURCE_DIR}/externals/codi/include/codi.hpp)
+  set(AMPIheader ${CMAKE_SOURCE_DIR}/externals/medi/include/medi/medi.hpp)
+
+  set(sha_version_codi 501dcf0305df147481630f20ce37c2e624fb351f)
+  set(github_repo_codi https://github.com/scicompkl/CoDiPack)
+  set(sha_version_medi a95a23ce7585905c3a731b28c1bb512028fc02bb)
+  set(github_repo_medi https://github.com/SciCompKL/MeDiPack)
+
+  set(medi_name MeDiPack)
+  set(codi_name CoDiPack)
+
+  set(alt_name_medi externals/medi)
+  set(alt_name_codi externals/codi)
+
+  if(NOT EXISTS ${CODIheader})
+    su2_download_module(${codi_name} ${alt_name_codi} ${github_repo_codi} ${sha_version_codi})
+  endif()
+  set(INCLUDE_DIRS "${CMAKE_SOURCE_DIR}/externals/codi/include")
+
+  if(SU2_ENABLE_MPI)
+    if(NOT EXISTS ${AMPIheader})
+      su2_download_module(${medi_name} ${alt_name_medi} ${github_repo_medi} ${sha_version_medi})
+    endif()
+    list(APPEND INCLUDE_DIRS "${CMAKE_SOURCE_DIR}/externals/medi/include" "${CMAKE_SOURCE_DIR}/externals/medi/src")
+  endif()
+
+  if(SU2_BUILD_DIRECTDIFF)
+    list(APPEND CODI_DEFINITIONS "CODI_FORWARD_TYPE")
+  else()
+    list(APPEND CODI_DEFINITIONS "CODI_REVERSE_TYPE")
+  endif()
+
+  # create a header-only target that can be linked against since compiling codi is not required
+  add_library(codi INTERFACE)
+  target_include_directories(codi INTERFACE ${INCLUDE_DIRS})
+  target_compile_definitions(codi INTERFACE ${CODI_DEFINITIONS})
+  add_library(Codi::Codi ALIAS codi)
+
+  su2_add_dependency(CODI TARGETS Codi::Codi DEFINITIONS ${CODI_DEFINITIONS} EXPLICIT)
+endif()

--- a/cmake/ConfigureExternals.cmake
+++ b/cmake/ConfigureExternals.cmake
@@ -1,0 +1,26 @@
+set(SU2_DEPENDENCIES
+    ""
+    CACHE INTERNAL "")
+
+include(${CMAKE_CURRENT_LIST_DIR}/functions.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/TLS.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/ConfigureThreads.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/ConfigureMPI.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/ConfigureCGNS.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/ConfigureMetis.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/ConfigureParmetis.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/ConfigureTecio.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/ConfigureCodi.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/ConfigureMutationpp.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/ConfigureMKL.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/ConfigureCLI11.cmake)
+
+su2_debug("SU2 dependencies: ${SU2_DEPENDENCIES}")
+foreach(dep IN LISTS SU2_DEPENDENCIES)
+  su2_debug(
+    "  ${dep}:
+        TARGETS: ${SU2_DEPENDENCY_${dep}_TARGETS}
+        INCLUDES: ${SU2_DEPENDENCY_${dep}_INCLUDES}
+        DEFINITIONS: ${SU2_DEPENDENCY_${dep}_DEFINITIONS}
+        EXPLICIT: ${SU2_DEPENDENCY_${dep}_EXPLICIT}")
+endforeach()

--- a/cmake/ConfigureMKL.cmake
+++ b/cmake/ConfigureMKL.cmake
@@ -1,0 +1,16 @@
+include(${CMAKE_CURRENT_LIST_DIR}/functions.cmake)
+
+set(SU2_ENABLE_MKL
+    OFF
+    CACHE BOOL "Build SU2 with Intel MKL support")
+
+if(SU2_ENABLE_MKL)
+  set(REQUIRED_MKL_VERSION 20190000)
+  find_package(MKL REQUIRED)
+  if(MKL_VERSION LESS REQUIRED_MKL_VERSION)
+    message(FATAL_ERROR "Unsupported MKL version ${MKL_VERSION}, ${REQUIRED_MKL_VERSION} or greater required")
+  endif()
+
+  message(STATUS "<<< Configuring library with Intel MKL support >>>")
+  su2_add_dependency(MKL TARGETS ${MKL_LIBRARIES} DEFINITIONS HAVE_MKL MKL_DIRECT_CALL_SEQ)
+endif()

--- a/cmake/ConfigureMPI.cmake
+++ b/cmake/ConfigureMPI.cmake
@@ -1,0 +1,12 @@
+include(${CMAKE_CURRENT_LIST_DIR}/functions.cmake)
+
+set(SU2_ENABLE_MPI
+    OFF
+    CACHE BOOL "Build SU2 with MPI support")
+
+if(SU2_ENABLE_MPI)
+  message(STATUS "<<< Configuring library with MPI support >>>")
+  find_package(MPI REQUIRED)
+
+  su2_add_dependency(MPI TARGETS MPI::MPI_CXX DEFINITIONS HAVE_MPI)
+endif()

--- a/cmake/ConfigureMetis.cmake
+++ b/cmake/ConfigureMetis.cmake
@@ -1,0 +1,12 @@
+include(${CMAKE_CURRENT_LIST_DIR}/functions.cmake)
+
+set(SU2_ENABLE_METIS
+    OFF
+    CACHE BOOL "Build SU2 with Metis support")
+
+if(SU2_ENABLE_METIS)
+  message(STATUS "<<< Configuring library with Metis support >>>")
+  add_subdirectory(${CMAKE_SOURCE_DIR}/externals/metis)
+
+  su2_add_dependency(METIS TARGETS Metis::Metis DEFINITIONS HAVE_METIS=1)
+endif()

--- a/cmake/ConfigureMutationpp.cmake
+++ b/cmake/ConfigureMutationpp.cmake
@@ -1,0 +1,12 @@
+include(${CMAKE_CURRENT_LIST_DIR}/functions.cmake)
+
+set(SU2_ENABLE_MUTATIONPP
+    OFF
+    CACHE BOOL "Build SU2 with Mutationpp support")
+
+if(SU2_ENABLE_MUTATIONPP)
+  find_package(mutation++ REQUIRED)
+
+  message(STATUS "<<< Configuring library with Mutationpp support >>>")
+  su2_add_dependency(MUTATIONPP TARGETS mutation++::mutation++ DEFINITIONS HAVE_MUTATIONPP)
+endif()

--- a/cmake/ConfigureParmetis.cmake
+++ b/cmake/ConfigureParmetis.cmake
@@ -1,0 +1,15 @@
+include(${CMAKE_CURRENT_LIST_DIR}/functions.cmake)
+
+set(PARMETIS_DOCSTRING "Build SU2 with Parmetis support")
+su2_option(SU2_ENABLE_PARMETIS SETUP OFF OFF BOOL ${PARMETIS_DOCSTRING})
+
+# hide option if MPI is not used
+if(NOT SU2_ENABLE_MPI)
+  su2_option(SU2_ENABLE_PARMETIS HIDE)
+endif()
+
+if(SU2_ENABLE_PARMETIS)
+  message(STATUS "<<< Configuring library with Parmetis support >>>")
+  add_subdirectory(${CMAKE_SOURCE_DIR}/externals/parmetis)
+  su2_add_dependency(PARMETIS TARGETS Parmetis::Parmetis DEFINITIONS HAVE_PARMETIS=1)
+endif()

--- a/cmake/ConfigureTecio.cmake
+++ b/cmake/ConfigureTecio.cmake
@@ -1,0 +1,18 @@
+include(${CMAKE_CURRENT_LIST_DIR}/functions.cmake)
+
+set(SU2_ENABLE_TECIO
+    OFF
+    CACHE BOOL "Build SU2 with TecIO support")
+
+if(SU2_ENABLE_TECIO)
+  message(STATUS "<<< Configuring library with Tecplot TecIO support >>>")
+  add_subdirectory(${CMAKE_SOURCE_DIR}/externals/tecio)
+  su2_add_dependency(
+    TECIO
+    TARGETS
+    Tecio::Tecio
+    DEFINITIONS
+    HAVE_TECIO=1
+    HAVE_TECPLOT_API=1
+    HAVE_TECPLOT_API_112=1)
+endif()

--- a/cmake/ConfigureThreads.cmake
+++ b/cmake/ConfigureThreads.cmake
@@ -1,0 +1,12 @@
+include(${CMAKE_CURRENT_LIST_DIR}/functions.cmake)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads)
+
+if(Threads_FOUND)
+  set(LIB_THREAD Threads::Threads)
+else()
+  set(LIB_THREAD)
+endif()
+
+su2_add_dependency(THREADS TARGETS "${LIB_THREAD}" EXPLICIT)

--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -1,0 +1,318 @@
+# Original: https://gist.github.com/multiplemonomials/6ee074038778a21cd25b73659a6a82d9
+
+# * Find Intel MKL modified for AMBER Find the MKL libraries
+#
+# NOTE: MKL_MULTI_THREADED requires the patched FindOpenMPFixed module from the Amber-MD/cmake-buildscripts repository.
+#
+# Options:
+#
+# MKL_STATIC        :   use static linking.  Requires linker support for the -Wl,--start-group flag. MKL_MULTI_THREADED:
+# use multi-threading. Requires the FindOpenMP module MKL_MIC           :   Use the Many Integrated Core libraries if
+# they are available MKL_NEEDEXTRA     :   Also import the "extra" MKL libraries (scalapack and cdft) MKL_NEEDINCLUDES :
+# Set to true if you require mkl.h.  Since many applications don't need the header, if this is false, MKL will still
+# count as found even if the headers aren't found.
+#
+# This module defines the following variables:
+#
+# MKL_FOUND            : True if MKL_INCLUDE_DIR are found.  Note that MKL_INCLUDE_DIR      : where to find mkl.h, etc
+# (can be a multi-element list) MKL_INCLUDE_DIRS     : alias for MKL_INCLUDE_DIR MKL_LIBRARIES        : Libraries to
+# link against for your configuration when using C or C++. MKL_FORTRAN_LIBRARIES: Libraries to link against when any
+# Fortran code is being linked.  Use these everywhere if you are mixing Fortran and C/C++.
+#
+# It also creates some imported targets.  Some are for internal use since they have to be used with the correct linker
+# flags. The ones for external use, enabled by the MKL_NEEDEXTRA variable, are:
+#
+# mkl::cdft               - MKL cdft library for Complex Distributed fast Fourier Transforms mkl::scalapack  - MKL
+# ScaLAPACK library for MPI LAPACK operations
+
+include(FindPackageHandleStandardArgs)
+include(${CMAKE_CURRENT_LIST_DIR}/LibraryUtils.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/CheckLinkerFlag.cmake)
+
+if(NOT DEFINED MKL_HOME)
+  # try to find in environment variables..
+  if(DEFINED ENV{MKL_HOME})
+    set(MKL_HOME
+        $ENV{MKL_HOME}
+        CACHE PATH "Root folder of Math Kernel Library")
+  elseif(DEFINED ENV{MKL_ROOT})
+    set(MKL_HOME
+        $ENV{MKL_ROOT}
+        CACHE PATH "Root folder of Math Kernel Library")
+    # now try default folders
+  elseif(WIN32 AND EXISTS "C:/Program Files (x86)/IntelSWTools/compilers_and_libraries/windows/mkl")
+    set(MKL_HOME
+        "C:/Program Files (x86)/IntelSWTools/compilers_and_libraries/windows/mkl"
+        CACHE PATH "Root folder of Math Kernel Library")
+  elseif(EXISTS "/opt/intel/mkl")
+    set(MKL_HOME
+        "/opt/intel/mkl"
+        CACHE PATH "Root folder of Math Kernel Library")
+  else()
+    message(
+      STATUS
+        "Unable to locate MKL_HOME for your system.  To use MKL, set MKL_HOME to point to your MKL installation location."
+    )
+    set(MKL_HOME
+        ""
+        CACHE PATH "Root folder of Math Kernel Library")
+  endif()
+endif()
+
+# local version of import_library() that does not add to the library tracker usage: import_library(<library name>
+# <library path> [include dir 1] [include dir 2]...)
+function(mkl_import_library NAME PATH) # 3rd arg: INCLUDE_DIRS
+
+  # Try to figure out whether it is shared or static.
+  get_lib_type(${PATH} LIB_TYPE)
+
+  if("${LIB_TYPE}" STREQUAL "STATIC")
+    add_library(${NAME} STATIC IMPORTED GLOBAL)
+  else()
+    add_library(${NAME} SHARED IMPORTED GLOBAL)
+  endif()
+
+  set_property(TARGET ${NAME} PROPERTY IMPORTED_LOCATION ${PATH})
+  set_property(TARGET ${NAME} PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${ARGN})
+
+endfunction(mkl_import_library)
+
+# ######################## Headers #######################
+
+# Find include dir
+find_path(MKL_INCLUDE_DIR mkl.h HINTS ${MKL_HOME}/include /usr/include/mkl)
+set(MKL_INCLUDE_DIRS ${MKL_INCLUDE_DIR})
+file(READ "${MKL_INCLUDE_DIR}/mkl_version.h" ver)
+string(REGEX MATCH "INTEL_MKL_VERSION ([0-9]*)" MKL_VERSION ${ver})
+string(REGEX MATCH "__INTEL_MKL__ ([0-9]*)" MKL_VERSION_MAJOR ${ver})
+string(REGEX MATCH "__INTEL_MKL_MINOR__ ([0-9]*)" MKL_VERSION_MINOR ${ver})
+string(REGEX MATCH "__INTEL_MKL_UPDATE__ ([0-9]*)" MKL_VERSION_UPDATE ${ver})
+
+# Find include directory There is no include folder under linux
+if(WIN32)
+  find_path(INTEL_INCLUDE_DIR omp.h PATHS ${MKL_HOME}/../include)
+  set(MKL_INCLUDE_DIRS ${MKL_INCLUDE_DIR} ${INTEL_INCLUDE_DIR})
+endif()
+
+# avoid passing "-NOTFOUND" to imported libraries
+if(MKL_INCLUDE_DIR)
+  set(MKL_INCLUDE_DIR_FOR_IMPLIB ${MKL_INCLUDE_DIR})
+else()
+  set(MKL_INCLUDE_DIR_FOR_IMPLIB "")
+endif()
+
+# ######################## Find libraries #######################
+
+# Handle suffix
+set(_MKL_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+
+if(MKL_STATIC)
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_STATIC_LIBRARY_SUFFIX})
+else()
+  if(DEFINED CMAKE_IMPORT_LIBRARY_SUFFIX)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_SHARED_LIBRARY_SUFFIX} ${CMAKE_IMPORT_LIBRARY_SUFFIX})
+  else()
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_SHARED_LIBRARY_SUFFIX})
+  endif()
+endif()
+
+# names of subdirectories in the lib folder
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  set(MKL_ARCHITECTURES intel64 em64t)
+else()
+  set(MKL_ARCHITECTURES ia32)
+endif()
+
+set(MKL_LIB_PATHS "")
+set(MKL_OMP_LIB_PATHS "") # paths to look for the Intel OpenMP runtime library in
+
+foreach(ARCH ${MKL_ARCHITECTURES})
+  list(APPEND MKL_LIB_PATHS ${MKL_HOME}/lib/${ARCH})
+  list(APPEND MKL_OMP_LIB_PATHS ${MKL_HOME}/../compiler/lib/${ARCH} ${MKL_HOME}/../lib/${ARCH})
+endforeach()
+
+# MKL is composed of four layers: Interface, Threading, Computational and OpenMP
+
+# ######################## Interface layer #######################
+
+# NOTE: right now it's hardcoded to use the 32-bit compatibility versions of certain libraries (lp64 instead of ilp64)
+
+if(WIN32)
+  set(MKL_INTERFACE_LIBNAMES mkl_intel mkl_intel_lp64 mkl_intel_c mkl_intel_c_lp64)
+else()
+  set(MKL_INTERFACE_LIBNAMES mkl_intel mkl_intel_lp64)
+endif()
+
+find_library(
+  MKL_INTERFACE_LIBRARY
+  NAMES ${MKL_INTERFACE_LIBNAMES}
+  HINTS ${MKL_LIB_PATHS})
+
+find_library(
+  MKL_GFORTRAN_INTERFACE_LIBRARY
+  NAMES mkl_gf mkl_gf_lp64
+  HINTS ${MKL_LIB_PATHS})
+
+# gfortran specifically needs a seperate library
+if("${CMAKE_FORTRAN_COMPILER_ID}" STREQUAL GNU)
+  set(MKL_FORTRAN_INTERFACE_LIBRARY MKL_GFORTRAN_INTERFACE_LIBRARY)
+else()
+  set(MKL_FORTRAN_INTERFACE_LIBRARY MKL_INTERFACE_LIBRARY)
+endif()
+
+if(MKL_INTERFACE_LIBRARY)
+  mkl_import_library(mkl::interface ${MKL_INTERFACE_LIBRARY} ${MKL_INCLUDE_DIR_FOR_IMPLIB})
+endif()
+
+if(${MKL_FORTRAN_INTERFACE_LIBRARY})
+  mkl_import_library(mkl::fortran_interface ${${MKL_FORTRAN_INTERFACE_LIBRARY}} ${MKL_INCLUDE_DIR_FOR_IMPLIB})
+endif()
+
+# ####################### Threading layer ########################
+find_library(MKL_SEQUENTIAL_THREADING_LIBRARY mkl_sequential HINTS ${MKL_LIB_PATHS})
+find_library(MKL_INTEL_THREADING_LIBRARY mkl_intel_thread HINTS ${MKL_LIB_PATHS})
+find_library(MKL_GNU_THREADING_LIBRARY mkl_gnu_thread HINTS ${MKL_LIB_PATHS})
+find_library(MKL_PGI_THREADING_LIBRARY mkl_pgi_thread HINTS ${MKL_LIB_PATHS})
+
+if(MKL_MULTI_THREADED)
+
+  # this might not be the best when mixing different compilers, but I'm not sure there IS a correct action to take in
+  # that case.
+  if("${CMAKE_C_COMPILER_ID}" STREQUAL GNU)
+    set(MKL_THREADING_LIBRARY MKL_GNU_THREADING_LIBRARY)
+  elseif("${CMAKE_C_COMPILER_ID}" STREQUAL PGI)
+    set(MKL_THREADING_LIBRARY MKL_PGI_THREADING_LIBRARY)
+  else()
+    set(MKL_THREADING_LIBRARY MKL_INTEL_THREADING_LIBRARY)
+  endif()
+
+else()
+  set(MKL_THREADING_LIBRARY MKL_SEQUENTIAL_THREADING_LIBRARY)
+endif()
+
+if(${MKL_THREADING_LIBRARY})
+  mkl_import_library(mkl::threading "${${MKL_THREADING_LIBRARY}}" ${MKL_INCLUDE_DIR_FOR_IMPLIB})
+endif()
+
+# ###################### Computational layer #####################
+find_library(MKL_CORE_LIBRARY mkl_core HINTS ${MKL_LIB_PATHS})
+
+if(MKL_CORE_LIBRARY)
+  mkl_import_library(mkl::core "${MKL_CORE_LIBRARY}" ${MKL_INCLUDE_DIR_FOR_IMPLIB})
+endif()
+
+if(MKL_NEEDEXTRA)
+  find_library(MKL_FFT_LIBRARY mkl_cdft_core HINTS ${MKL_LIB_PATHS})
+  find_library(MKL_SCALAPACK_LIBRARY mkl_scalapack_core mkl_scalapack_lp64 HINTS ${MKL_LIB_PATHS})
+
+  if(MKL_FFT_LIBRARY)
+    mkl_import_library(mkl::cdft "${MKL_FFT_LIBRARY}" ${MKL_INCLUDE_DIR_FOR_IMPLIB})
+  endif()
+  if(MKL_SCALAPACK_LIBRARY)
+    mkl_import_library(mkl::scalapack "${MKL_SCALAPACK_LIBRARY}" ${MKL_INCLUDE_DIR_FOR_IMPLIB})
+  endif()
+endif()
+
+# ########################### OpenMP Library ##########################
+
+if(MKL_MULTI_THREADED)
+  find_package(OpenMPFixed)
+
+  # NOTE: we don't want to link against the imported targets, because that would apply OpenMP compile flags to anything
+  # linked to MKL
+  set(MKL_OMP_LIBRARY ${OpenMP_C_FLAGS} ${OpenMP_C_LIBRARIES})
+else()
+  set(MKL_OMP_LIBRARY "")
+endif()
+
+# ########################### Link Options ##########################
+
+if(MKL_STATIC)
+  # figure out how to link the static libraries
+  check_linker_flag(-Wl,--start-group C SUPPORTS_LIB_GROUPS)
+
+  if(NOT SUPPORTS_LIB_GROUPS)
+    message(
+      FATAL_ERROR "Your linker does not support library grouping.  MKL cannot be linked statically on this platform.")
+  endif()
+
+  set(LIB_LIST_PREFIX -Wl,--start-group)
+  set(LIB_LIST_SUFFIX -Wl,--end-group)
+
+else()
+  check_linker_flag(-Wl,--no-as-needed C SUPPORTS_NO_AS_NEEDED)
+
+  if(SUPPORTS_NO_AS_NEEDED)
+    set(LIB_LIST_PREFIX -Wl,--no-as-needed)
+  else()
+    # we *hope* that the linker doesn't do as-needed linking at all and thus the flag is not necessary
+    set(LIB_LIST_PREFIX "")
+  endif()
+
+  set(LIB_LIST_SUFFIX "")
+endif()
+
+# Library names to pass to FPHSA
+set(MKL_NEEDED_LIBNAMES MKL_INTERFACE_LIBRARY ${MKL_FORTRAN_INTERFACE_LIBRARY} ${MKL_THREADING_LIBRARY}
+                        MKL_CORE_LIBRARY)
+if(MKL_NEEDINCLUDES)
+  list(APPEND MKL_NEEDED_LIBNAMES MKL_INCLUDE_DIR)
+endif()
+
+# fix MKL_INTERFACE_LIBRARY appearing twice if the fortran interface library is the same as the normal one
+list(REMOVE_DUPLICATES MKL_NEEDED_LIBNAMES)
+
+set(CMAKE_FIND_LIBRARY_SUFFIXES ${_MKL_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
+
+# ########################### Extra Libraries ##########################
+
+# link libdl if it exists
+find_library(LIBDL dl HINTS "")
+if(LIBDL)
+  check_library_exists(dl dlopen ${LIBDL} HAVE_LIBDL)
+else()
+  set(HAVE_LIBDL FALSE)
+endif()
+
+if(HAVE_LIBDL)
+  set(MKL_LIBDL ${LIBDL})
+else()
+  set(MKL_LIBDL "")
+endif()
+
+# Link pthread if it exists
+find_package(Threads)
+
+if(CMAKE_THREAD_LIBS_INIT)
+  set(MKL_PTHREAD_LIB Threads::Threads)
+else()
+  set(MKL_PTHREAD_LIB "")
+endif()
+
+find_package_handle_standard_args(MKL DEFAULT_MSG ${MKL_NEEDED_LIBNAMES})
+
+if(MKL_FOUND)
+  # Build the final library lists
+  set(MKL_LIBRARIES
+      ${LIB_LIST_PREFIX}
+      mkl::core
+      mkl::threading
+      mkl::interface
+      ${LIB_LIST_SUFFIX}
+      ${MKL_LIBDL}
+      ${MKL_PTHREAD_LIB}
+      ${MKL_OMP_LIBRARY})
+  set(MKL_FORTRAN_LIBRARIES
+      ${LIB_LIST_PREFIX}
+      mkl::core
+      mkl::threading
+      mkl::fortran_interface
+      ${LIB_LIST_SUFFIX}
+      ${MKL_LIBDL}
+      ${MKL_PTHREAD_LIB}
+      ${MKL_OMP_LIBRARY})
+else()
+  # Build the final library lists
+  set(MKL_LIBRARIES MKL_LIBRARIES-NOTFOUND)
+  set(MKL_FORTRAN_LIBRARIES MKL_FORTRAN_LIBRARIES-NOTFOUND)
+endif()

--- a/cmake/FindMPI4PY.cmake
+++ b/cmake/FindMPI4PY.cmake
@@ -1,0 +1,50 @@
+# * FindMPI4PY Find mpi4py includes and library This module defines: MPI4PY_INCLUDE_DIR, where to find mpi4py.h, etc.
+#   MPI4PY_FOUND
+
+# https://compacc.fnal.gov/projects/repositories/entry/synergia2/CMake/FindMPI4PY.cmake?rev=c147eafb60728606af4fe7b1b161
+# a660df142e9a
+
+if(NOT MPI4PY_INCLUDE_DIR)
+  if(NOT Python_EXECUTABLE)
+    find_package(Python COMPONENTS Interpreter)
+  endif()
+
+  if(Python_FOUND)
+    execute_process(
+      COMMAND "${Python_EXECUTABLE}" -c "import mpi4py; print(mpi4py.get_include())"
+      OUTPUT_VARIABLE MPI4PY_INCLUDE_DIR
+      RESULT_VARIABLE MPI4PY_COMMAND_RESULT
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    if(MPI4PY_COMMAND_RESULT)
+      message("mpi4py not found: ${MPI4PY_COMMAND_RESULT}")
+      set(MPI4PY_FOUND FALSE)
+    else()
+      if(MPI4PY_INCLUDE_DIR MATCHES "Traceback")
+        message("mpi4py matches traceback")
+        # Did not successfully include MPI4PY
+        set(MPI4PY_FOUND FALSE)
+      else()
+        # successful
+        set(MPI4PY_FOUND TRUE)
+        set(MPI4PY_INCLUDE_DIR
+            ${MPI4PY_INCLUDE_DIR}
+            CACHE STRING "mpi4py include path")
+      endif()
+    endif()
+  else()
+    message("mpi4py not found: could not find Python interpreter")
+    set(MPI4PY_FOUND FALSE)
+  endif()
+else()
+  set(MPI4PY_FOUND TRUE)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(MPI4PY DEFAULT_MSG MPI4PY_INCLUDE_DIR)
+
+if(MPI4PY_FOUND)
+  add_library(mpi4py INTERFACE)
+  target_include_directories(mpi4py INTERFACE ${MPI4PY_INCLUDE_DIR})
+  add_library(mpi4py::mpi4py ALIAS mpi4py)
+endif()

--- a/cmake/LibraryUtils.cmake
+++ b/cmake/LibraryUtils.cmake
@@ -1,0 +1,239 @@
+# Original: https://gist.github.com/multiplemonomials/ec430ac5291ebf712e11cf1068dd6ec2
+
+# Script containing several advanced functions for handling libraries in CMake.
+
+# linker flag prefix -- if a link library starts with this character, it will be ignored by import_libraries() this is
+# needed because FindMKL can return linker flags mixed with its libraries (which is actually the official CMake way of
+# doing things)
+if(TARGET_WINDOWS AND NOT MINGW)
+  set(LINKER_FLAG_PREFIX "/") # stupid illogical MSVC command-line format...
+else()
+  set(LINKER_FLAG_PREFIX "-")
+endif()
+
+# Unfortunately, CMake doesn't let you import a library without knowing whether it is shared or static, and there's no
+# easy way to tell which it is. sets OUTPUT_VARAIBLE to "IMPORT", "SHARED", or "STATIC" depending on the library passed
+function(get_lib_type LIBRARY OUTPUT_VARIABLE)
+
+  if(NOT EXISTS ${LIBRARY})
+    message(FATAL_ERROR "get_lib_type(): library ${LIBRARY} does not exist!")
+  endif()
+
+  get_filename_component(LIB_NAME ${LIBRARY} NAME)
+
+  set(CACHE_VAR_NAME GET_LIB_TYPE_CACHED_RESULT_${LIB_NAME})
+
+  if((DEFINED ${CACHE_VAR_NAME})
+     AND ("${${CACHE_VAR_NAME}}" STREQUAL "SHARED"
+          OR "${${CACHE_VAR_NAME}}" STREQUAL "STATIC"
+          OR "${${CACHE_VAR_NAME}}" STREQUAL "IMPORT"))
+
+    # use cache variable
+    set(${OUTPUT_VARIABLE}
+        ${${CACHE_VAR_NAME}}
+        PARENT_SCOPE)
+    return()
+  endif()
+
+  # first, check for import libraries
+  if(TARGET_WINDOWS)
+    if(MINGW)
+      # on MinGW, import libraries have a different file extension, so our job is easy.
+      if(${LIB_NAME} MATCHES ".*${CMAKE_IMPORT_LIBRARY_SUFFIX}")
+        set(LIB_TYPE IMPORT)
+      endif()
+    else() # MSVC, Intel, or some other Windows compiler
+
+      # we have to work a little harder, and use Dumpbin to check the library type, since import and static libraries
+      # have the same extensions
+      find_program(DUMPBIN dumpbin)
+
+      if(NOT DUMPBIN)
+        message(
+          FATAL_ERROR
+            "The Microsoft Dumpbin tool was not found.  It is needed to analyze libraries, so please set the DUMPBIN variable to point to it."
+        )
+      endif()
+
+      # NOTE: this can take around 2-5 seconds for large libraries -- hence why we cache the result of this function
+      execute_process(
+        COMMAND ${DUMPBIN} -headers ${LIBRARY}
+        OUTPUT_VARIABLE DUMPBIN_OUTPUT
+        ERROR_VARIABLE DUMPBIN_ERROUT
+        RESULT_VARIABLE DUMPBIN_RESULT)
+
+      # sanity check
+      if(NOT ${DUMPBIN_RESULT} EQUAL 0)
+        message(
+          FATAL_ERROR
+            "Could not analyze the type of library ${LIBRARY}: dumpbin failed to execute with output ${DUMPBIN_OUTPUT} and error message ${DUMPBIN_ERROUT}"
+        )
+      endif()
+
+      # check for dynamic symbol entries https://stackoverflow.com/questions/488809/tools-for-inspecting-lib-files
+      if("${DUMPBIN_OUTPUT}" MATCHES "Symbol name  :")
+        # found one!  It's an import library!
+        set(LIB_TYPE IMPORT)
+      else()
+        # by process of elimination, it's a static library
+        set(LIB_TYPE STATIC)
+      endif()
+    endif()
+  endif()
+
+  # now we can figure the rest out by suffix matching
+  if((NOT TARGET_WINDOWS)
+     OR (TARGET_WINDOWS
+         AND MINGW
+         AND "${LIB_TYPE}" STREQUAL ""))
+    if(${LIB_NAME} MATCHES ".*${CMAKE_SHARED_LIBRARY_SUFFIX}")
+      set(LIB_TYPE SHARED)
+    elseif(${LIB_NAME} MATCHES ".*${CMAKE_STATIC_LIBRARY_SUFFIX}")
+      set(LIB_TYPE STATIC)
+    else()
+      message(
+        FATAL_ERROR
+          "Could not determine whether \"${LIBRARY}\" is a static or shared library, it does not have a known suffix.")
+    endif()
+  endif()
+
+  set(${OUTPUT_VARIABLE}
+      ${LIB_TYPE}
+      PARENT_SCOPE)
+  set(${CACHE_VAR_NAME}
+      ${LIB_TYPE}
+      CACHE INTERNAL "Result of get_lib_type() for ${LIB_NAME}" FORCE)
+
+endfunction(get_lib_type)
+
+# Takes a list of CMake libraries that you might pass to a target, and returns a list of resolved library paths that
+# correspond to it. Some libraries are known by full path, others are known by link-name only (as in, the name you'd
+# pass to "ld -l").  They'll be returned in order in LIB_PATHS. Accepts 5 types of thing: full paths to libraries, CMake
+# library targets built by this project, CMake imported targets, CMake interface targets (returns their
+# INTERFACE_LINK_LIBRARIES), and regular linker library names.
+
+# For example, on my system, resolve_cmake_library_list("-Wl,--no-as-
+# needed;mkl::core;mkl::threading;mkl::fortran_interface;/usr/lib/x86_64-linux-
+# gnu/libdl.so;Threads::Threads;arpack;/usr/lib/x86_64-linux-gnu/libm.so") returns "-Wl,--no-as-needed;/home/jamie/anaco
+# nda3/lib/libmkl_core.so;/home/jamie/anaconda3/lib/libmkl_sequential.so;/home/jamie/anaconda3/lib/libmkl_gf_lp64.so;/us
+# r/lib/x86_64-linux-gnu/libdl.so;-lpthread;arpack;/usr/lib/x86_64-linux-gnu/libm.so"
+
+# usage: resolve_cmake_library_list(<path output var> <libs...>)
+function(resolve_cmake_library_list LIB_PATH_OUTPUT)
+  # we don't want to add generator expressions to the library tracker...
+  string(GENEX_STRIP "${ARGN}" LIBS_TO_RESOLVE)
+
+  set(LIB_PATHS "")
+
+  foreach(LIBRARY ${LIBS_TO_RESOLVE})
+    if("${LIBRARY}" MATCHES "^${LINKER_FLAG_PREFIX}")
+      # linker flag
+      list(APPEND LIB_PATHS "${LIBRARY}")
+
+    elseif(EXISTS "${LIBRARY}")
+      # full path to library
+      list(APPEND LIB_PATHS "${LIBRARY}")
+
+    elseif(TARGET "${LIBRARY}")
+
+      get_property(
+        TARGET_LIB_TYPE
+        TARGET ${LIBRARY}
+        PROPERTY TYPE)
+
+      # it's an error to check if an interface library has an imported location
+      if("${TARGET_LIB_TYPE}" STREQUAL "INTERFACE_LIBRARY")
+
+        # interface library -- but it will have dependencies that we need to get.
+        get_property(
+          INTERFACE_LIB_DEPENDENCIES
+          TARGET ${LIBRARY}
+          PROPERTY INTERFACE_LINK_LIBRARIES)
+
+        # avoid crashing CMake if somebody accidentally made an interface library depend on itself
+        list(REMOVE_ITEM INTERFACE_LIB_DEPENDENCIES "${LIBRARY}")
+
+        # now parse those dependencies!
+        resolve_cmake_library_list(INTERFACE_DEPS_LIB_PATHS ${INTERFACE_LIB_DEPENDENCIES})
+
+        list(APPEND LIB_PATHS ${INTERFACE_DEPS_LIB_PATHS})
+
+      else()
+        # must be either imported or an actual target
+        get_property(
+          LIBRARY_HAS_IMPORTED_LOCATION
+          TARGET ${LIBRARY}
+          PROPERTY IMPORTED_LOCATION
+          SET)
+        if(LIBRARY_HAS_IMPORTED_LOCATION)
+          # CMake imported target
+          get_property(
+            LIBRARY_IMPORTED_LOCATION
+            TARGET ${LIBRARY}
+            PROPERTY IMPORTED_LOCATION)
+          list(APPEND LIB_PATHS "${LIBRARY_IMPORTED_LOCATION}")
+
+        else()
+          # else it's a CMake target that is built by this project
+
+          # detect if the library has been renamed
+          get_property(
+            LIB_NAME
+            TARGET ${LIBRARY}
+            PROPERTY OUTPUT_NAME)
+
+          if("${LIB_NAME}" STREQUAL "")
+            # use target name if output name was not set
+            set(LIB_NAME ${LIBRARY})
+          endif()
+
+          list(APPEND LIB_PATHS ${LIB_NAME})
+        endif()
+      endif()
+    else()
+
+      # otherwise it's a library name to find on the linker search path (using CMake in "naive mode")
+      list(APPEND LIB_PATHS ${LIBRARY})
+    endif()
+
+  endforeach()
+
+  # debugging code
+  if(FALSE)
+    message("resolve_cmake_library_list(${LIBS_TO_RESOLVE}):")
+    message("    -> ${LIB_PATHS}")
+  endif()
+
+  set(${LIB_PATH_OUTPUT}
+      ${LIB_PATHS}
+      PARENT_SCOPE)
+endfunction(resolve_cmake_library_list)
+
+# gets the "linker name" (the name you'd pass to "ld -l") for a library file.
+
+function(get_linker_name LIBRARY_PATH OUTPUT_VARIABLE)
+
+  # get full library name
+  get_filename_component(LIBNAME "${LIBRARY_PATH}" NAME)
+
+  # remove prefix
+  string(REGEX REPLACE "^lib" "" LIBNAME "${LIBNAME}")
+
+  # remove numbers after the file extension
+  string(REGEX REPLACE "(\\.[0-9])+$" "" LIBNAME "${LIBNAME}")
+
+  # remove the file extension
+  get_lib_type(${LIBRARY_PATH} LIB_TYPE)
+
+  if("${LIB_TYPE}" STREQUAL "IMPORT")
+    string(REGEX REPLACE "${CMAKE_IMPORT_LIBRARY_SUFFIX}$" "" LIBNAME ${LIBNAME})
+  elseif("${LIB_TYPE}" STREQUAL "STATIC")
+    string(REGEX REPLACE "${CMAKE_STATIC_LIBRARY_SUFFIX}\$" "" LIBNAME ${LIBNAME})
+  else()
+    string(REGEX REPLACE "${CMAKE_SHARED_LIBRARY_SUFFIX}\$" "" LIBNAME ${LIBNAME})
+  endif()
+
+  set(${OUTPUT_VARIABLE}
+      ${LIBNAME}
+      PARENT_SCOPE)
+endfunction(get_linker_name)

--- a/cmake/TLS.cmake
+++ b/cmake/TLS.cmake
@@ -1,0 +1,28 @@
+# don't check if already done
+if(TLS_CHECKED)
+  return()
+endif()
+
+# persist through reconfigures
+set(TLS_CHECKED
+    ON
+    CACHE INTERNAL "")
+
+# Custom check for TLS.
+if(MSVC)
+  add_definitions(-D__thread=__declspec\(thread\))
+else()
+  # This if checks if that value is cached or not.
+  try_compile(HAVE_THREADLOCALSTORAGE ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_LIST_DIR}/check_thread_storage.c)
+  if(HAVE_THREADLOCALSTORAGE)
+    message(STATUS "checking for thread-local storage - found")
+    include(${CMAKE_CURRENT_LIST_DIR}/functions.cmake)
+    add_definitions(-DTLS)
+  else()
+    message(STATUS "checking for thread-local storage - not found")
+  endif()
+
+  if(NOT HAVE_THREADLOCALSTORAGE)
+    add_definitions(-D__thread=)
+  endif()
+endif()

--- a/cmake/check_thread_storage.c
+++ b/cmake/check_thread_storage.c
@@ -1,0 +1,5 @@
+extern __thread int x;
+
+int main(int argc, char** argv) {
+  return 0;
+}

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -1,0 +1,416 @@
+# include guard
+if(INCLUDED)
+  return()
+endif()
+
+set(INCLUDED 1)
+
+#[[
+output additional messages if DEBUG is defined and TRUE
+]]
+function(su2_debug)
+  if(DEBUG)
+    message(STATUS "--Debug: ${ARGN}")
+  endif()
+endfunction()
+
+#[[
+merge list B into A without duplicates
+]]
+function(su2_merge_lists A B)
+  if(NOT ${A})
+    # list A is empty, return B
+    set(${A} ${${B}} PARENT_SCOPE)
+  elseif(${B})
+    # if B is not empty, remove duplicates
+    list(REMOVE_ITEM ${B} ${${A}})
+    list(APPEND ${A} ${${B}}) # append
+    set(${A} ${${A}} PARENT_SCOPE) # return
+  endif()
+endfunction()
+
+#[[
+su2_add_dependency(<NAME> [EXPLICIT]
+                  [TARGETS ...]
+                  [DEFINITIONS ...]
+                  [INCLUDES ...])
+
+setup dependency to SU2 that will be used when building SU2 components
+NAME: name of the dependency to be used in cmake variables
+EXPLICIT: whether using this dependency is explicit, i.e. requires su2_setup_target called with LIBS WITH_<NAME>
+TARGETS: list of targets to link against
+DEFINITIONS: list of compile definitions to use for the build target
+INCLUDES: list of include directories to use for the build target
+
+This function defines:
+SU2_DEPENDENCY_<NAME>_INCLUDES: include directories merged from INCLUDES and INTERFACE_INCLUDE_DIRECTORIES of TARGETS
+SU2_DEPENDENCY_<NAME>_DEFINITIONS: compile definitions merged from DEFINITIONS and INTERFACE_COMPILE_DEFINITIONS of TARGETS
+SU2_DEPENDENCY_<NAME>_TARGETS: TARGETS
+SU2_DEPENDENCY_<NAME>_EXPLICIT: EXPLICIT
+]]
+function(su2_add_dependency NAME)
+  set(options EXPLICIT)
+  set(oneValueArgs)
+  set(multiValueArgs TARGETS DEFINITIONS INCLUDES)
+  cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  if(NOT ARG_TARGETS)
+    set(ARG_TARGETS "")
+  endif()
+
+  if(NOT ARG_DEFINITIONS)
+    set(ARG_DEFINITIONS "")
+  endif()
+
+  set(includes)
+  set(definitions ${ARG_DEFINITIONS})
+  foreach(library IN LISTS ARG_TARGETS)
+    if(TARGET ${library})
+      get_target_property(INCLUDES ${library} INTERFACE_INCLUDE_DIRECTORIES)
+      get_target_property(DEFINITIONS ${library} INTERFACE_COMPILE_DEFINITIONS)
+      if(INCLUDES)
+        su2_merge_lists(includes INCLUDES)
+      endif()
+
+      if(DEFINITIONS)
+        su2_merge_lists(definitions DEFINITIONS)
+      endif()
+    endif()
+  endforeach()
+
+  if(ARG_INCLUDES)
+    su2_merge_lists(includes ARG_INCLUDES)
+  endif()
+
+  set(dependencies "${SU2_DEPENDENCIES};${NAME}")
+  set(SU2_DEPENDENCIES ${dependencies} CACHE INTERNAL "")
+  set(SU2_DEPENDENCY_${NAME}_INCLUDES ${includes} CACHE INTERNAL "")
+  set(SU2_DEPENDENCY_${NAME}_DEFINITIONS ${definitions} CACHE INTERNAL "")
+  set(SU2_DEPENDENCY_${NAME}_TARGETS ${ARG_TARGETS} CACHE INTERNAL "")
+  set(SU2_DEPENDENCY_${NAME}_EXPLICIT ${ARG_EXPLICIT} CACHE INTERNAL "")
+
+endfunction()
+
+#[[
+su2_get_dependency_options(<NAME> [LINK_LIBRARIES <VAR>]
+                            [DEFINITIONS <VAR>]
+                            [INCLUDES <VAR>]
+                            [EXPLICIT <VAR>])
+
+Use this function to get options to a dependency that was added by su2_add_dependency(<NAME>)
+LINK_LIBRARIES: sets <VAR> to SU2_DEPENDENCY_<NAME>_TARGETS
+DEFINITIONS: sets <VAR> to SU2_DEPENDENCY_<NAME>_DEFINITIONS
+INCLUDES: sets <VAR> to SU2_DEPENDENCY_<NAME>_INCLUDES
+EXPLICIT: sets <VAR> to SU2_DEPENDENCY_<NAME>_EXPLICIT
+]]
+function(su2_get_dependency_options NAME)
+  set(options)
+  set(oneValueArgs LINK_LIBRARIES DEFINITIONS INCLUDES EXPLICIT)
+  set(multiValueArgs)
+  cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  if(NOT ${NAME} IN_LIST SU2_DEPENDENCIES)
+    message(FATAL_ERROR "Invalid dependency specified: ${NAME}")
+  endif()
+
+  if(ARG_INCLUDES)
+    set(${ARG_INCLUDES} ${SU2_DEPENDENCY_${NAME}_INCLUDES} PARENT_SCOPE)
+  endif()
+  if(ARG_DEFINITIONS)
+    set(${ARG_DEFINITIONS} ${SU2_DEPENDENCY_${NAME}_DEFINITIONS} PARENT_SCOPE)
+  endif()
+  if(ARG_LINK_LIBRARIES)
+    set(${ARG_LINK_LIBRARIES} ${SU2_DEPENDENCY_${NAME}_TARGETS} PARENT_SCOPE)
+  endif()
+  if(ARG_EXPLICIT)
+    set(${ARG_EXPLICIT} ${SU2_DEPENDENCY_${NAME}_EXPLICIT} PARENT_SCOPE)
+  endif()
+endfunction()
+
+#[[
+su2_get_target_options(<NAME> [LINK_LIBRARIES <VAR>]
+                        [DEFINITIONS <VAR>]
+                        [INCLUDES <VAR>])
+
+su2_get_dependency_options variant for valid CMake targets
+LINK_LIBRARIES: sets <VAR> INTERFACE_LINK_LIBRARIES of target <NAME>
+DEFINITIONS: sets <VAR> to INTERFACE_COMPILE_DEFINITIONS of target <NAME>
+INCLUDES: sets <VAR> to INTERFACE_INCLUDE_DIRECTORIES of target <NAME>
+]]
+function(su2_get_target_options NAME)
+  set(options)
+  set(oneValueArgs LINK_LIBRARIES DEFINITIONS INCLUDES)
+  set(multiValueArgs)
+  cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  if(NOT TARGET ${NAME})
+    message(FATAL_ERROR "${NAME} is not a valid CMake target")
+  endif()
+
+  if(ARG_INCLUDES)
+    get_target_property(OUT ${NAME} INTERFACE_INCLUDE_DIRECTORIES)
+    if(OUT)
+      set(${ARG_INCLUDES} ${OUT} PARENT_SCOPE)
+    endif()
+  endif()
+  if(ARG_DEFINITIONS)
+    get_target_property(OUT ${NAME} INTERFACE_COMPILE_DEFINITIONS)
+    if(OUT)
+      set(${ARG_DEFINITIONS} ${OUT} PARENT_SCOPE)
+    endif()
+  endif()
+  if(ARG_LINK_LIBRARIES)
+    get_target_property(OUT ${NAME} INTERFACE_LINK_LIBRARIES)
+    if(OUT)
+      set(${ARG_LINK_LIBRARIES} ${OUT} PARENT_SCOPE)
+    endif()
+  endif()
+endfunction()
+
+#[[
+su2_get_compile_options([LINK_LIBRARIES <VAR>] [DEFINITIONS <VAR>]
+                        [INCLUDES <VAR>] [LIBS ...])
+
+Get all compile options that should be used for the build target
+LIBS: list of additional CMake targets to link against or WITH_<NAME> dependencies added with su2_add_dependency
+LINK_LIBRARIES: sets <VAR> to libraries to be linked from implicit dependencies and LIBS
+DEFINITIONS: sets <VAR> to compile definitions of implicit dependencies and LIBS
+INCLUDES: sets <VAR> to include directories of implicit dependencies and LIBS
+]]
+function(su2_get_compile_options)
+  set(options)
+  set(oneValueArgs LINK_LIBRARIES DEFINITIONS INCLUDES)
+  set(multiValueArgs LIBS)
+  cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  set(includes)
+  set(definitions)
+  set(links)
+
+  foreach(VAR IN LISTS ARG_LIBS SU2_DEPENDENCIES)
+    if(TARGET ${VAR})
+      su2_get_target_options(${VAR}
+        INCLUDES I
+        DEFINITIONS D
+        LINK_LIBRARIES L)
+      list(APPEND L ${VAR})
+    elseif(${VAR} MATCHES "WITH_(.*)")
+      set(lib ${CMAKE_MATCH_1})
+      if(NOT ${lib} IN_LIST SU2_DEPENDENCIES)
+        message(FATAL_ERROR "Unknown dependency ${lib}")
+      endif()
+      su2_get_dependency_options(${lib}
+        INCLUDES I
+        DEFINITIONS D
+        LINK_LIBRARIES L)
+    elseif(${VAR} IN_LIST SU2_DEPENDENCIES)
+      if(NOT SU2_DEPENDENCY_${VAR}_EXPLICIT)
+        su2_get_dependency_options(${VAR}
+          INCLUDES I
+          DEFINITIONS D
+          LINK_LIBRARIES L)
+      else()
+        set(I)
+        set(D)
+        set(L)
+      endif()
+    else()
+      message(FATAL_ERROR "Invalid option ${VAR}")
+    endif()
+
+    su2_merge_lists(includes I)
+    su2_merge_lists(definitions D)
+    su2_merge_lists(links L)
+  endforeach()
+
+  if(ARG_INCLUDES)
+    set(${ARG_INCLUDES} ${includes} PARENT_SCOPE)
+  endif()
+  if(ARG_DEFINITIONS)
+    set(${ARG_DEFINITIONS} ${definitions} PARENT_SCOPE)
+  endif()
+  if(ARG_LINK_LIBRARIES)
+    set(${ARG_LINK_LIBRARIES} ${links} PARENT_SCOPE)
+  endif()
+endfunction()
+
+#[[
+su2_setup_target(<TARGET> [NO_PIC]
+                  [NO_INSTALL] [INSTALL_DIR <dir>]
+                  [LIBS ...])
+
+convenience function to setup provided target to compile with currenly enabled external libraries and
+setup additional common compilation options/install targets
+
+TARGET: valid CMake target to setup
+NO_PIC: disable compilation with -fPIC (only valid for static library targets)
+NO_INSTALL: disable installing <TARGET> to <dir> (only valid for targets that are not static libraries)
+INSTALL_DIR: <TARGET> install directory, default is bin
+LIBS: additional libraries to link against, either valid CMake targets or one of SU2 dependencies in the form of WITH_<NAME>
+]]
+function(su2_setup_target target)
+  set(options NO_PIC NO_INSTALL)
+  set(oneValueArgs INSTALL_DIR)
+  set(multiValueArgs LIBS)
+  cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  # set default install dir
+  if(NOT ARG_INSTALL_DIR)
+    set(ARG_INSTALL_DIR bin)
+  endif()
+
+  get_target_property(target_type ${target} TYPE)
+  if(target_type STREQUAL "STATIC_LIBRARY")
+    # compile static libraries with -fPIC in not disabled
+    if(NOT ARG_NO_PIC)
+      set_target_properties(${target} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    endif()
+  else()
+    # setup install target if not disabled
+    if(NOT ARG_NO_INSTALL)
+      install(FILES "$<TARGET_FILE:${target}>" DESTINATION ${ARG_INSTALL_DIR})
+    endif()
+  endif()
+
+  su2_get_compile_options(
+    INCLUDES I
+    DEFINITIONS D
+    LINK_LIBRARIES L
+    LIBS ${ARG_LIBS})
+  target_compile_definitions(${target} PUBLIC ${D})
+  target_include_directories(${target} PUBLIC ${I})
+  target_link_libraries(${target} PUBLIC ${L})
+
+  # debug
+  su2_debug(
+    "${target} setup with:
+    includes: ${I}
+    definitions: ${D}
+    link libraries: ${L}")
+endfunction()
+
+#[[
+su2_download_module(<NAME> <ALT_NAME> <GIT_REPO> <COMMIT_SHA>)
+
+Download and install git repositories
+NAME: name of the repository to use
+ALT_NAME: directory in SU2 root to install repository at
+GIT_REPO: URL of the git repository
+COMMIT_SHA: SHA of the commit to download
+]]
+function(su2_download_module
+  NAME ALT_NAME GIT_REPO COMMIT_SHA)
+  message(
+    STATUS
+      "Initializing ${NAME} '${COMMIT_SHA}'
+=====================================================================
+Downloading module from ${GIT_REPO}")
+
+set(LOCAL_FILE "${CMAKE_BINARY_DIR}/${COMMIT_SHA}.zip")
+
+  file(
+    DOWNLOAD "${GIT_REPO}/archive/${COMMIT_SHA}.zip" "${LOCAL_FILE}"
+    LOG LOG
+    STATUS STATUS)
+  list(GET STATUS 0 RESULT)
+
+  if(RESULT)
+    list(GET STATUS 1 ERR_MSG)
+    file(WRITE ${CMAKE_BINARY_DIR}/configure.log ${LOG})
+    file(WRITE ${CMAKE_BINARY_DIR}/configure.err ${ERR_MSG})
+    message(
+      FATAL_ERROR
+        "Download of module ${NAME} failed.
+To download it manually, perform the following steps:
+  - Download the zip at \"${GIT_REPO}/archive/${COMMIT_SHA}.zip\"
+  - Extract the archive to ${CMAKE_SOURCE_DIR}/${ALT_NAME}
+  - Execute command 'touch ${CMAKE_SOURCE_DIR}/${ALT_NAME}/${COMMIT_SHA}'
+  - Run CMake again")
+  endif()
+
+  message(STATUS "Extracting archive...")
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -E tar -xzf ${LOCAL_FILE}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    OUTPUT_VARIABLE LOG
+    ERROR_VARIABLE ERR
+    RESULT_VARIABLE RESULT)
+
+  if(RESULT)
+    message(FATAL_ERROR "Extraction of module ${NAME} failed: ${RESULT}
+-- Command: ${CMAKE_COMMAND} -E tar -xzf ${LOCAL_FILE}
+-- Output: ${LOG}
+-- Error: ${ERR}")
+  endif()
+
+  message(STATUS "Creating identifier...")
+  file(RENAME "${CMAKE_BINARY_DIR}/${NAME}-${COMMIT_SHA}" "${CMAKE_SOURCE_DIR}/${ALT_NAME}")
+  file(TOUCH "${CMAKE_SOURCE_DIR}/${ALT_NAME}/${COMMIT_SHA}")
+  file(REMOVE "${LOCAL_FILE}")
+
+endfunction()
+
+#[[
+su2_option(<NAME> [SETUP <VALUE> <HIDE_VALUE> <TYPE> <DOCSTRING> [HIDE])
+
+Use this to create on option that can be hidden from the cmake-gui if some conditions are not met
+NAME: name of the option
+SETUP: initialize <NAME> option with <VALUE>, <TYPE> and <DOCSTRING> are used the same way as setting cache variables
+HIDE: hide <NAME> option
+]]
+function(su2_option NAME)
+  set(options HIDE)
+  set(oneValueArgs)
+  set(multiValueArgs SETUP)
+  cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  # set default value
+  if(NOT DEFINED SU2_OPTION_${NAME}_HIDDEN)
+    set(SU2_OPTION_${NAME}_HIDDEN
+        FALSE
+        CACHE INTERNAL "")
+  endif()
+
+  if(ARG_SETUP)
+    list(GET ARG_SETUP 0 VALUE)
+    list(GET ARG_SETUP 1 HIDE_VALUE)
+    list(GET ARG_SETUP 2 TYPE)
+    list(SUBLIST ARG_SETUP 3 -1 DOCSTRING)
+
+    if(SU2_OPTION_${NAME}_HIDDEN)
+      # if hidden, set to last cached value and make it visible until HIDE is called again
+      set(${NAME}
+          ${SU2_OPTION_${NAME}_VALUE}
+          CACHE ${TYPE} "${DOCSTRING}" FORCE)
+    else()
+      # not hidden so use default cache variable setup
+      set(${NAME}
+          ${VALUE}
+          CACHE ${TYPE} "${DOCSTRING}")
+    endif()
+
+    # clear hidden flag
+    set(SU2_OPTION_${NAME}_HIDDEN
+        FALSE
+        CACHE INTERNAL "")
+    set(SU2_OPTION_${NAME}_HIDE_VALUE
+        ${HIDE_VALUE}
+        CACHE INTERNAL "")
+
+    su2_debug("Setup ${NAME} with ${VALUE} \"${DOCSTRING}\", value will be ${HIDE_VALUE} when hidden")
+  endif()
+
+  if(ARG_HIDE)
+    # cache current value and set hidden flag before setting <NAME> to internal variable
+    set(SU2_OPTION_${NAME}_VALUE
+        ${${NAME}}
+        CACHE INTERNAL "")
+    set(SU2_OPTION_${NAME}_HIDDEN
+        TRUE
+        CACHE INTERNAL "")
+    set(${NAME}
+        ${SU2_OPTION_${NAME}_HIDE_VALUE}
+        CACHE INTERNAL "")
+  endif()
+
+endfunction()

--- a/externals/cgns/CMakeLists.txt
+++ b/externals/cgns/CMakeLists.txt
@@ -1,0 +1,26 @@
+project(CGNS C)
+
+set(SU2_CGNS_CPPFLAGS "" CACHE STRING "Specific CGNS C Preprocessor flags to use")
+
+set(CGNS_SOURCES
+    cgnslib.h
+    cgns_header.h
+    cgns_io.h
+    cgnstypes.h
+    fortran_macros.h
+    adf/ADF.h
+    adf/ADF_fbind.h
+    adf/ADF_internals.h
+    cgns_error.c
+    cgns_internals.c
+    cgns_io.c
+    cgnslib.c
+    adf/ADF_interface.c
+    adf/ADF_internals.c)
+
+add_library(cgns STATIC ${CGNS_SOURCES})
+target_compile_definitions(cgns PRIVATE ${SU2_CGNS_CPPFLAGS})
+set_target_properties(cgns PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+target_include_directories(cgns PUBLIC "${CMAKE_CURRENT_LIST_DIR}" "${CMAKE_CURRENT_LIST_DIR}/adf")
+add_library(CGNS::CGNS ALIAS cgns)

--- a/externals/metis/CMakeLists.txt
+++ b/externals/metis/CMakeLists.txt
@@ -1,0 +1,108 @@
+project(metis C)
+
+set(SU2_METIS_CPPFLAGS
+    "_FILE_OFFSET_BITS=64;NDEBUG;NDEBUG2;HAVE_EXECINFO_H;HAVE_GETLINE"
+    CACHE STRING "Specific METIS C Preprocessor flags to use")
+
+set(METIS_SOURCES
+    include/metis.h
+    GKlib/b64.c
+    GKlib/blas.c
+    GKlib/csr.c
+    GKlib/error.c
+    GKlib/evaluate.c
+    GKlib/fkvkselect.c
+    GKlib/fs.c
+    GKlib/getopt.c
+    GKlib/gk_arch.h
+    GKlib/gk_defs.h
+    GKlib/gk_externs.h
+    GKlib/gk_getopt.h
+    GKlib/gk_macros.h
+    GKlib/gk_mkblas.h
+    GKlib/gk_mkmemory.h
+    GKlib/gk_mkpqueue.h
+    GKlib/gk_mkpqueue2.h
+    GKlib/gk_mkrandom.h
+    GKlib/gk_mksort.h
+    GKlib/gk_mkutils.h
+    GKlib/gk_proto.h
+    GKlib/gk_struct.h
+    GKlib/gk_types.h
+    GKlib/GKlib.h
+    GKlib/gkregex.c
+    GKlib/gkregex.h
+    GKlib/graph.c
+    GKlib/htable.c
+    GKlib/io.c
+    GKlib/itemsets.c
+    GKlib/mcore.c
+    GKlib/memory.c
+    GKlib/ms_inttypes.h
+    GKlib/ms_stat.h
+    GKlib/ms_stdint.h
+    GKlib/omp.c
+    GKlib/pdb.c
+    GKlib/pqueue.c
+    GKlib/random.c
+    GKlib/rw.c
+    GKlib/seq.c
+    GKlib/sort.c
+    GKlib/string.c
+    GKlib/timers.c
+    GKlib/tokenizer.c
+    GKlib/util.c
+    libmetis/auxapi.c
+    libmetis/balance.c
+    libmetis/bucketsort.c
+    libmetis/checkgraph.c
+    libmetis/coarsen.c
+    libmetis/compress.c
+    libmetis/contig.c
+    libmetis/debug.c
+    libmetis/defs.h
+    libmetis/fm.c
+    libmetis/fortran.c
+    libmetis/frename.c
+    libmetis/gklib.c
+    libmetis/gklib_defs.h
+    libmetis/gklib_rename.h
+    libmetis/graph.c
+    libmetis/initpart.c
+    libmetis/kmetis.c
+    libmetis/kwayfm.c
+    libmetis/kwayrefine.c
+    libmetis/macros.h
+    libmetis/mcutil.c
+    libmetis/mesh.c
+    libmetis/meshpart.c
+    libmetis/metislib.h
+    libmetis/minconn.c
+    libmetis/mincover.c
+    libmetis/mmd.c
+    libmetis/ometis.c
+    libmetis/options.c
+    libmetis/parmetis.c
+    libmetis/pmetis.c
+    libmetis/proto.h
+    libmetis/refine.c
+    libmetis/rename.h
+    libmetis/separator.c
+    libmetis/sfm.c
+    libmetis/srefine.c
+    libmetis/stat.c
+    libmetis/stdheaders.h
+    libmetis/struct.h
+    libmetis/timing.c
+    libmetis/util.c
+    libmetis/wspace.c)
+
+add_library(metis STATIC ${METIS_SOURCES})
+target_compile_definitions(metis PRIVATE ${SU2_METIS_CPPFLAGS})
+set_target_properties(metis PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+target_include_directories(
+  metis
+  PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include ${CMAKE_CURRENT_LIST_DIR}/GKlib
+         ${CMAKE_CURRENT_LIST_DIR}/libmetis)
+add_library(Metis::Metis ALIAS metis)

--- a/externals/parmetis/CMakeLists.txt
+++ b/externals/parmetis/CMakeLists.txt
@@ -1,0 +1,70 @@
+project(parmetis C)
+
+if(NOT SU2_ENABLE_METIS)
+	message(FATAL_ERROR "Parmetis requires Metis to be built")
+endif()
+
+set(SU2_PARMETIS_CPPFLAGS "" CACHE STRING "Specific PARMETIS C Preprocessor flags to use")
+
+find_package(MPI REQUIRED)
+
+set(PARMETIS_SOURCES
+    include/parmetis.h
+	libparmetis/akwayfm.c
+	libparmetis/ametis.c
+	libparmetis/balancemylink.c
+	libparmetis/comm.c
+	libparmetis/csrmatch.c
+	libparmetis/ctrl.c
+	libparmetis/debug.c
+	libparmetis/defs.h
+	libparmetis/diffutil.c
+	libparmetis/frename.c
+	libparmetis/gkmetis.c
+	libparmetis/gkmpi.c
+	libparmetis/graph.c
+	libparmetis/initbalance.c
+	libparmetis/initmsection.c
+	libparmetis/initpart.c
+	libparmetis/kmetis.c
+	libparmetis/kwayrefine.c
+	libparmetis/macros.h
+	libparmetis/match.c
+	libparmetis/mdiffusion.c
+	libparmetis/mesh.c
+	libparmetis/mmetis.c
+	libparmetis/move.c
+	libparmetis/msetup.c
+	libparmetis/node_refine.c
+	libparmetis/ometis.c
+	libparmetis/parmetislib.h
+	libparmetis/proto.h
+	libparmetis/pspases.c
+	libparmetis/redomylink.c
+	libparmetis/remap.c
+	libparmetis/rename.h
+	libparmetis/renumber.c
+	libparmetis/rmetis.c
+	libparmetis/selectq.c
+	libparmetis/serial.c
+	libparmetis/stat.c
+	libparmetis/struct.h
+	libparmetis/timer.c
+	libparmetis/util.c
+	libparmetis/wave.c
+	libparmetis/weird.c
+	libparmetis/wspace.c
+	libparmetis/xyzpart.c)
+
+add_library(parmetis STATIC ${PARMETIS_SOURCES})
+target_compile_definitions(parmetis PRIVATE ${SU2_METIS_CPPFLAGS} ${SU2_PARMETIS_CPPFLAGS})
+set_target_properties(parmetis PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_link_libraries(parmetis PUBLIC MPI::MPI_C Metis::Metis)
+
+target_include_directories(
+  parmetis
+  PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/include ${CMAKE_CURRENT_LIST_DIR}/libparmetis ${CMAKE_SOURCE_DIR}/externals/metis/GKlib
+    ${CMAKE_SOURCE_DIR}/externals/metis/include ${CMAKE_CURRENT_LIST_DIR})
+
+add_library(Parmetis::Parmetis ALIAS parmetis)

--- a/externals/tecio/CMakeLists.txt
+++ b/externals/tecio/CMakeLists.txt
@@ -1,0 +1,36 @@
+project(tecio C CXX)
+
+set(SU2_TECIO_CPPFLAGS
+    "-fpermissive;USEENUM;THREED;MAKEARCHIVE;NO_ASSERTS;NO_THIRD_PARTY_LIBS"
+    CACHE STRING "Specific Tecio compile definitions to use")
+
+if(NOT EXISTS "${CMAKE_CURRENT_LIST_DIR}/boost")
+  message(STATUS "Extracting boost source ...")
+  execute_process(COMMAND ${CMAKE_COMMAND} -E tar -xzf ${CMAKE_CURRENT_LIST_DIR}/boost.tar.gz
+                          WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR} RESULT_VARIABLE RESULT)
+  if(RESULT)
+    message(
+      FATAL_ERROR "Extraction of boost sources to ${CMAKE_CURRENT_LIST_DIR}/boost using 'tar' failed ...")
+  endif()
+endif()
+
+set(TECIO_CPPFLAGS)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  set(TECIO_CPPFLAGS LINUX)
+  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    list(APPEND TECIO_CPPFLAGS LINUX64)
+  endif()
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  set(TECIO_CPPFLAGS DARWIN MAC64)
+else()
+  message(
+    FATAL_ERROR
+      ">>> Unrecognized TecIO platform ${CMAKE_SYSTEM_NAME}, see externals/tecio/Runmake for hints on how to extend <<<"
+  )
+endif()
+
+if(SU2_ENABLE_MPI)
+  add_subdirectory(teciompisrc)
+else()
+  add_subdirectory(teciosrc)
+endif()

--- a/externals/tecio/teciompisrc/CMakeLists.txt
+++ b/externals/tecio/teciompisrc/CMakeLists.txt
@@ -1,42 +1,87 @@
-cmake_minimum_required(VERSION 2.8.12) # requiring 2.8.12 sets the CMP0022 policy to new (non-transitive linking, i.e. just the interfaces) by default
+project(teciompi CXX)
 
-if (NOT CMAKE_BUILD_TYPE)
-    set (CMAKE_BUILD_TYPE Release CACHE STRING "CMake build type (Debug|Release)" FORCE)
-endif ()
+set(SU2_TECIOMPI_CPP_FLAGS
+    "TP_PROJECT_USES_BOOST;BOOST_ALL_NO_LIB"
+    CACHE STRING "Specific TecioMPI compile definitions to use")
 
-project (teciompi)
+find_package(MPI REQUIRED)
 
-FIND_PACKAGE(Boost)
-IF (Boost_FOUND)
-    INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIR})
-ELSE()
-    Set (Boost_INCLUDE_DIR /3rdpartylibs/boost/1.59.0/build/linux64-centos6.5/include)
-    message ("Warning:  Cannot find boost include directories.  Hardcoding to ${Boost_INCLUDE_DIR}")
-    INCLUDE_DIRECTORIES(SYSTEM ${Boost_INCLUDE_DIR})
-ENDIF()
+set(TECIOMPI_SOURCES
+    ClassicZoneWriterAbstract.cpp
+    SZLOrderedPartitionedZoneWriterMPI.cpp
+    szcombine.cpp
+    FileSystem.cpp
+    MPIUtil.cpp
+    SZLOrderedZoneHeaderWriter.cpp
+    ZoneWriterFactory.cpp
+    importSzPltFile.cpp
+    FaceNeighborGeneratorAbstract.cpp
+    PartitionTecUtilDecorator.cpp
+    ZoneWriterFactoryMPI.cpp
+    tecio.cpp
+    TecioData.cpp
+    MPIFileIOStream.cpp
+    checkPercentDone.cpp
+    Zone_s.cpp
+    DataSetWriter.cpp
+    ClassicZoneVariableWriter.cpp
+    ClassicZoneFaceNeighborWriter.cpp
+    UnicodeStringUtils.cpp
+    ClassicZoneHeaderWriter.cpp
+    SZLOrderedPartitionedZoneWriter.cpp
+    SZLFEPartitionedZoneWriter.cpp
+    MPICommunicator.cpp
+    writeValueArray.cpp
+    FECellSubzoneCompressor.cpp
+    fileStuff.cpp
+    MPICommunicationCache.cpp
+    FileStreamReader.cpp
+    SZLFEPartitionedZoneWriterMPI.cpp
+    SZLOrderedPartitionWriter.cpp
+    MPIFileWriter.cpp
+    ZoneHeaderWriterAbstract.cpp
+    TecioTecUtil.cpp
+    ZoneWriterAbstract.cpp
+    NodeToElemMap_s.cpp
+    DataSetWriterMPI.cpp
+    FileIOStream.cpp
+    SZLFEPartitionedZoneHeaderWriter.cpp
+    MPIFileReader.cpp
+    ClassicFEZoneConnectivityWriter.cpp
+    MinMaxTree.cpp
+    FieldData.cpp
+    SZLOrderedPartitionedZoneHeaderWriter.cpp
+    AsciiOutputInfo.cpp
+    FieldData_s.cpp
+    IntervalTree.cpp
+    ClassicFEZoneFaceNeighborGenerator.cpp
+    mpiDatatype.cpp
+    ClassicOrderedZoneFaceNeighborGenerator.cpp
+    OrthogonalBisection.cpp
+    ORBFESubzonePartitioner.cpp
+    IJKZoneInfo.cpp
+    IJKSubzoneInfo.cpp
+    Scanner.cpp
+    ClassicFEZoneWriter.cpp
+    NodeMap.cpp
+    SZLOrderedZoneWriter.cpp
+    SZLFEPartitionWriter.cpp
+    SZLFEZoneWriter.cpp
+    ZoneVarMetadata.cpp
+    MPINonBlockingCommunicationCollection.cpp
+    SZLFEZoneHeaderWriter.cpp
+    FileStreamWriter.cpp
+    ClassicOrderedZoneWriter.cpp
+    ZoneInfoCache.cpp
+    readValueArray.cpp
+    TecioSZL.cpp
+    exportSubzonePlt.cpp)
 
-FIND_PACKAGE(MPI)
-IF (NOT MPI_CXX_FOUND)
-    message(FATAL_ERROR "Unable to find MPI installation.")
-ENDIF ()
+add_library(teciompi STATIC ${TECIOMPI_SOURCES})
+set_target_properties(teciompi PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_compile_definitions(teciompi PRIVATE ${SU2_TECIO_CPPFLAGS} ${SU2_TECIOMPI_CPPFLAGS} ${TECIO_CPPFLAGS})
+target_compile_definitions(teciompi PUBLIC TECIOMPI)
 
-include_directories(.)
-if(NOT "${MPI_CXX_INCLUDE_PATH}" STREQUAL "")
-    include_directories(SYSTEM "${MPI_CXX_INCLUDE_PATH}")
-endif()
-
-IF (WIN32)
-    set(BaseFlags "/EHsc /MP /wd\"4996\" /D MSWIN /D TP_PROJECT_USES_BOOST /D BOOST_ALL_NO_LIB /D MAKEARCHIVE /D NO_THIRD_PARTY_LIBS /D TECIOMPI /D NO_ASSERTS")
-ELSE ()
-    set(BaseFlags "-DLINUX -DLINUX64 -DTP_PROJECT_USES_BOOST -DBOOST_ALL_NO_LIB -DMAKEARCHIVE -DNO_THIRD_PARTY_LIBS -DTECIOMPI -DOMPI_SKIP_MPICXX -DNO_ASSERTS -fmessage-length=0 -fPIC -fvisibility=hidden -w")
-ENDIF ()
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${BaseFlags} ${MPI_CXX_COMPILE_FLAGS}")
-                    
-FILE(GLOB mainFiles "*.cpp" "*.h")
-LIST(REMOVE_ITEM mainFiles "${CMAKE_CURRENT_SOURCE_DIR}/szcombine.cpp")
-
-add_library(teciompi STATIC ${mainFiles})
-
-add_executable(szcombine "szcombine.cpp")
-target_link_libraries(szcombine teciompi ${MPI_LIBRARIES})
-
+target_link_libraries(teciompi PUBLIC MPI::MPI_CXX)
+target_include_directories(teciompi PUBLIC ${CMAKE_CURRENT_LIST_DIR} ${CMAKE_CURRENT_LIST_DIR}/../teciosrc)
+add_library(Tecio::Tecio ALIAS teciompi)

--- a/externals/tecio/teciosrc/CMakeLists.txt
+++ b/externals/tecio/teciosrc/CMakeLists.txt
@@ -1,40 +1,230 @@
-cmake_minimum_required(VERSION 2.8.12) # requiring 2.8.12 sets the CMP0022 policy to new (non-transitive linking, i.e. just the interfaces) by default
+project(tecio CXX)
 
-if (NOT CMAKE_BUILD_TYPE)
-    set (CMAKE_BUILD_TYPE Release CACHE STRING "CMake build type (Debug|Release)" FORCE)
-endif ()
+set(TECIO_SOURCES
+    ALLOC.h
+    AltTecUtil.h
+    AnyTypeLightweightVector.h
+    ARRLIST.h
+    AtomicMinMax.h
+    AUXDATA.h
+    AuxData_s.h
+    basicTypes.h
+    CHARTYPE.h
+    checkPercentDone.h
+    clampToDataTypeRange.h
+    ClassicFEZoneConnectivityWriter.h
+    ClassicFEZoneFaceNeighborGenerator.h
+    ClassicFEZoneWriter.h
+    ClassicOrderedZoneFaceNeighborGenerator.h
+    ClassicOrderedZoneWriter.h
+    ClassicZoneFaceNeighborWriter.h
+    ClassicZoneFileLocations.h
+    ClassicZoneHeaderWriter.h
+    ClassicZoneVariableWriter.h
+    ClassicZoneWriterAbstract.h
+    ClassMacros.h
+    CodeContract.h
+    CszConnectivity.h
+    DATAIO4.h
+    DATAIO.h
+    DATASET0.h
+    DATASET.h
+    DataSetWriter.h
+    DATASHR.h
+    DATAUTIL.h
+    DataWriteStatisticsInterface.h
+    exportSubzonePlt.h
+    FACE.h
+    FaceNeighborGeneratorAbstract.h
+    FECellSubzoneCompressor.h
+    FESubzonePartitionerInterface.h
+    FEZoneInfo.h
+    FieldData.h
+    FieldData_s.h
+    FileDescription.h
+    fileio.h
+    FileIOStatistics.h
+    FileIOStream.h
+    FileIOStreamInterface.h
+    FileReaderInterface.h
+    FILESTREAM.h
+    FileStreamReader.h
+    FileStreamWriter.h
+    fileStuff.h
+    FileSystem.h
+    FileWriterInterface.h
+    gatherOffsets.h
+    GEOM2.h
+    GEOM.h
+    Geom_s.h
+    GhostInfo_s.h
+    GLOBAL.h
+    IJK.h
+    IJKPartitionTree.h
+    IJKSubzoneInfo.h
+    IJKZoneInfo.h
+    importSzPltFile.h
+    INPUT.h
+    IntervalTree.h
+    ioDescription.h
+    ItemAddress.h
+    ItemSetIterator.h
+    JobControl_s.h
+    LightweightVector.h
+    MASTER.h
+    MinMax.h
+    MinMaxTree.h
+    MiscMacros.h
+    Mutex_s.h
+    NodeMap.h
+    NodeMap_s.h
+    NodeToElemMap_s.h
+    NoOpFESubzonePartitioner.h
+    ORBFESubzonePartitioner.h
+    OrthogonalBisection.h
+    PartitionMetadata.h
+    PartitionTecUtilDecorator.h
+    Q_MSG.h
+    Q_UNICODE.h
+    RawArray.h
+    readValueArray.h
+    Scanner.h
+    SET.h
+    showMessage.h
+    StandardIntegralTypes.h
+    stdafx.h
+    stringformat.h
+    STRLIST.h
+    STRUTIL.h
+    SYSTEM.h
+    SZLFEPartitionedZoneHeaderWriter.h
+    SZLFEPartitionedZoneWriter.h
+    SZLFEPartitionWriter.h
+    SZLFEZoneHeaderWriter.h
+    SZLFEZoneWriter.h
+    SzlFileLoader.h
+    SZLOrderedPartitionedZoneHeaderWriter.h
+    SZLOrderedPartitionedZoneWriter.h
+    SZLOrderedPartitionWriter.h
+    SZLOrderedZoneHeaderWriter.h
+    SZLOrderedZoneWriter.h
+    TASSERT.h
+    TECGLBL.h
+    TecioData.h
+    tecio_Exports.h
+    TECIO.h
+    TecioPLT.h
+    TecioSZL.h
+    TecioTecUtil.h
+    TecplotMinorRev.h
+    TecplotVersion.h
+    TEXT.h
+    Text_s.h
+    ThirdPartyHeadersBegin.h
+    ThirdPartyHeadersEnd.h
+    TranslatedString.h
+    UnicodeStringUtils.h
+    Version.h
+    writeValueArray.h
+    xyz.h
+    ZoneHeaderWriterAbstract.h
+    ZoneInfoCache.h
+    ZoneMetadata.h
+    Zone_s.h
+    zoneUtil.h
+    ZoneVarMetadata.h
+    ZoneWriterAbstract.h
+    ZoneWriterFactory.h
+    arrlist.cpp
+    auxdata.cpp
+    checkPercentDone.cpp
+    ClassicFEZoneConnectivityWriter.cpp
+    ClassicFEZoneFaceNeighborGenerator.cpp
+    ClassicFEZoneWriter.cpp
+    ClassicOrderedZoneFaceNeighborGenerator.cpp
+    ClassicOrderedZoneWriter.cpp
+    ClassicZoneFaceNeighborWriter.cpp
+    ClassicZoneHeaderWriter.cpp
+    ClassicZoneVariableWriter.cpp
+    ClassicZoneWriterAbstract.cpp
+    dataio4.cpp
+    dataio.cpp
+    dataset0.cpp
+    dataset.cpp
+    DataSetWriter.cpp
+    datautil.cpp
+    exportSubzonePlt.cpp
+    FaceNeighborGeneratorAbstract.cpp
+    FECellSubzoneCompressor.cpp
+    FieldData.cpp
+    FieldData_s.cpp
+    FileIOStream.cpp
+    filestream.cpp
+    FileStreamReader.cpp
+    FileStreamWriter.cpp
+    fileStuff.cpp
+    FileSystem.cpp
+    geom2.cpp
+    IJKSubzoneInfo.cpp
+    IJKZoneInfo.cpp
+    importSzPltFile.cpp
+    IntervalTree.cpp
+    MinMaxTree.cpp
+    NodeMap.cpp
+    NodeToElemMap_s.cpp
+    ORBFESubzonePartitioner.cpp
+    OrthogonalBisection.cpp
+    PartitionTecUtilDecorator.cpp
+    q_msg.cpp
+    readValueArray.cpp
+    Scanner.cpp
+    set.cpp
+    strlist.cpp
+    strutil.cpp
+    szcombine.cpp
+    SZLFEPartitionedZoneHeaderWriter.cpp
+    SZLFEPartitionedZoneWriter.cpp
+    SZLFEPartitionWriter.cpp
+    SZLFEZoneHeaderWriter.cpp
+    SZLFEZoneWriter.cpp
+    SZLOrderedPartitionedZoneHeaderWriter.cpp
+    SZLOrderedPartitionedZoneWriter.cpp
+    SZLOrderedPartitionWriter.cpp
+    SZLOrderedZoneHeaderWriter.cpp
+    SZLOrderedZoneWriter.cpp
+    tecio.cpp
+    TecioData.cpp
+    TecioPLT.cpp
+    TecioSZL.cpp
+    TecioTecUtil.cpp
+    TranslatedString.cpp
+    UnicodeStringUtils.cpp
+    writeValueArray.cpp
+    ZoneHeaderWriterAbstract.cpp
+    ZoneInfoCache.cpp
+    Zone_s.cpp
+    ZoneVarMetadata.cpp
+    ZoneWriterAbstract.cpp
+    ZoneWriterFactory.cpp
+    ../boost/algorithm/string.hpp
+    ../boost/assign.hpp
+    ../boost/atomic.hpp
+    ../boost/bind.hpp
+    ../boost/foreach.hpp
+    ../boost/function.hpp
+    ../boost/make_shared.hpp
+    ../boost/ref.hpp
+    ../boost/scoped_array.hpp
+    ../boost/scoped_ptr.hpp
+    ../boost/shared_ptr.hpp
+    ../boost/static_assert.hpp
+    ../boost/tokenizer.hpp
+    ../boost/unordered_map.hpp
+    ../boost/unordered_set.hpp)
 
-project (tecio C CXX)
+add_library(tecio STATIC ${TECIO_SOURCES})
+target_compile_definitions(tecio PRIVATE ${SU2_TECIO_CPPFLAGS} ${TECIO_CPPFLAGS})
+set_target_properties(tecio PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
-FIND_PACKAGE(Boost)
-IF (Boost_FOUND)
-    INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIR})
-ELSE()
-    Set (Boost_INCLUDE_DIR /3rdpartylibs/boost/1.59.0/build/linux64-centos6.5/include)
-    message ("Warning:  Cannot find boost include directories.  Hardcoding to ${Boost_INCLUDE_DIR}")
-    INCLUDE_DIRECTORIES(SYSTEM ${Boost_INCLUDE_DIR})
-ENDIF()
-include_directories(.)
-
-IF (WIN32)
-    set(BaseFlags "/EHsc /MP /wd\"4996\" /D MSWIN /D TP_PROJECT_USES_BOOST /D BOOST_ALL_NO_LIB /D MAKEARCHIVE /D NO_THIRD_PARTY_LIBS /D NO_ASSERTS")
-ELSE ()
-	set(BaseFlags "-DLINUX -DLINUX64 -DTP_PROJECT_USES_BOOST -DBOOST_ALL_NO_LIB -DMAKEARCHIVE -DNO_THIRD_PARTY_LIBS -DNO_ASSERTS -fmessage-length=0 -fPIC -fvisibility=hidden -w")
-ENDIF ()
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${BaseFlags}")
-                    
-FILE(GLOB mainFiles "*.cpp" "*.h")
-LIST(REMOVE_ITEM mainFiles "${CMAKE_CURRENT_SOURCE_DIR}/szcombine.cpp")
-
-add_library(tecio STATIC ${mainFiles})
-
-add_executable(szcombine "szcombine.cpp")
-if (WIN32)
-    target_link_libraries(szcombine tecio)
-else ()
-    target_link_libraries(szcombine tecio pthread)
-endif ()
-
-# Had to add this so building tecio care package within loci-chem works...
-set_target_properties(tecio PROPERTIES LINKER_LANGUAGE CXX)
-set_target_properties(szcombine PROPERTIES LINKER_LANGUAGE CXX)
+target_include_directories(tecio PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+add_library(Tecio::Tecio ALIAS tecio)


### PR DESCRIPTION
## Proposed Changes
Added CMake build support for SU2. With this, many popular IDEs will be able to use SU2 as a project with minimal setup. CMake also enables to add dependencies more easily since most libraries have CMake support. `vcpkg` is great for the libraries available there.

SU2 CMake has the same build options as autotools but uses CMake to find system libraries and compilers (MKL, Mutationpp, MPI and Python currently). No longer need to specify paths to compilers/libraries if they are in standard locations. In addition, compile flags can be modified from CMake. There is no need to use `preconfigure.py` anymore since downloading/unpacking is handled by CMake and is system-agnostic.

At the moment, all library targets are static but that could be easily changed to be configurable from CMake. The installation directory is `${CMAKE_PREFIX_PATH}/bin`.

Similarly to autotools, some build options are disabled if built with Codi forward/reverse datatypes or without MPI. Note that SWIG fails to compile `pySU2ad` with `Nothing known about namespace 'medi'` in `Common/include/mpi_structure.hpp:57` without `-includeall` SWIG option but then it takes forever to generate the wrapper (more than 15 minutes on my machine, stopped early). I suggest removing `using namespace` declarations and either importing used symbols explicitly with `using` or prepending namespace name, `clang-tidy` warns against them and it makes the code clearer.

SU2 CMake options are:
* Build modules:
  * `SU2_BUILD_CFD`: `ON|OFF`
  * `SU2_BUILD_DEF`: `ON|OFF`, disabled when building with Codi
  * `SU2_BUILD_DOT`: `ON|OFF`, disabled when building with Codi forward
  * `SU2_BUILD_GEO`: `ON|OFF`, disabled when building with Codi
  * `SU2_BUILD_MSH`: `ON|OFF`, disabled when building with Codi
  * `SU2_BUILD_PY_WRAPPER`: `ON|OFF`, disabled when building with Codi forward
  * `SU2_BUILD_SOL`: `ON|OFF`, disabled when building with Codi
* Enable modules:
  * `SU2_ENABLE_CGNS`: 
    * `SU2_CGNS_CPPFLAGS`: flags to pass when compiling CGNS
  * `SU2_ENABLE_CODI`: `no|forward|reverse`
    * `SU2_CODI_CPPFLAGS`: flags to pass to SU2 modules when compiling with Codi
  * `SU2_ENABLE_METIS`: `ON|OFF`
    * `SU2_METIS_CPPFLAGS`: flags to pass when compiling Metis
  * `SU2_ENABLE_MKL`: `ON|OFF`
  * `SU2_ENABLE_MPI`: `ON|OFF`
  * `SU2_ENABLE_MUTATIONPP`: `ON|OFF`
  * `SU2_ENABLE_PARMETIS`: `ON|OFF`, only available when `SU2_ENABLE_MPI` is `ON`
    * `SU2_PARMETIS_CPPFLAGS`: flags to pass when compiling Parmetis
  * `SU2_ENABLE_TECIO`: `ON|OFF`
    * `SU2_TECIO_CPPFLAGS`: flags to pass when compiling Tecio and TecioMPI
    * `SU2_TECIOMPI_CPPFLAGS`: flags to pass when compiling TecioMPI, requires `SU2_ENABLE_MPI`

There is an additional variable that is recognized by CMake scripts - `DEBUG`, turning it `ON` enables additional `STATUS` messages, mainly to check that correct include directories, compile definitions and linked libraries were set up correctly.

The remaining options like install location and compilers are handled by CMake. Tested this on Ubuntu with CMake 3.15.5 and everything except `pySU2ad` wrapper compiles. Haven't tested on earlier CMake versions so there might be bugs with them but they should be easy to resolve if any.

I have based the CMake scripts on autotools scripts so there's no Pastix/Blas options yet. [FindBLAS](https://cmake.org/cmake/help/latest/module/FindBLAS.html), [FindPastix](https://github.com/eigenteam/eigen-git-mirror/blob/master/cmake/FindPastix.cmake), [FindScotch](https://github.com/eigenteam/eigen-git-mirror/blob/master/cmake/FindScotch.cmake)

## Related Work
*Resolve any issues (bug fix or feature request), note any related PRs, or mention interactions with the work of others, if any.*



## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [x] My contribution is commented and consistent with SU2 style.
- [x] I have added a test case that demonstrates my contribution, if necessary.
