### PR TITLE
Add rotating frame coefficients to the history output.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ compiler:
 notifications:
     email:
         recipients:
-            - su2code-dev@lists.stanford.edu
+            - koodlyakshay@gmail.com
   
 branches:
     only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ compiler:
 notifications:
     email:
         recipients:
-            - koodlyakshay@gmail.com
+            - su2code-dev@lists.stanford.edu
   
 branches:
     only:

--- a/SU2_CFD/include/output/CFlowOutput.hpp
+++ b/SU2_CFD/include/output/CFlowOutput.hpp
@@ -71,6 +71,13 @@ protected:
    * \param[in] flow_solver - The container holding all solution data.
    */
   void SetAerodynamicCoefficients(CConfig *config, CSolver *flow_solver);
+  
+  /*!
+   * \brief  Set the value of the rotating frame coefficients (CT, CQ and CMerit).
+   * \param[in] config - Definition of the particular problem.
+   * \param[in] flow_solver - The container holding all solution data.
+   */
+  void SetRotatingFrameCoefficients(CConfig *config, CSolver *flow_solver);
 
   /*!
    * \brief Add CP inverse design output as history fields

--- a/SU2_CFD/src/output/CFlowCompOutput.cpp
+++ b/SU2_CFD/src/output/CFlowCompOutput.cpp
@@ -680,6 +680,10 @@ void CFlowCompOutput::LoadHistoryData(CConfig *config, CGeometry *geometry, CSol
 
   SetAerodynamicCoefficients(config, flow_solver);
 
+  /*--- Set rotating frame coefficients --- */
+
+  SetRotatingFrameCoefficients(config, flow_solver);
+
   /*--- Set Cp diff fields ---*/
 
   Set_CpInverseDesign(flow_solver, geometry, config);

--- a/SU2_CFD/src/output/CFlowIncOutput.cpp
+++ b/SU2_CFD/src/output/CFlowIncOutput.cpp
@@ -181,6 +181,15 @@ void CFlowIncOutput::SetHistoryOutputFields(CConfig *config){
   }
   /// END_GROUP
 
+  /// BEGIN_GROUP: ROTATING_FRAME, DESCRIPTION: Coefficients related to a rotating frame of reference.
+  /// DESCRIPTION: Merit
+  AddHistoryOutput("MERIT", "CMerit", ScreenOutputFormat::SCIENTIFIC, "ROTATING_FRAME", "Merit", HistoryFieldType::COEFFICIENT);
+  /// DESCRIPTION: CT
+  AddHistoryOutput("CT",    "CT",     ScreenOutputFormat::SCIENTIFIC, "ROTATING_FRAME", "CT", HistoryFieldType::COEFFICIENT);
+  /// DESCRIPTION: CQ
+  AddHistoryOutput("CQ",    "CQ",     ScreenOutputFormat::SCIENTIFIC, "ROTATING_FRAME", "CQ", HistoryFieldType::COEFFICIENT);
+  /// END_GROUP
+
   /// BEGIN_GROUP: HEAT_COEFF, DESCRIPTION: Heat coefficients on all surfaces set with MARKER_MONITORING.
   /// DESCRIPTION: Total heatflux
   AddHistoryOutput("TOTAL_HEATFLUX", "HF",      ScreenOutputFormat::SCIENTIFIC, "HEAT", "Total heatflux on all surfaces set with MARKER_MONITORING.", HistoryFieldType::COEFFICIENT);

--- a/SU2_CFD/src/output/CFlowIncOutput.cpp
+++ b/SU2_CFD/src/output/CFlowIncOutput.cpp
@@ -332,6 +332,10 @@ void CFlowIncOutput::LoadHistoryData(CConfig *config, CGeometry *geometry, CSolv
 
   SetAerodynamicCoefficients(config, flow_solver);
 
+  /*--- Set rotating frame coefficients --- */
+
+  SetRotatingFrameCoefficients(config, flow_solver);
+
 }
 
 

--- a/SU2_CFD/src/output/CFlowOutput.cpp
+++ b/SU2_CFD/src/output/CFlowOutput.cpp
@@ -791,6 +791,13 @@ void CFlowOutput::SetAerodynamicCoefficients(CConfig *config, CSolver *flow_solv
   SetHistoryOutputValue("AOA", config->GetAoA());
 }
 
+void CFlowOutput::SetRotatingFrameCoefficients(CConfig *config, CSolver *flow_solver) {
+
+  SetHistoryOutputValue("CT", flow_solver->GetTotal_CT());
+  SetHistoryOutputValue("CQ", flow_solver->GetTotal_CQ());
+  SetHistoryOutputValue("MERIT", flow_solver->GetTotal_CMerit());
+}
+
 
 void CFlowOutput::Add_CpInverseDesignOutput(CConfig *config){
 


### PR DESCRIPTION
## Proposed Changes
Small fix to add the rotating frame coefficients (CT, CQ and CMerit) to the output. 
 
## Related Work
Issue #957 

## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [X] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
