### PR TITLE
Add the Wtime function to the MPI wrapper (to avoid #ifdefs)

### DIFF
--- a/Common/include/grid_movement_structure.hpp
+++ b/Common/include/grid_movement_structure.hpp
@@ -36,7 +36,6 @@
 #include <cstdlib>
 #include <fstream>
 #include <cmath>
-#include <ctime>
 
 #include "geometry/CGeometry.hpp"
 #include "CConfig.hpp"

--- a/Common/include/mpi_structure.hpp
+++ b/Common/include/mpi_structure.hpp
@@ -7,7 +7,7 @@
  *
  * SU2 Project Website: https://su2code.github.io
  *
- * The SU2 Project is maintained by the SU2 Foundation 
+ * The SU2 Project is maintained by the SU2 Foundation
  * (http://su2foundation.org)
  *
  * Copyright 2012-2020, SU2 Contributors (cf. AUTHORS.md)
@@ -90,29 +90,29 @@ template<> struct SelectMPIWrapper<passivedouble> { typedef CBaseMPIWrapper W; }
 class CBaseMPIWrapper {
 
 public:
-  
+
   typedef MPI_Request  Request;
   typedef MPI_Status   Status;
   typedef MPI_Datatype Datatype;
   typedef MPI_Op       Op;
   typedef MPI_Comm     Comm;
   typedef MPI_Win      Win;
-  
+
 protected:
-  
+
   static int Rank, Size, MinRankError;
   static Comm currentComm;
   static bool winMinRankErrorInUse;
   static Win  winMinRankError;
-  
+
 public:
-  
+
   static int GetRank();
-  
+
   static int GetSize();
-  
+
   static Comm GetComm();
-  
+
   static void SetComm(Comm NewComm);
 
   static void Error(std::string ErrorMsg, std::string FunctionName);
@@ -126,13 +126,13 @@ public:
   static void Buffer_detach(void *buffer, int *size);
 
   static void Finalize();
-  
+
   static void Comm_rank(Comm comm, int* rank);
-  
+
   static void Comm_size(Comm comm, int* size);
-  
+
   static void Barrier(Comm comm);
-  
+
   static void Abort(Comm comm, int error);
 
   static void Get_count(Status *status, Datatype datatype, int *count);
@@ -200,6 +200,8 @@ public:
 
   static void Reduce_scatter(void *sendbuf, void *recvbuf, int *recvcounts,
                              Datatype datatype, Op op, Comm comm);
+
+  static passivedouble Wtime(void);
 };
 
 typedef MPI_Comm SU2_Comm;
@@ -225,7 +227,7 @@ public:
   static AMPI_Datatype convertDatatype(MPI_Datatype datatype);
 
   static void SetComm(Comm NewComm);
-  
+
   static void Init(int *argc, char***argv);
 
   static void Init_thread(int *argc, char***argv, int required, int* provided);
@@ -331,13 +333,13 @@ public:
 #define MPI_INT 11
 #define MPI_PROD 12
 class CBaseMPIWrapper {
-  
+
 public:
   typedef int Comm;
   typedef int Datatype;
   typedef int Request;
   typedef int Op;
-  
+
   struct Status {
     int MPI_TAG;
     int MPI_SOURCE;
@@ -350,33 +352,33 @@ private:
 
 public:
   static int GetRank();
-  
-  static int GetSize();  
-  
+
+  static int GetSize();
+
   static Comm GetComm();
-  
+
   static void SetComm(Comm NewComm);
-  
+
   static void Error(std::string ErrorMsg, std::string FunctionName);
-    
+
   static void Init(int *argc, char***argv);
 
   static void Init_thread(int *argc, char***argv, int required, int* provided);
-  
+
   static void Buffer_attach(void *buffer, int size);
-  
+
   static void Buffer_detach(void *buffer, int *size);
-  
+
   static void Finalize();
-  
+
   static void Comm_rank(Comm comm, int* rank);
-  
+
   static void Comm_size(Comm comm, int* size);
-  
+
   static void Barrier(Comm comm);
-  
+
   static void Abort(Comm comm, int error);
-  
+
   static void Get_count(Status *status, Datatype datatype, int *count);
 
   static void Isend(void *buf, int count, Datatype datatype, int dest,
@@ -428,7 +430,7 @@ public:
                        int dest, int sendtag, void *recvbuf, int recvcnt,
                        Datatype recvtype,int source, int recvtag,
                        Comm comm, Status *status);
-  
+
   static void Alltoall(void *sendbuf, int sendcount, Datatype sendtype,
                            void *recvbuf, int recvcount, Datatype recvtype,
                            Comm comm);
@@ -439,9 +441,10 @@ public:
 
   static void Reduce_scatter(void *sendbuf, void *recvbuf, int *recvcounts,
                              Datatype datatype, Op op, Comm comm);
-    
+
   static void CopyData(void *sendbuf, void *recvbuf, int size, Datatype datatype);
-  
+
+  static passivedouble Wtime(void);
 };
 typedef int SU2_Comm;
 typedef CBaseMPIWrapper SU2_MPI;

--- a/Common/include/mpi_structure.inl
+++ b/Common/include/mpi_structure.inl
@@ -6,7 +6,7 @@
  *
  * SU2 Project Website: https://su2code.github.io
  *
- * The SU2 Project is maintained by the SU2 Foundation 
+ * The SU2 Project is maintained by the SU2 Foundation
  * (http://su2foundation.org)
  *
  * Copyright 2012-2020, SU2 Contributors (cf. AUTHORS.md)
@@ -41,13 +41,13 @@ inline void CBaseMPIWrapper::Error(std::string ErrorMsg, std::string FunctionNam
   MPI_Ibarrier(currentComm, &barrierRequest);
 
   /* Try to complete the non-blocking barrier call for a second. */
-  double startTime = MPI_Wtime();
+  double startTime = SU2_MPI::Wtime();
   while( true ) {
 
     MPI_Test(&barrierRequest, &flag, MPI_STATUS_IGNORE);
     if( flag ) break;
 
-    double currentTime = MPI_Wtime();
+    double currentTime = SU2_MPI::Wtime();
     if(currentTime > startTime + 1.0) break;
   }
 #else
@@ -90,7 +90,7 @@ inline void CBaseMPIWrapper::Error(std::string ErrorMsg, std::string FunctionNam
     std::cout <<  "-------------------------------------------------------------------------" << std::endl;
     std::cout << ErrorMsg << std::endl;
     std::cout <<  "------------------------------ Error Exit -------------------------------" << std::endl;
-    std::cout << std::endl << std::endl;    
+    std::cout << std::endl << std::endl;
   }
   Abort(currentComm, EXIT_FAILURE);
 }
@@ -106,7 +106,7 @@ inline int CBaseMPIWrapper::GetSize(){
 
 inline void CBaseMPIWrapper::SetComm(Comm newComm){
   currentComm = newComm;
-  MPI_Comm_rank(currentComm, &Rank);  
+  MPI_Comm_rank(currentComm, &Rank);
   MPI_Comm_size(currentComm, &Size);
 
   if( winMinRankErrorInUse ) MPI_Win_free(&winMinRankError);
@@ -122,8 +122,8 @@ inline CBaseMPIWrapper::Comm CBaseMPIWrapper::GetComm(){
 
 inline void CBaseMPIWrapper::Init(int *argc, char ***argv) {
   MPI_Init(argc,argv);
-  MPI_Comm_rank(currentComm, &Rank);    
-  MPI_Comm_size(currentComm, &Size);  
+  MPI_Comm_rank(currentComm, &Rank);
+  MPI_Comm_size(currentComm, &Size);
 
   MinRankError = Size;
   MPI_Win_create(&MinRankError, sizeof(int), sizeof(int), MPI_INFO_NULL,
@@ -133,8 +133,8 @@ inline void CBaseMPIWrapper::Init(int *argc, char ***argv) {
 
 inline void CBaseMPIWrapper::Init_thread(int *argc, char ***argv, int required, int* provided) {
   MPI_Init_thread(argc,argv,required,provided);
-  MPI_Comm_rank(currentComm, &Rank);    
-  MPI_Comm_size(currentComm, &Size);  
+  MPI_Comm_rank(currentComm, &Rank);
+  MPI_Comm_size(currentComm, &Size);
 
   MinRankError = Size;
   MPI_Win_create(&MinRankError, sizeof(int), sizeof(int), MPI_INFO_NULL,
@@ -278,14 +278,17 @@ inline void CBaseMPIWrapper::Waitany(int nrequests, Request *request,
   MPI_Waitany(nrequests, request, index, status);
 }
 
+inline passivedouble CBaseMPIWrapper::Wtime(void) {
+  return MPI_Wtime();
+}
 
 #if defined CODI_REVERSE_TYPE || defined CODI_FORWARD_TYPE
 
 inline void CMediMPIWrapper::Init(int *argc, char ***argv) {
   AMPI_Init(argc,argv);
   MediTool::init();
-  AMPI_Comm_rank(convertComm(currentComm), &Rank);    
-  AMPI_Comm_size(convertComm(currentComm), &Size);  
+  AMPI_Comm_rank(convertComm(currentComm), &Rank);
+  AMPI_Comm_size(convertComm(currentComm), &Size);
 
   MinRankError = Size;
   MPI_Win_create(&MinRankError, sizeof(int), sizeof(int), MPI_INFO_NULL,
@@ -296,8 +299,8 @@ inline void CMediMPIWrapper::Init(int *argc, char ***argv) {
 inline void CMediMPIWrapper::Init_thread(int *argc, char ***argv, int required, int* provided) {
   AMPI_Init_thread(argc,argv,required,provided);
   MediTool::init();
-  AMPI_Comm_rank(convertComm(currentComm), &Rank);    
-  AMPI_Comm_size(convertComm(currentComm), &Size);  
+  AMPI_Comm_rank(convertComm(currentComm), &Rank);
+  AMPI_Comm_size(convertComm(currentComm), &Size);
 
   MinRankError = Size;
   MPI_Win_create(&MinRankError, sizeof(int), sizeof(int), MPI_INFO_NULL,
@@ -312,7 +315,7 @@ inline void CMediMPIWrapper::Init_AMPI(void) {
 
 inline void CMediMPIWrapper::SetComm(Comm newComm){
   currentComm = newComm;
-  AMPI_Comm_rank(convertComm(currentComm), &Rank);  
+  AMPI_Comm_rank(convertComm(currentComm), &Rank);
   AMPI_Comm_size(convertComm(currentComm), &Size);
 
   if( winMinRankErrorInUse ) MPI_Win_free(&winMinRankError);
@@ -508,7 +511,8 @@ inline void CMediMPIWrapper::Waitany(int nrequests, Request *request,
   AMPI_Waitany(nrequests, request, index, status);
 }
 #endif
-#else
+#else // HAVE_MPI
+#include <ctime>
 
 inline void CBaseMPIWrapper::Error(std::string ErrorMsg, std::string FunctionName){
   if (Rank == 0){
@@ -517,7 +521,7 @@ inline void CBaseMPIWrapper::Error(std::string ErrorMsg, std::string FunctionNam
     std::cout <<  "-------------------------------------------------------------------------" << std::endl;
     std::cout << ErrorMsg << std::endl;
     std::cout <<  "------------------------------ Error Exit -------------------------------" << std::endl;
-    std::cout << std::endl << std::endl;    
+    std::cout << std::endl << std::endl;
   }
   Abort(currentComm, 0);
 }
@@ -681,5 +685,9 @@ inline void CBaseMPIWrapper::CopyData(void *sendbuf, void *recvbuf, int size, Da
     default:
       break;
   }
+}
+
+inline passivedouble CBaseMPIWrapper::Wtime(void) {
+  return passivedouble(clock()) / CLOCKS_PER_SEC;
 }
 #endif

--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -9142,12 +9142,7 @@ su2double CConfig::GetSpline(vector<su2double>&xa, vector<su2double>&ya, vector<
 void CConfig::Tick(double *val_start_time) {
 
 #ifdef PROFILE
-#ifndef HAVE_MPI
-  *val_start_time = double(clock())/double(CLOCKS_PER_SEC);
-#else
-  *val_start_time = MPI_Wtime();
-#endif
-
+  *val_start_time = SU2_MPI::Wtime();
 #endif
 
 }
@@ -9158,11 +9153,7 @@ void CConfig::Tock(double val_start_time, string val_function_name, int val_grou
 
   double val_stop_time = 0.0, val_elapsed_time = 0.0;
 
-#ifndef HAVE_MPI
-  val_stop_time = double(clock())/double(CLOCKS_PER_SEC);
-#else
-  val_stop_time = MPI_Wtime();
-#endif
+  val_stop_time = SU2_MPI::Wtime();
 
   /*--- Compute the elapsed time for this subroutine ---*/
   val_elapsed_time = val_stop_time - val_start_time;
@@ -9344,10 +9335,8 @@ void CConfig::GEMM_Tick(double *val_start_time) {
 
 #ifdef HAVE_MKL
   *val_start_time = dsecnd();
-#elif HAVE_MPI
-  *val_start_time = MPI_Wtime();
 #else
-  *val_start_time = double(clock())/double(CLOCKS_PER_SEC);
+  *val_start_time = SU2_MPI::Wtime();
 #endif
 
 #endif
@@ -9364,10 +9353,8 @@ void CConfig::GEMM_Tock(double val_start_time, int M, int N, int K) {
 
 #ifdef HAVE_MKL
   val_stop_time = dsecnd();
-#elif HAVE_MPI
-  val_stop_time = MPI_Wtime();
 #else
-  val_stop_time = double(clock())/double(CLOCKS_PER_SEC);
+  val_stop_time = SU2_MPI::Wtime();
 #endif
 
   /* Compute the elapsed time. */

--- a/SU2_CFD/include/SU2_CFD.hpp
+++ b/SU2_CFD/include/SU2_CFD.hpp
@@ -31,8 +31,6 @@
 #include "../../Common/include/omp_structure.hpp"
 #include "CLI11.hpp"
 
-#include <ctime>
-
 #include "drivers/CDriver.hpp"
 #include "drivers/CSinglezoneDriver.hpp"
 #include "drivers/CMultizoneDriver.hpp"

--- a/SU2_CFD/include/definition_structure.hpp
+++ b/SU2_CFD/include/definition_structure.hpp
@@ -7,7 +7,7 @@
  *
  * SU2 Project Website: https://su2code.github.io
  *
- * The SU2 Project is maintained by the SU2 Foundation 
+ * The SU2 Project is maintained by the SU2 Foundation
  * (http://su2foundation.org)
  *
  * Copyright 2012-2020, SU2 Contributors (cf. AUTHORS.md)
@@ -29,8 +29,6 @@
 #pragma once
 
 #include "../../Common/include/mpi_structure.hpp"
-
-#include <ctime>
 
 #include "../../Common/include/fem_geometry_structure.hpp"
 #include "../../Common/include/geometry/CGeometry.hpp"

--- a/SU2_CFD/include/iteration_structure.hpp
+++ b/SU2_CFD/include/iteration_structure.hpp
@@ -28,8 +28,6 @@
 
 #pragma once
 
-#include <ctime>
-
 #include "../../Common/include/mpi_structure.hpp"
 #include "../../Common/include/geometry/CGeometry.hpp"
 #include "../../Common/include/grid_movement_structure.hpp"

--- a/SU2_CFD/src/drivers/CDriver.cpp
+++ b/SU2_CFD/src/drivers/CDriver.cpp
@@ -102,11 +102,7 @@ CDriver::CDriver(char* confFile, unsigned short val_nZone, SU2_Comm MPICommunica
 
   /*--- Start timer to track preprocessing for benchmarking. ---*/
 
-#ifndef HAVE_MPI
-  StartTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  StartTime = MPI_Wtime();
-#endif
+  StartTime = SU2_MPI::Wtime();
 
   /*--- Initialize containers with null --- */
 
@@ -265,11 +261,7 @@ CDriver::CDriver(char* confFile, unsigned short val_nZone, SU2_Comm MPICommunica
 
   /*--- Preprocessing time is reported now, but not included in the next compute portion. ---*/
 
-#ifndef HAVE_MPI
-  StopTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  StopTime = MPI_Wtime();
-#endif
+  StopTime = SU2_MPI::Wtime();
 
   /*--- Compute/print the total time for performance benchmarking. ---*/
 
@@ -291,11 +283,8 @@ CDriver::CDriver(char* confFile, unsigned short val_nZone, SU2_Comm MPICommunica
   }
 
   /*--- Reset timer for compute/output performance benchmarking. ---*/
-#ifndef HAVE_MPI
-  StopTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  StopTime = MPI_Wtime();
-#endif
+
+  StopTime = SU2_MPI::Wtime();
 
   /*--- Compute/print the total time for performance benchmarking. ---*/
 
@@ -303,11 +292,8 @@ CDriver::CDriver(char* confFile, unsigned short val_nZone, SU2_Comm MPICommunica
   UsedTimePreproc = UsedTime;
 
   /*--- Reset timer for compute performance benchmarking. ---*/
-#ifndef HAVE_MPI
-  StartTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  StartTime = MPI_Wtime();
-#endif
+
+  StartTime = SU2_MPI::Wtime();
 
 }
 
@@ -551,11 +537,8 @@ void CDriver::Postprocessing() {
 
   /*--- Stop the timer and output the final performance summary. ---*/
 
-#ifndef HAVE_MPI
-  StopTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  StopTime = MPI_Wtime();
-#endif
+  StopTime = SU2_MPI::Wtime();
+
   UsedTime = StopTime-StartTime;
   UsedTimeCompute += UsedTime;
 
@@ -3087,14 +3070,10 @@ bool CFluidDriver::Monitor(unsigned long ExtIter) {
   /*--- Synchronization point after a single solver iteration. Compute the
    wall clock time required. ---*/
 
-#ifndef HAVE_MPI
-  StopTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  StopTime = MPI_Wtime();
-#endif
+  StopTime = SU2_MPI::Wtime();
+
   IterCount++;
   UsedTime = (StopTime - StartTime) + UsedTimeCompute;
-
 
   /*--- Check if there is any change in the runtime parameters ---*/
 
@@ -3270,11 +3249,8 @@ bool CTurbomachineryDriver::Monitor(unsigned long ExtIter) {
   /*--- Synchronization point after a single solver iteration. Compute the
    wall clock time required. ---*/
 
-#ifndef HAVE_MPI
-  StopTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  StopTime = MPI_Wtime();
-#endif
+  StopTime = SU2_MPI::Wtime();
+
   IterCount++;
   UsedTime = (StopTime - StartTime);
 

--- a/SU2_CFD/src/drivers/CMultizoneDriver.cpp
+++ b/SU2_CFD/src/drivers/CMultizoneDriver.cpp
@@ -155,11 +155,7 @@ void CMultizoneDriver::StartSolver() {
     config_container[iZone]->SetTotal_UnstTimeND(config_container[iZone]->GetTotal_UnstTime() / Time_Ref);
   }
 
-#ifndef HAVE_MPI
-  StartTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  StartTime = MPI_Wtime();
-#endif
+  StartTime = SU2_MPI::Wtime();
 
   driver_config->Set_StartTime(StartTime);
 
@@ -478,17 +474,12 @@ void CMultizoneDriver::Update() {
 void CMultizoneDriver::Output(unsigned long TimeIter) {
 
   /*--- Time the output for performance benchmarking. ---*/
-#ifndef HAVE_MPI
-  StopTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  StopTime = MPI_Wtime();
-#endif
+
+  StopTime = SU2_MPI::Wtime();
+
   UsedTimeCompute += StopTime-StartTime;
-#ifndef HAVE_MPI
-  StartTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  StartTime = MPI_Wtime();
-#endif
+
+  StartTime = SU2_MPI::Wtime();
 
   bool wrote_files = false;
 
@@ -500,19 +491,14 @@ void CMultizoneDriver::Output(unsigned long TimeIter) {
 
   if (wrote_files){
 
-#ifndef HAVE_MPI
-    StopTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-    StopTime = MPI_Wtime();
-#endif
+    StopTime = SU2_MPI::Wtime();
+
     UsedTimeOutput += StopTime-StartTime;
     OutputCount++;
     BandwidthSum = config_container[ZONE_0]->GetRestart_Bandwidth_Agg();
-#ifndef HAVE_MPI
-    StartTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-    StartTime = MPI_Wtime();
-#endif
+
+    StartTime = SU2_MPI::Wtime();
+
     driver_config->Set_StartTime(StartTime);
   }
 

--- a/SU2_CFD/src/drivers/CSinglezoneDriver.cpp
+++ b/SU2_CFD/src/drivers/CSinglezoneDriver.cpp
@@ -46,11 +46,7 @@ CSinglezoneDriver::~CSinglezoneDriver(void) {
 
 void CSinglezoneDriver::StartSolver() {
 
-#ifndef HAVE_MPI
-  StartTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  StartTime = MPI_Wtime();
-#endif
+  StartTime = SU2_MPI::Wtime();
 
   config_container[ZONE_0]->Set_StartTime(StartTime);
 
@@ -185,17 +181,12 @@ void CSinglezoneDriver::Update() {
 void CSinglezoneDriver::Output(unsigned long TimeIter) {
 
   /*--- Time the output for performance benchmarking. ---*/
-#ifndef HAVE_MPI
-  StopTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  StopTime = MPI_Wtime();
-#endif
+
+  StopTime = SU2_MPI::Wtime();
+
   UsedTimeCompute += StopTime-StartTime;
-#ifndef HAVE_MPI
-  StartTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  StartTime = MPI_Wtime();
-#endif
+
+  StartTime = SU2_MPI::Wtime();
 
   bool wrote_files = output_container[ZONE_0]->SetResult_Files(geometry_container[ZONE_0][INST_0][MESH_0],
                                                                config_container[ZONE_0],
@@ -204,19 +195,14 @@ void CSinglezoneDriver::Output(unsigned long TimeIter) {
 
   if (wrote_files){
 
-#ifndef HAVE_MPI
-    StopTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-    StopTime = MPI_Wtime();
-#endif
+    StopTime = SU2_MPI::Wtime();
+
     UsedTimeOutput += StopTime-StartTime;
     OutputCount++;
     BandwidthSum = config_container[ZONE_0]->GetRestart_Bandwidth_Agg();
-#ifndef HAVE_MPI
-    StartTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-    StartTime = MPI_Wtime();
-#endif
+
+    StartTime = SU2_MPI::Wtime();
+
     config_container[ZONE_0]->Set_StartTime(StartTime);
   }
 }

--- a/SU2_CFD/src/iteration_structure.cpp
+++ b/SU2_CFD/src/iteration_structure.cpp
@@ -561,11 +561,8 @@ bool CFluidIteration::Monitor(COutput *output,
 
   bool StopCalc = false;
 
-#ifndef HAVE_MPI
-  StopTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  StopTime = MPI_Wtime();
-#endif
+  StopTime = SU2_MPI::Wtime();
+
   UsedTime = StopTime - StartTime;
 
 
@@ -653,11 +650,7 @@ void CFluidIteration::Solve(COutput *output,
   /*--- Synchronization point before a single solver iteration.
         Compute the wall clock time required. ---*/
 
-#ifndef HAVE_MPI
-  StartTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  StartTime = MPI_Wtime();
-#endif
+  StartTime = SU2_MPI::Wtime();
 
   /*--- Preprocess the solver ---*/
   Preprocess(output, integration, geometry, solver, numerics, config,
@@ -1122,11 +1115,7 @@ void CHeatIteration::Solve(COutput *output,
   /*--- Synchronization point before a single solver iteration.
         Compute the wall clock time required. ---*/
 
-#ifndef HAVE_MPI
-  StartTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  StartTime = MPI_Wtime();
-#endif
+  StartTime = SU2_MPI::Wtime();
 
   /*--- Preprocess the solver ---*/
 
@@ -1484,11 +1473,8 @@ bool CFEAIteration::Monitor(COutput *output,
                             unsigned short val_iZone,
                             unsigned short val_iInst) {
 
-#ifndef HAVE_MPI
-  StopTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  StopTime = MPI_Wtime();
-#endif
+  StopTime = SU2_MPI::Wtime();
+
   UsedTime = StopTime - StartTime;
 
   if (config[val_iZone]->GetMultizone_Problem() || config[val_iZone]->GetSinglezone_Driver()){
@@ -1747,12 +1733,7 @@ void CDiscAdjFluidIteration::Preprocess(COutput *output,
                                            CFreeFormDefBox*** FFDBox,
                                            unsigned short val_iZone,
                                            unsigned short val_iInst) {
-
-#ifndef HAVE_MPI
-  StartTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  StartTime = MPI_Wtime();
-#endif
+  StartTime = SU2_MPI::Wtime();
 
   unsigned long iPoint;
   unsigned short TimeIter = config[val_iZone]->GetTimeIter();
@@ -2295,11 +2276,8 @@ bool CDiscAdjFluidIteration::Monitor(COutput *output,
     unsigned short val_iZone,
     unsigned short val_iInst)     {
 
-#ifndef HAVE_MPI
-  StopTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  StopTime = MPI_Wtime();
-#endif
+  StopTime = SU2_MPI::Wtime();
+
   UsedTime = StopTime - StartTime;
 
   /*--- Write the convergence history for the fluid (only screen output) ---*/

--- a/SU2_CFD/src/output/COutput.cpp
+++ b/SU2_CFD/src/output/COutput.cpp
@@ -2038,11 +2038,8 @@ void COutput::LoadCommonHistoryData(CConfig *config){
   SetHistoryOutputValue("OUTER_ITER", curOuterIter);
 
   su2double StopTime, UsedTime;
-#ifndef HAVE_MPI
-  StopTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  StopTime = MPI_Wtime();
-#endif
+
+  StopTime = SU2_MPI::Wtime();
 
   UsedTime = (StopTime - config->Get_StartTime())/((curOuterIter + 1) * (curInnerIter+1));
 

--- a/SU2_CFD/src/output/filewriter/CParallelFileWriter.cpp
+++ b/SU2_CFD/src/output/filewriter/CParallelFileWriter.cpp
@@ -66,7 +66,7 @@ bool CFileWriter::WriteMPIBinaryDataAll(const void *data, unsigned long sizeInBy
   
 #ifdef HAVE_MPI
 
-  startTime = MPI_Wtime();
+  startTime = SU2_MPI::Wtime();
   
   MPI_Datatype filetype;
   
@@ -91,14 +91,14 @@ bool CFileWriter::WriteMPIBinaryDataAll(const void *data, unsigned long sizeInBy
   disp      += totalSizeInBytes;
   fileSize  += sizeInBytes;
   
-  stopTime = MPI_Wtime();
+  stopTime = SU2_MPI::Wtime();
   
   usedTime += stopTime - startTime;
   
   return (ierr == MPI_SUCCESS);
 #else
 
-  startTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
+  startTime = SU2_MPI::Wtime();
   
   unsigned long bytesWritten;
   
@@ -107,7 +107,7 @@ bool CFileWriter::WriteMPIBinaryDataAll(const void *data, unsigned long sizeInBy
   bytesWritten = fwrite(data, sizeof(char), sizeInBytes, fhw);
   fileSize += bytesWritten;
   
-  stopTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
+  stopTime = SU2_MPI::Wtime();
   
   usedTime += stopTime - startTime;
   
@@ -120,7 +120,7 @@ bool CFileWriter::WriteMPIBinaryData(const void *data, unsigned long sizeInBytes
   
 #ifdef HAVE_MPI
   
-  startTime = MPI_Wtime();
+  startTime = SU2_MPI::Wtime();
   
   int ierr = MPI_SUCCESS;
   
@@ -135,14 +135,14 @@ bool CFileWriter::WriteMPIBinaryData(const void *data, unsigned long sizeInBytes
   disp     += sizeInBytes;
   fileSize += sizeInBytes;
   
-  stopTime = MPI_Wtime();
+  stopTime = SU2_MPI::Wtime();
   
   usedTime += stopTime - startTime;
   
   return (ierr == MPI_SUCCESS);
 #else
   
-  startTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
+  startTime = SU2_MPI::Wtime();
   
   unsigned long bytesWritten = sizeInBytes;
   
@@ -150,7 +150,7 @@ bool CFileWriter::WriteMPIBinaryData(const void *data, unsigned long sizeInBytes
   
   bytesWritten = fwrite(data, sizeof(char), sizeInBytes, fhw);
   
-  stopTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
+  stopTime = SU2_MPI::Wtime();
   
   usedTime += stopTime - startTime;
   
@@ -164,7 +164,7 @@ bool CFileWriter::WriteMPIString(const string &str, unsigned short processor){
   
 #ifdef HAVE_MPI
 
-  startTime = MPI_Wtime();
+  startTime = SU2_MPI::Wtime();
   
   int ierr = MPI_SUCCESS;
   
@@ -180,7 +180,7 @@ bool CFileWriter::WriteMPIString(const string &str, unsigned short processor){
   disp += str.size()*sizeof(char);
   fileSize += sizeof(char)*str.size();
   
-  stopTime = MPI_Wtime();
+  stopTime = SU2_MPI::Wtime();
   
   usedTime += stopTime - startTime;
   
@@ -188,14 +188,14 @@ bool CFileWriter::WriteMPIString(const string &str, unsigned short processor){
   
 #else
   
-  startTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
+  startTime = SU2_MPI::Wtime();
   
   unsigned long bytesWritten;  
   bytesWritten = fwrite(str.c_str(), sizeof(char), str.size(), fhw);
   
   fileSize += bytesWritten;
   
-  stopTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
+  stopTime = SU2_MPI::Wtime();
   
   usedTime += stopTime - startTime;
   

--- a/SU2_CFD/src/output/filewriter/CParaviewFileWriter.cpp
+++ b/SU2_CFD/src/output/filewriter/CParaviewFileWriter.cpp
@@ -55,11 +55,7 @@ void CParaviewFileWriter::Write_Data(){
 
   /*--- Set a timer for the file writing. ---*/
 
-#ifndef HAVE_MPI
-  startTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  startTime = MPI_Wtime();
-#endif
+  startTime = SU2_MPI::Wtime();
 
   /*--- Open Paraview ASCII file and write the header. ---*/
 
@@ -358,11 +354,8 @@ void CParaviewFileWriter::Write_Data(){
 
   /*--- Compute and store the write time. ---*/
 
-#ifndef HAVE_MPI
-  stopTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  stopTime = MPI_Wtime();
-#endif
+  stopTime = SU2_MPI::Wtime();
+
   usedTime = stopTime-startTime;
 
   fileSize = Determine_Filesize(fileName);

--- a/SU2_CFD/src/output/filewriter/CSU2FileWriter.cpp
+++ b/SU2_CFD/src/output/filewriter/CSU2FileWriter.cpp
@@ -51,11 +51,7 @@ void CSU2FileWriter::Write_Data(){
 
   /*--- Set a timer for the file writing. ---*/
 
-#ifndef HAVE_MPI
-  startTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  startTime = MPI_Wtime();
-#endif
+  startTime = SU2_MPI::Wtime();
 
   /*--- Only the master node writes the header. ---*/
 
@@ -113,11 +109,8 @@ void CSU2FileWriter::Write_Data(){
 
   /*--- Compute and store the write time. ---*/
 
-#ifndef HAVE_MPI
-  stopTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  stopTime = MPI_Wtime();
-#endif
+  stopTime = SU2_MPI::Wtime();
+
   usedTime = stopTime-startTime;
 
   /*--- Determine the file size ---*/

--- a/SU2_CFD/src/output/filewriter/CTecplotBinaryFileWriter.cpp
+++ b/SU2_CFD/src/output/filewriter/CTecplotBinaryFileWriter.cpp
@@ -47,11 +47,7 @@ void CTecplotBinaryFileWriter::Write_Data(){
 
   /*--- Set a timer for the binary file writing. ---*/
 
-#ifndef HAVE_MPI
-  startTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  startTime = MPI_Wtime();
-#endif
+  startTime = SU2_MPI::Wtime();
 
 #ifdef HAVE_TECIO
 
@@ -588,11 +584,8 @@ void CTecplotBinaryFileWriter::Write_Data(){
 
   /*--- Compute and store the write time. ---*/
 
-#ifndef HAVE_MPI
-  stopTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  stopTime = MPI_Wtime();
-#endif
+  stopTime = SU2_MPI::Wtime();
+
   usedTime = stopTime-startTime;
 
   fileSize = Determine_Filesize(fileName);

--- a/SU2_CFD/src/output/filewriter/CTecplotFileWriter.cpp
+++ b/SU2_CFD/src/output/filewriter/CTecplotFileWriter.cpp
@@ -55,11 +55,7 @@ void CTecplotFileWriter::Write_Data(){
 
   /*--- Set a timer for the file writing. ---*/
 
-#ifndef HAVE_MPI
-  startTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  startTime = MPI_Wtime();
-#endif
+  startTime = SU2_MPI::Wtime();
 
   /*--- Reduce the total number of each element. ---*/
 
@@ -216,11 +212,8 @@ void CTecplotFileWriter::Write_Data(){
 
   /*--- Compute and store the write time. ---*/
 
-#ifndef HAVE_MPI
-  stopTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  stopTime = MPI_Wtime();
-#endif
+  stopTime = SU2_MPI::Wtime();
+
   usedTime = stopTime-startTime;
 
   fileSize = Determine_Filesize(fileName);

--- a/SU2_CFD/src/output/output_structure_legacy.cpp
+++ b/SU2_CFD/src/output/output_structure_legacy.cpp
@@ -17601,11 +17601,7 @@ void COutputLegacy::WriteRestart_Parallel_Binary(CConfig *config, CGeometry *geo
 
   /*--- Set a timer for the binary file writing. ---*/
 
-#ifndef HAVE_MPI
-  StartTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  StartTime = MPI_Wtime();
-#endif
+  StartTime = SU2_MPI::Wtime();
 
 #ifndef HAVE_MPI
 
@@ -17768,11 +17764,8 @@ void COutputLegacy::WriteRestart_Parallel_Binary(CConfig *config, CGeometry *geo
 
   /*--- Compute and store the write time. ---*/
 
-#ifndef HAVE_MPI
-  StopTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#else
-  StopTime = MPI_Wtime();
-#endif
+  StopTime = SU2_MPI::Wtime();
+
   UsedTime = StopTime-StartTime;
 
   /*--- Communicate the total file size for the restart ---*/

--- a/SU2_DEF/src/SU2_DEF.cpp
+++ b/SU2_DEF/src/SU2_DEF.cpp
@@ -165,11 +165,8 @@ int main(int argc, char *argv[]) {
   
   /*--- Set up a timer for performance benchmarking (preprocessing time is included) ---*/
   
-#ifdef HAVE_MPI
-  StartTime = MPI_Wtime();
-#else
-  StartTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#endif
+  StartTime = SU2_MPI::Wtime();
+
   for (iZone = 0; iZone < nZone; iZone++) {
 
     /*--- Computational grid preprocesing ---*/
@@ -430,11 +427,7 @@ int main(int argc, char *argv[]) {
   /*--- Synchronization point after a single solver iteration. Compute the
    wall clock time required. ---*/
   
-#ifdef HAVE_MPI
-  StopTime = MPI_Wtime();
-#else
-  StopTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#endif
+  StopTime = SU2_MPI::Wtime();
   
   /*--- Compute/print the total time for performance benchmarking. ---*/
   

--- a/SU2_DOT/src/SU2_DOT.cpp
+++ b/SU2_DOT/src/SU2_DOT.cpp
@@ -215,11 +215,7 @@ int main(int argc, char *argv[]) {
 
   /*--- Set up a timer for performance benchmarking (preprocessing time is included) ---*/
 
-#ifdef HAVE_MPI
-  StartTime = MPI_Wtime();
-#else
-  StartTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#endif
+  StartTime = SU2_MPI::Wtime();
 
   for (iZone = 0; iZone < nZone; iZone++) {
 
@@ -400,11 +396,7 @@ int main(int argc, char *argv[]) {
   /*--- Synchronization point after a single solver iteration. Compute the
    wall clock time required. ---*/
 
-#ifdef HAVE_MPI
-  StopTime = MPI_Wtime();
-#else
-  StopTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#endif
+  StopTime = SU2_MPI::Wtime();
 
   /*--- Compute/print the total time for performance benchmarking. ---*/
 

--- a/SU2_GEO/src/SU2_GEO.cpp
+++ b/SU2_GEO/src/SU2_GEO.cpp
@@ -146,13 +146,9 @@ int main(int argc, char *argv[]) {
   bool tabTecplot = config_container[ZONE_0]->GetTabular_FileFormat() == TAB_TECPLOT;
   
   /*--- Set up a timer for performance benchmarking (preprocessing time is included) ---*/
-  
-#ifdef HAVE_MPI
-  StartTime = MPI_Wtime();
-#else
-  StartTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#endif
-  
+
+  StartTime = SU2_MPI::Wtime();
+
   /*--- Evaluation of the objective function ---*/
   
   if (rank == MASTER_NODE)
@@ -1283,13 +1279,9 @@ int main(int argc, char *argv[]) {
   
   /*--- Synchronization point after a single solver iteration. Compute the
    wall clock time required. ---*/
-  
-#ifdef HAVE_MPI
-  StopTime = MPI_Wtime();
-#else
-  StopTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#endif
-  
+
+  StopTime = SU2_MPI::Wtime();
+
   /*--- Compute/print the total time for performance benchmarking. ---*/
   
   UsedTime = StopTime-StartTime;

--- a/SU2_MSH/src/SU2_MSH.cpp
+++ b/SU2_MSH/src/SU2_MSH.cpp
@@ -126,13 +126,9 @@ int main(int argc, char *argv[]) {
   }
   
   /*--- Set up a timer for performance benchmarking (preprocessing time is included) ---*/
-  
-#ifdef HAVE_MPI
-  StartTime = MPI_Wtime();
-#else
-  StartTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#endif
-  
+
+  StartTime = SU2_MPI::Wtime();
+
 	cout << endl <<"----------------------- Preprocessing computations ----------------------" << endl;
 	
 	/*--- Compute elements surrounding points, points surrounding points, and elements surronding elements ---*/
@@ -306,13 +302,9 @@ int main(int argc, char *argv[]) {
 
   /*--- Synchronization point after a single solver iteration. Compute the
    wall clock time required. ---*/
-  
-#ifdef HAVE_MPI
-  StopTime = MPI_Wtime();
-#else
-  StopTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#endif
-  
+
+  StopTime = SU2_MPI::Wtime();
+
   /*--- Compute/print the total time for performance benchmarking. ---*/
   
   UsedTime = StopTime-StartTime;

--- a/SU2_SOL/include/SU2_SOL.hpp
+++ b/SU2_SOL/include/SU2_SOL.hpp
@@ -7,7 +7,7 @@
  *
  * SU2 Project Website: https://su2code.github.io
  *
- * The SU2 Project is maintained by the SU2 Foundation 
+ * The SU2 Project is maintained by the SU2 Foundation
  * (http://su2foundation.org)
  *
  * Copyright 2012-2020, SU2 Contributors (cf. AUTHORS.md)
@@ -30,8 +30,6 @@
 #pragma once
 
 #include "../../Common/include/mpi_structure.hpp"
-
-#include <ctime>
 
 #include "../../SU2_CFD/include/solvers/CBaselineSolver.hpp"
 #include "../../SU2_CFD/include/solvers/CBaselineSolver_FEM.hpp"

--- a/SU2_SOL/src/SU2_SOL.cpp
+++ b/SU2_SOL/src/SU2_SOL.cpp
@@ -225,11 +225,7 @@ int main(int argc, char *argv[]) {
 
   /*--- Set up a timer for performance benchmarking (preprocessing time is included) ---*/
 
-#ifdef HAVE_MPI
-  StartTime = MPI_Wtime();
-#else
-  StartTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#endif
+  StartTime = SU2_MPI::Wtime();
 
   if (rank == MASTER_NODE)
     cout << endl <<"------------------------- Solution Postprocessing -----------------------" << endl;
@@ -775,11 +771,7 @@ int main(int argc, char *argv[]) {
   /*--- Synchronization point after a single solver iteration. Compute the
    wall clock time required. ---*/
 
-#ifdef HAVE_MPI
-  StopTime = MPI_Wtime();
-#else
-  StopTime = su2double(clock())/su2double(CLOCKS_PER_SEC);
-#endif
+  StopTime = SU2_MPI::Wtime();
 
   /*--- Compute/print the total time for performance benchmarking. ---*/
 


### PR DESCRIPTION
## Proposed Changes
Add the `Wtime` function to the MPI wrapper (to avoid `#ifdefs`)

## PR Checklist
- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [X] My contribution is commented and consistent with SU2 style.
- [X] I have added a test case that demonstrates my contribution, if necessary.
- [X] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
