### PR TITLE
Fix SU2 Mesh Writer

### DIFF
--- a/SU2_CFD/src/output/filewriter/CSU2MeshFileWriter.cpp
+++ b/SU2_CFD/src/output/filewriter/CSU2MeshFileWriter.cpp
@@ -78,7 +78,7 @@ void CSU2MeshFileWriter::Write_Data(){
 
     output_file << "NDIME= " << dataSorter->GetnDim() << endl;
 
-    output_file << "NELEM= " << dataSorter->GetnElem() << endl;
+    output_file << "NELEM= " << dataSorter->GetnElemGlobal() << endl;
 
     output_file.close();
   }


### PR DESCRIPTION
## Proposed Changes
This is a bugfix for the mesh writer, which was outputting the wrong number of elements when run in parallel.  


## Related Work
[Post on CFD online](https://www.cfd-online.com/Forums/su2-shape-design/224088-segfault-second-dsn-iteration.html#post757055) that made me aware of that problem.


## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [x] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
