### PR TITLE
Fix spelling error subroutines in top comment

### DIFF
--- a/SU2_CFD/src/solvers/CTemplateSolver.cpp
+++ b/SU2_CFD/src/solvers/CTemplateSolver.cpp
@@ -1,6 +1,6 @@
 /*!
  * \file CTemplateSolver.cpp
- * \brief Subrotuines to be implemented for any new solvers
+ * \brief Subroutines to be implemented for any new solvers
  * \author F. Palacios
  * \version 7.0.3 "Blackbird"
  *


### PR DESCRIPTION
## Proposed Changes
*Give a brief overview of your contribution here in a few sentences.*
 Fixed a spelling error in the top comment of the file CTemplateSolver.cpp in SU2_CFD/src/solvers/


## Related Work
*Resolve any issues (bug fix or feature request), note any related PRs, or mention interactions with the work of others, if any.*



## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [x] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
