### PR TITLE
Fixes for MG in Multizone Disc Adjoint cases, and incompressible time-averaged history output

### DIFF
--- a/SU2_CFD/src/drivers/CDiscAdjMultizoneDriver.cpp
+++ b/SU2_CFD/src/drivers/CDiscAdjMultizoneDriver.cpp
@@ -426,8 +426,11 @@ void CDiscAdjMultizoneDriver::SetRecording(unsigned short kind_recording, Kind_T
   for(iZone = 0; iZone < nZone; iZone++) {
     for (unsigned short iSol=0; iSol < MAX_SOLS; iSol++) {
       auto solver = solver_container[iZone][INST_0][MESH_0][iSol];
-      if (solver && solver->GetAdjoint())
-        solver->SetRecording(geometry_container[iZone][INST_0][MESH_0], config_container[iZone]);
+      if (solver && solver->GetAdjoint()) {
+        for (unsigned short iMesh = 0; iMesh <= config_container[iZone]->GetnMGLevels(); iMesh++) {
+          solver->SetRecording(geometry_container[iZone][INST_0][iMesh], config_container[iZone]);
+        }
+      }
     }
   }
 

--- a/SU2_CFD/src/output/CFlowIncOutput.cpp
+++ b/SU2_CFD/src/output/CFlowIncOutput.cpp
@@ -651,8 +651,7 @@ bool CFlowIncOutput::SetInit_Residuals(CConfig *config){
 }
 
 bool CFlowIncOutput::SetUpdate_Averages(CConfig *config){
-  return false;
 
-//  return (config->GetUnsteady_Simulation() != STEADY && !dualtime);
+  return (config->GetTime_Marching() != STEADY && (curInnerIter == config->GetnInner_Iter() - 1 || convergence));
 
 }


### PR DESCRIPTION
## Proposed Changes
This is a very short PR with two quick fixes. The first is a fix for accurate multizone adjoints when multigrid is enabled. Second fix is to re-enable time-averaged history output for incompressible flows (direct differentiation for unsteady, incompressible flow also works again as a result).

## Related Work
N/A

## PR Checklist

- [ x] I am submitting my contribution to the develop branch.
- [ x] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [ x] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
