### PR TITLE
fixing for support for SST model in C1Dinterpolation

### DIFF
--- a/Common/src/toolboxes/C1DInterpolation.cpp
+++ b/Common/src/toolboxes/C1DInterpolation.cpp
@@ -148,7 +148,7 @@ vector<su2double> CorrectedInletValues(const vector<su2double> &Inlet_Interpolat
   /*---For turbulence variables columns---*/
   if (nVar_Turb == 1)
     Inlet_Values[nDim+5] = Inlet_Interpolated[5];
-  else if (nVar_Turb == 2)
+  if (nVar_Turb == 2)
     Inlet_Values[nDim+6] = Inlet_Interpolated[6];
 
   /*--- Correct for Interpolation Type now ---*/

--- a/Common/src/toolboxes/C1DInterpolation.cpp
+++ b/Common/src/toolboxes/C1DInterpolation.cpp
@@ -148,8 +148,10 @@ vector<su2double> CorrectedInletValues(const vector<su2double> &Inlet_Interpolat
   /*---For turbulence variables columns---*/
   if (nVar_Turb == 1)
     Inlet_Values[nDim+5] = Inlet_Interpolated[5];
-  if (nVar_Turb == 2)
+  else if (nVar_Turb == 2){
+    Inlet_Values[nDim+5] = Inlet_Interpolated[5];
     Inlet_Values[nDim+6] = Inlet_Interpolated[6];
+  }
 
   /*--- Correct for Interpolation Type now ---*/
   switch(Interpolation_Type){


### PR DESCRIPTION
small change to fix support for SST model.

@pcarruscag I think you inadvertently added an else-if during your formatting corrections. I intentionally did not use an else-if as it will support both SA and SST models.

Thanks.