### PR TITLE
Update Xcode and one bug fix

### DIFF
--- a/Common/include/adt_structure.hpp
+++ b/Common/include/adt_structure.hpp
@@ -35,6 +35,7 @@
 #include <cmath>
 #include <vector>
 #include <algorithm>
+#include <array>
 
 #include "./mpi_structure.hpp"
 #include "./omp_structure.hpp"

--- a/SU2_CFD/include/output/tools/CWindowingTools.hpp
+++ b/SU2_CFD/include/output/tools/CWindowingTools.hpp
@@ -28,7 +28,7 @@
 #pragma once
 
 #include <vector>
-#include "../../../Common/include/option_structure.hpp"
+#include "../../../../Common/include/option_structure.hpp"
 
 class CWindowingTools{
 public:

--- a/SU2_IDE/Xcode/SU2_CFD.xcodeproj/project.pbxproj
+++ b/SU2_IDE/Xcode/SU2_CFD.xcodeproj/project.pbxproj
@@ -7,11 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		05E6DB9217EB61E600FA1F7E /* config_structure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DB8917EB61E600FA1F7E /* config_structure.cpp */; };
-		05E6DB9317EB61E600FA1F7E /* dual_grid_structure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DB8A17EB61E600FA1F7E /* dual_grid_structure.cpp */; };
 		05E6DB9517EB61E600FA1F7E /* grid_adaptation_structure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DB8C17EB61E600FA1F7E /* grid_adaptation_structure.cpp */; };
 		05E6DB9617EB61E600FA1F7E /* grid_movement_structure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DB8D17EB61E600FA1F7E /* grid_movement_structure.cpp */; };
-		05E6DB9917EB61E600FA1F7E /* primal_grid_structure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DB9017EB61E600FA1F7E /* primal_grid_structure.cpp */; };
 		05E6DC0117EB62A100FA1F7E /* definition_structure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DBBC17EB62A000FA1F7E /* definition_structure.cpp */; };
 		05E6DC0517EB62A100FA1F7E /* iteration_structure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DBC017EB62A100FA1F7E /* iteration_structure.cpp */; };
 		05E6DC3117EB62A100FA1F7E /* SU2_CFD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DBEC17EB62A100FA1F7E /* SU2_CFD.cpp */; };
@@ -64,6 +61,17 @@
 		40303E61246A064900CD7789 /* CHeatVariable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E5E246A064900CD7789 /* CHeatVariable.cpp */; };
 		40303E62246A064900CD7789 /* CRadP1Variable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E5F246A064900CD7789 /* CRadP1Variable.cpp */; };
 		40303E63246A064900CD7789 /* CRadVariable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E60246A064900CD7789 /* CRadVariable.cpp */; };
+		40303EB0246A5CC000CD7789 /* CConfig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303EAF246A5CC000CD7789 /* CConfig.cpp */; };
+		40303EB9246A5D2700CD7789 /* C1DInterpolation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303EB7246A5D2700CD7789 /* C1DInterpolation.cpp */; };
+		40303EBA246A5D2700CD7789 /* CSymmetricMatrix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303EB8246A5D2700CD7789 /* CSymmetricMatrix.cpp */; };
+		40303EBC246A5D4800CD7789 /* CPastixWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303EBB246A5D4800CD7789 /* CPastixWrapper.cpp */; };
+		40303EC5246A5D9300CD7789 /* CInterpolator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303EBE246A5D9200CD7789 /* CInterpolator.cpp */; };
+		40303EC6246A5D9300CD7789 /* CNearestNeighbor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303EBF246A5D9200CD7789 /* CNearestNeighbor.cpp */; };
+		40303EC7246A5D9300CD7789 /* CMirror.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303EC0246A5D9300CD7789 /* CMirror.cpp */; };
+		40303EC8246A5D9300CD7789 /* CIsoparametric.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303EC1246A5D9300CD7789 /* CIsoparametric.cpp */; };
+		40303EC9246A5D9300CD7789 /* CSlidingMesh.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303EC2246A5D9300CD7789 /* CSlidingMesh.cpp */; };
+		40303ECA246A5D9300CD7789 /* CRadialBasisFunction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303EC3246A5D9300CD7789 /* CRadialBasisFunction.cpp */; };
+		40303ECB246A5D9300CD7789 /* CInterpolatorFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303EC4246A5D9300CD7789 /* CInterpolatorFactory.cpp */; };
 		403426C2235F83B2005B5215 /* CAdjFlowIncOutput.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 403426B2235F83B1005B5215 /* CAdjFlowIncOutput.cpp */; };
 		403426C3235F83B2005B5215 /* CFlowOutput.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 403426B3235F83B1005B5215 /* CFlowOutput.cpp */; };
 		403426C4235F83B2005B5215 /* CFlowIncOutput.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 403426B4235F83B1005B5215 /* CFlowIncOutput.cpp */; };
@@ -103,6 +111,27 @@
 		4040B283235FBFF200843C83 /* CSurfaceFEMDataSorter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4040B275235FBFF200843C83 /* CSurfaceFEMDataSorter.cpp */; };
 		4040B284235FBFF200843C83 /* CTecplotFileWriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4040B276235FBFF200843C83 /* CTecplotFileWriter.cpp */; };
 		4040B285235FBFF200843C83 /* CSU2MeshFileWriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4040B277235FBFF200843C83 /* CSU2MeshFileWriter.cpp */; };
+		405220B4246A626400D9AB4D /* CTurboVertex.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 405220AF246A626300D9AB4D /* CTurboVertex.cpp */; };
+		405220B5246A626400D9AB4D /* CVertex.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 405220B0246A626300D9AB4D /* CVertex.cpp */; };
+		405220B6246A626400D9AB4D /* CDualGrid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 405220B1246A626300D9AB4D /* CDualGrid.cpp */; };
+		405220B7246A626400D9AB4D /* CPoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 405220B2246A626400D9AB4D /* CPoint.cpp */; };
+		405220B8246A626400D9AB4D /* CEdge.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 405220B3246A626400D9AB4D /* CEdge.cpp */; };
+		405220BE246A628000D9AB4D /* CCGNSMeshReaderFVM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 405220B9246A628000D9AB4D /* CCGNSMeshReaderFVM.cpp */; };
+		405220BF246A628000D9AB4D /* CRectangularMeshReaderFVM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 405220BA246A628000D9AB4D /* CRectangularMeshReaderFVM.cpp */; };
+		405220C0246A628000D9AB4D /* CMeshReaderFVM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 405220BB246A628000D9AB4D /* CMeshReaderFVM.cpp */; };
+		405220C1246A628000D9AB4D /* CBoxMeshReaderFVM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 405220BC246A628000D9AB4D /* CBoxMeshReaderFVM.cpp */; };
+		405220C2246A628000D9AB4D /* CSU2ASCIIMeshReaderFVM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 405220BD246A628000D9AB4D /* CSU2ASCIIMeshReaderFVM.cpp */; };
+		405220CE246A629100D9AB4D /* CPyramid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 405220C3246A629000D9AB4D /* CPyramid.cpp */; };
+		405220CF246A629100D9AB4D /* CTriangle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 405220C4246A629100D9AB4D /* CTriangle.cpp */; };
+		405220D0246A629100D9AB4D /* CHexahedron.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 405220C5246A629100D9AB4D /* CHexahedron.cpp */; };
+		405220D1246A629100D9AB4D /* CPrimalGridFEM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 405220C6246A629100D9AB4D /* CPrimalGridFEM.cpp */; };
+		405220D2246A629100D9AB4D /* CVertexMPI.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 405220C7246A629100D9AB4D /* CVertexMPI.cpp */; };
+		405220D3246A629100D9AB4D /* CPrimalGrid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 405220C8246A629100D9AB4D /* CPrimalGrid.cpp */; };
+		405220D4246A629100D9AB4D /* CTetrahedron.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 405220C9246A629100D9AB4D /* CTetrahedron.cpp */; };
+		405220D5246A629100D9AB4D /* CPrism.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 405220CA246A629100D9AB4D /* CPrism.cpp */; };
+		405220D6246A629100D9AB4D /* CQuadrilateral.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 405220CB246A629100D9AB4D /* CQuadrilateral.cpp */; };
+		405220D7246A629100D9AB4D /* CPrimalGridBoundFEM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 405220CC246A629100D9AB4D /* CPrimalGridBoundFEM.cpp */; };
+		405220D8246A629100D9AB4D /* CLine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 405220CD246A629100D9AB4D /* CLine.cpp */; };
 		4063F8182469E40B00DE870E /* CMultiGridIntegration.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F8122469E40A00DE870E /* CMultiGridIntegration.cpp */; };
 		4063F8192469E40B00DE870E /* CSingleGridIntegration.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F8132469E40A00DE870E /* CSingleGridIntegration.cpp */; };
 		4063F81A2469E40B00DE870E /* CStructuralIntegration.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F8142469E40A00DE870E /* CStructuralIntegration.cpp */; };
@@ -157,7 +186,6 @@
 		E90B4FFD22DFDFE4000ED392 /* CDiscAdjFEAVariable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E90B4FEB22DFDFE2000ED392 /* CDiscAdjFEAVariable.cpp */; };
 		E90B4FFE22DFDFE4000ED392 /* CAdjEulerVariable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E90B4FEC22DFDFE3000ED392 /* CAdjEulerVariable.cpp */; };
 		E90B4FFF22DFDFE4000ED392 /* CIncNSVariable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E90B4FED22DFDFE3000ED392 /* CIncNSVariable.cpp */; };
-		E90B500022DFDFE4000ED392 /* CHeatFVMVariable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E90B4FEE22DFDFE3000ED392 /* CHeatFVMVariable.cpp */; };
 		E90B500122DFDFE4000ED392 /* CEulerVariable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E90B4FEF22DFDFE3000ED392 /* CEulerVariable.cpp */; };
 		E90B500222DFDFE4000ED392 /* CTurbSSTVariable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E90B4FF022DFDFE3000ED392 /* CTurbSSTVariable.cpp */; };
 		E90B500322DFDFE4000ED392 /* CBaselineVariable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E90B4FF122DFDFE3000ED392 /* CBaselineVariable.cpp */; };
@@ -186,7 +214,6 @@
 		E9C830852061E60E004417A9 /* geometry_structure_fem_part.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9C8307B2061E60E004417A9 /* geometry_structure_fem_part.cpp */; };
 		E9D6EE572316522800618E36 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		E9D6EE5A23165FD300618E36 /* CDummyDriver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9D6EE5923165FD300618E36 /* CDummyDriver.cpp */; };
-		E9D6EE5D2316653200618E36 /* CSU2ASCIIMeshReaderFVM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9D6EE5C2316653100618E36 /* CSU2ASCIIMeshReaderFVM.cpp */; };
 		E9D6EE672317B80600618E36 /* CMeshSolver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9D6EE652317B80500618E36 /* CMeshSolver.cpp */; };
 		E9D6EE682317B80600618E36 /* CDiscAdjMeshSolver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9D6EE662317B80600618E36 /* CDiscAdjMeshSolver.cpp */; };
 		E9D6EE722317B88F00618E36 /* CDiscAdjMeshBoundVariable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9D6EE6B2317B88F00618E36 /* CDiscAdjMeshBoundVariable.cpp */; };
@@ -195,13 +222,8 @@
 		E9D6EE772317B88F00618E36 /* CMeshBoundVariable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9D6EE702317B88F00618E36 /* CMeshBoundVariable.cpp */; };
 		E9D6EE782317B88F00618E36 /* CMeshVariable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9D6EE712317B88F00618E36 /* CMeshVariable.cpp */; };
 		E9D85B4C1C3F1B9E0077122F /* ad_structure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9D85B4B1C3F1B9E0077122F /* ad_structure.cpp */; };
-		E9D885A92303F8E400917362 /* CBoxMeshReaderFVM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9D885A82303F8E400917362 /* CBoxMeshReaderFVM.cpp */; };
-		E9D9CE861C62A1A7004119E9 /* interpolation_structure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9D9CE851C62A1A7004119E9 /* interpolation_structure.cpp */; };
 		E9E51AD622FA313900773E0C /* CLinearPartitioner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9E51AD522FA313800773E0C /* CLinearPartitioner.cpp */; };
-		E9E51AD922FA603800773E0C /* CMeshReaderFVM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9E51AD822FA603700773E0C /* CMeshReaderFVM.cpp */; };
-		E9E51ADD22FAB11800773E0C /* CCGNSMeshReaderFVM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9E51ADC22FAB11700773E0C /* CCGNSMeshReaderFVM.cpp */; };
 		E9E674342302A2E4009B6A25 /* CMultiGridQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9E674332302A2E3009B6A25 /* CMultiGridQueue.cpp */; };
-		E9E674372302A92C009B6A25 /* CRectangularMeshReaderFVM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9E674362302A92C009B6A25 /* CRectangularMeshReaderFVM.cpp */; };
 		E9FDF6EA1D2DD0560066E49C /* adt_structure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9FDF6E91D2DD0560066E49C /* adt_structure.cpp */; };
 		EB14FF9822F790500045FB27 /* CSinglezoneDriver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB14FF9422F790500045FB27 /* CSinglezoneDriver.cpp */; };
 		EB14FF9922F790500045FB27 /* CDiscAdjSinglezoneDriver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB14FF9522F790500045FB27 /* CDiscAdjSinglezoneDriver.cpp */; };
@@ -223,29 +245,15 @@
 
 /* Begin PBXFileReference section */
 		0541ABEE1370F5A6002D668B /* SU2_CFD */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = SU2_CFD; sourceTree = BUILT_PRODUCTS_DIR; };
-		05E6DA9F17EB603F00FA1F7E /* config_structure.inl */ = {isa = PBXFileReference; lastKnownFileType = text; lineEnding = 0; name = config_structure.inl; path = ../../Common/include/config_structure.inl; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DAA017EB603F00FA1F7E /* dual_grid_structure.inl */ = {isa = PBXFileReference; lastKnownFileType = text; lineEnding = 0; name = dual_grid_structure.inl; path = ../../Common/include/dual_grid_structure.inl; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		05E6DAA217EB603F00FA1F7E /* grid_adaptation_structure.inl */ = {isa = PBXFileReference; lastKnownFileType = text; lineEnding = 0; name = grid_adaptation_structure.inl; path = ../../Common/include/grid_adaptation_structure.inl; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		05E6DAA317EB603F00FA1F7E /* grid_movement_structure.inl */ = {isa = PBXFileReference; lastKnownFileType = text; lineEnding = 0; name = grid_movement_structure.inl; path = ../../Common/include/grid_movement_structure.inl; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DAA617EB603F00FA1F7E /* primal_grid_structure.inl */ = {isa = PBXFileReference; lastKnownFileType = text; lineEnding = 0; name = primal_grid_structure.inl; path = ../../Common/include/primal_grid_structure.inl; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DAC517EB608000FA1F7E /* config_structure.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; lineEnding = 0; name = config_structure.hpp; path = ../../Common/include/config_structure.hpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		05E6DAC817EB608000FA1F7E /* grid_adaptation_structure.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; lineEnding = 0; name = grid_adaptation_structure.hpp; path = ../../Common/include/grid_adaptation_structure.hpp; sourceTree = "<group>"; };
 		05E6DAC917EB608000FA1F7E /* grid_movement_structure.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; lineEnding = 0; name = grid_movement_structure.hpp; path = ../../Common/include/grid_movement_structure.hpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		05E6DACC17EB608000FA1F7E /* option_structure.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; lineEnding = 0; name = option_structure.hpp; path = ../../Common/include/option_structure.hpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DACD17EB608000FA1F7E /* primal_grid_structure.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; lineEnding = 0; name = primal_grid_structure.hpp; path = ../../Common/include/primal_grid_structure.hpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DB8917EB61E600FA1F7E /* config_structure.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = config_structure.cpp; path = ../../Common/src/config_structure.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DB8A17EB61E600FA1F7E /* dual_grid_structure.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = dual_grid_structure.cpp; path = ../../Common/src/dual_grid_structure.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		05E6DB8C17EB61E600FA1F7E /* grid_adaptation_structure.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = grid_adaptation_structure.cpp; path = ../../Common/src/grid_adaptation_structure.cpp; sourceTree = "<group>"; };
 		05E6DB8D17EB61E600FA1F7E /* grid_movement_structure.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = grid_movement_structure.cpp; path = ../../Common/src/grid_movement_structure.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DB9017EB61E600FA1F7E /* primal_grid_structure.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = primal_grid_structure.cpp; path = ../../Common/src/primal_grid_structure.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DBB017EB624700FA1F7E /* integration_structure.inl */ = {isa = PBXFileReference; lastKnownFileType = text; lineEnding = 0; name = integration_structure.inl; path = ../../SU2_CFD/include/integration_structure.inl; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DBB117EB624700FA1F7E /* numerics_structure.inl */ = {isa = PBXFileReference; lastKnownFileType = text; lineEnding = 0; name = numerics_structure.inl; path = ../../SU2_CFD/include/numerics_structure.inl; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DBB217EB624700FA1F7E /* solver_structure.inl */ = {isa = PBXFileReference; lastKnownFileType = text; lineEnding = 0; name = solver_structure.inl; path = ../../SU2_CFD/include/solver_structure.inl; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		05E6DBB417EB627400FA1F7E /* definition_structure.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; lineEnding = 0; name = definition_structure.hpp; path = ../../SU2_CFD/include/definition_structure.hpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DBB517EB627400FA1F7E /* integration_structure.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; lineEnding = 0; name = integration_structure.hpp; path = ../../SU2_CFD/include/integration_structure.hpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		05E6DBB617EB627400FA1F7E /* iteration_structure.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; lineEnding = 0; name = iteration_structure.hpp; path = ../../SU2_CFD/include/iteration_structure.hpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DBB717EB627400FA1F7E /* numerics_structure.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; lineEnding = 0; name = numerics_structure.hpp; path = ../../SU2_CFD/include/numerics_structure.hpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DBB917EB627400FA1F7E /* solver_structure.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; lineEnding = 0; name = solver_structure.hpp; path = ../../SU2_CFD/include/solver_structure.hpp; sourceTree = "<group>"; };
 		05E6DBBA17EB627400FA1F7E /* SU2_CFD.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; lineEnding = 0; name = SU2_CFD.hpp; path = ../../SU2_CFD/include/SU2_CFD.hpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		05E6DBBC17EB62A000FA1F7E /* definition_structure.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = definition_structure.cpp; path = ../../SU2_CFD/src/definition_structure.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		05E6DBC017EB62A100FA1F7E /* iteration_structure.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = iteration_structure.cpp; path = ../../SU2_CFD/src/iteration_structure.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
@@ -308,6 +316,138 @@
 		40303E5E246A064900CD7789 /* CHeatVariable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CHeatVariable.cpp; path = ../../SU2_CFD/src/variables/CHeatVariable.cpp; sourceTree = "<group>"; };
 		40303E5F246A064900CD7789 /* CRadP1Variable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CRadP1Variable.cpp; path = ../../SU2_CFD/src/variables/CRadP1Variable.cpp; sourceTree = "<group>"; };
 		40303E60246A064900CD7789 /* CRadVariable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CRadVariable.cpp; path = ../../SU2_CFD/src/variables/CRadVariable.cpp; sourceTree = "<group>"; };
+		40303E65246A079A00CD7789 /* computeGradientsGreenGauss.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = computeGradientsGreenGauss.hpp; path = ../../SU2_CFD/include/gradients/computeGradientsGreenGauss.hpp; sourceTree = "<group>"; };
+		40303E66246A079A00CD7789 /* computeGradientsLeastSquares.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = computeGradientsLeastSquares.hpp; path = ../../SU2_CFD/include/gradients/computeGradientsLeastSquares.hpp; sourceTree = "<group>"; };
+		40303E68246A07D300CD7789 /* CIntegrationFactory.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CIntegrationFactory.hpp; path = ../../SU2_CFD/include/integration/CIntegrationFactory.hpp; sourceTree = "<group>"; };
+		40303E69246A07D300CD7789 /* CMultiGridIntegration.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CMultiGridIntegration.hpp; path = ../../SU2_CFD/include/integration/CMultiGridIntegration.hpp; sourceTree = "<group>"; };
+		40303E6A246A07D300CD7789 /* CSingleGridIntegration.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CSingleGridIntegration.hpp; path = ../../SU2_CFD/include/integration/CSingleGridIntegration.hpp; sourceTree = "<group>"; };
+		40303E6B246A07D300CD7789 /* CStructuralIntegration.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CStructuralIntegration.hpp; path = ../../SU2_CFD/include/integration/CStructuralIntegration.hpp; sourceTree = "<group>"; };
+		40303E6C246A07D300CD7789 /* CIntegration.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CIntegration.hpp; path = ../../SU2_CFD/include/integration/CIntegration.hpp; sourceTree = "<group>"; };
+		40303E6D246A07D300CD7789 /* CFEM_DG_Integration.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CFEM_DG_Integration.hpp; path = ../../SU2_CFD/include/integration/CFEM_DG_Integration.hpp; sourceTree = "<group>"; };
+		40303E6E246A580700CD7789 /* CLimiterDetails.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CLimiterDetails.hpp; path = ../../SU2_CFD/include/limiters/CLimiterDetails.hpp; sourceTree = "<group>"; };
+		40303E6F246A580700CD7789 /* computeLimiters_impl.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = computeLimiters_impl.hpp; path = ../../SU2_CFD/include/limiters/computeLimiters_impl.hpp; sourceTree = "<group>"; };
+		40303E70246A580700CD7789 /* computeLimiters.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = computeLimiters.hpp; path = ../../SU2_CFD/include/limiters/computeLimiters.hpp; sourceTree = "<group>"; };
+		40303E76246A589B00CD7789 /* heat.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = heat.hpp; path = ../../SU2_CFD/include/numerics/heat.hpp; sourceTree = "<group>"; };
+		40303E77246A589B00CD7789 /* fds.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = fds.hpp; path = ../../SU2_CFD/include/numerics/flow/convection/fds.hpp; sourceTree = "<group>"; };
+		40303E78246A589B00CD7789 /* hllc.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = hllc.hpp; path = ../../SU2_CFD/include/numerics/flow/convection/hllc.hpp; sourceTree = "<group>"; };
+		40303E79246A589B00CD7789 /* roe.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = roe.hpp; path = ../../SU2_CFD/include/numerics/flow/convection/roe.hpp; sourceTree = "<group>"; };
+		40303E7A246A589B00CD7789 /* template.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = template.hpp; path = ../../SU2_CFD/include/numerics/template.hpp; sourceTree = "<group>"; };
+		40303E7B246A589B00CD7789 /* turb_sources.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = turb_sources.hpp; path = ../../SU2_CFD/include/numerics/turbulent/turb_sources.hpp; sourceTree = "<group>"; };
+		40303E7C246A589B00CD7789 /* adj_sources.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = adj_sources.hpp; path = ../../SU2_CFD/include/numerics/continuous_adjoint/adj_sources.hpp; sourceTree = "<group>"; };
+		40303E7D246A589B00CD7789 /* nonlinear_models.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = nonlinear_models.hpp; path = ../../SU2_CFD/include/numerics/elasticity/nonlinear_models.hpp; sourceTree = "<group>"; };
+		40303E7E246A589B00CD7789 /* turb_convection.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = turb_convection.hpp; path = ../../SU2_CFD/include/numerics/turbulent/turb_convection.hpp; sourceTree = "<group>"; };
+		40303E7F246A589C00CD7789 /* centered.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = centered.hpp; path = ../../SU2_CFD/include/numerics/flow/convection/centered.hpp; sourceTree = "<group>"; };
+		40303E80246A589C00CD7789 /* adj_diffusion.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = adj_diffusion.hpp; path = ../../SU2_CFD/include/numerics/continuous_adjoint/adj_diffusion.hpp; sourceTree = "<group>"; };
+		40303E81246A589C00CD7789 /* transition.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = transition.hpp; path = ../../SU2_CFD/include/numerics/transition.hpp; sourceTree = "<group>"; };
+		40303E82246A589C00CD7789 /* CNumerics.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CNumerics.hpp; path = ../../SU2_CFD/include/numerics/CNumerics.hpp; sourceTree = "<group>"; };
+		40303E83246A589C00CD7789 /* flow_diffusion.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = flow_diffusion.hpp; path = ../../SU2_CFD/include/numerics/flow/flow_diffusion.hpp; sourceTree = "<group>"; };
+		40303E84246A589C00CD7789 /* cusp.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = cusp.hpp; path = ../../SU2_CFD/include/numerics/flow/convection/cusp.hpp; sourceTree = "<group>"; };
+		40303E85246A589C00CD7789 /* radiation.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = radiation.hpp; path = ../../SU2_CFD/include/numerics/radiation.hpp; sourceTree = "<group>"; };
+		40303E86246A589C00CD7789 /* flow_sources.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = flow_sources.hpp; path = ../../SU2_CFD/include/numerics/flow/flow_sources.hpp; sourceTree = "<group>"; };
+		40303E87246A589C00CD7789 /* CFEANonlinearElasticity.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CFEANonlinearElasticity.hpp; path = ../../SU2_CFD/include/numerics/elasticity/CFEANonlinearElasticity.hpp; sourceTree = "<group>"; };
+		40303E88246A589C00CD7789 /* CFEALinearElasticity.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CFEALinearElasticity.hpp; path = ../../SU2_CFD/include/numerics/elasticity/CFEALinearElasticity.hpp; sourceTree = "<group>"; };
+		40303E89246A589C00CD7789 /* turb_diffusion.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = turb_diffusion.hpp; path = ../../SU2_CFD/include/numerics/turbulent/turb_diffusion.hpp; sourceTree = "<group>"; };
+		40303E8A246A589C00CD7789 /* CFEAElasticity.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CFEAElasticity.hpp; path = ../../SU2_CFD/include/numerics/elasticity/CFEAElasticity.hpp; sourceTree = "<group>"; };
+		40303E8B246A589C00CD7789 /* adj_convection.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = adj_convection.hpp; path = ../../SU2_CFD/include/numerics/continuous_adjoint/adj_convection.hpp; sourceTree = "<group>"; };
+		40303E8C246A589C00CD7789 /* ausm_slau.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = ausm_slau.hpp; path = ../../SU2_CFD/include/numerics/flow/convection/ausm_slau.hpp; sourceTree = "<group>"; };
+		40303E8D246A589C00CD7789 /* fvs.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = fvs.hpp; path = ../../SU2_CFD/include/numerics/flow/convection/fvs.hpp; sourceTree = "<group>"; };
+		40303E8E246A5A4900CD7789 /* CParaviewVTMFileWriter.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = CParaviewVTMFileWriter.hpp; sourceTree = "<group>"; };
+		40303E8F246A5A4900CD7789 /* CSTLFileWriter.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = CSTLFileWriter.hpp; sourceTree = "<group>"; };
+		40303E90246A5A4900CD7789 /* COutputFactory.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = COutputFactory.hpp; path = ../../SU2_CFD/include/output/COutputFactory.hpp; sourceTree = "<group>"; };
+		40303E91246A5A4900CD7789 /* CParaviewXMLFileWriter.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = CParaviewXMLFileWriter.hpp; sourceTree = "<group>"; };
+		40303E92246A5A4900CD7789 /* CWindowingTools.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CWindowingTools.hpp; path = ../../SU2_CFD/include/output/tools/CWindowingTools.hpp; sourceTree = "<group>"; };
+		40303E94246A5BA700CD7789 /* CTurbSSTSolver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CTurbSSTSolver.hpp; path = ../../SU2_CFD/include/solvers/CTurbSSTSolver.hpp; sourceTree = "<group>"; };
+		40303E95246A5BA700CD7789 /* CDiscAdjSolver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CDiscAdjSolver.hpp; path = ../../SU2_CFD/include/solvers/CDiscAdjSolver.hpp; sourceTree = "<group>"; };
+		40303E96246A5BA700CD7789 /* CRadP1Solver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CRadP1Solver.hpp; path = ../../SU2_CFD/include/solvers/CRadP1Solver.hpp; sourceTree = "<group>"; };
+		40303E97246A5BA700CD7789 /* CSolverFactory.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CSolverFactory.hpp; path = ../../SU2_CFD/include/solvers/CSolverFactory.hpp; sourceTree = "<group>"; };
+		40303E98246A5BA700CD7789 /* CTransLMSolver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CTransLMSolver.hpp; path = ../../SU2_CFD/include/solvers/CTransLMSolver.hpp; sourceTree = "<group>"; };
+		40303E99246A5BA700CD7789 /* CBaselineSolver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CBaselineSolver.hpp; path = ../../SU2_CFD/include/solvers/CBaselineSolver.hpp; sourceTree = "<group>"; };
+		40303E9A246A5BA700CD7789 /* CTurbSASolver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CTurbSASolver.hpp; path = ../../SU2_CFD/include/solvers/CTurbSASolver.hpp; sourceTree = "<group>"; };
+		40303E9B246A5BA700CD7789 /* CEulerSolver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CEulerSolver.hpp; path = ../../SU2_CFD/include/solvers/CEulerSolver.hpp; sourceTree = "<group>"; };
+		40303E9C246A5BA700CD7789 /* CFEM_DG_NSSolver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CFEM_DG_NSSolver.hpp; path = ../../SU2_CFD/include/solvers/CFEM_DG_NSSolver.hpp; sourceTree = "<group>"; };
+		40303E9D246A5BA700CD7789 /* CAdjEulerSolver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CAdjEulerSolver.hpp; path = ../../SU2_CFD/include/solvers/CAdjEulerSolver.hpp; sourceTree = "<group>"; };
+		40303E9E246A5BA700CD7789 /* CFEASolver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CFEASolver.hpp; path = ../../SU2_CFD/include/solvers/CFEASolver.hpp; sourceTree = "<group>"; };
+		40303E9F246A5BA700CD7789 /* CHeatSolver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CHeatSolver.hpp; path = ../../SU2_CFD/include/solvers/CHeatSolver.hpp; sourceTree = "<group>"; };
+		40303EA0246A5BA700CD7789 /* CSolver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CSolver.hpp; path = ../../SU2_CFD/include/solvers/CSolver.hpp; sourceTree = "<group>"; };
+		40303EA1246A5BA700CD7789 /* CRadSolver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CRadSolver.hpp; path = ../../SU2_CFD/include/solvers/CRadSolver.hpp; sourceTree = "<group>"; };
+		40303EA2246A5BA700CD7789 /* CFEM_DG_EulerSolver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CFEM_DG_EulerSolver.hpp; path = ../../SU2_CFD/include/solvers/CFEM_DG_EulerSolver.hpp; sourceTree = "<group>"; };
+		40303EA3246A5BA700CD7789 /* CBaselineSolver_FEM.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CBaselineSolver_FEM.hpp; path = ../../SU2_CFD/include/solvers/CBaselineSolver_FEM.hpp; sourceTree = "<group>"; };
+		40303EA4246A5BA700CD7789 /* CTurbSolver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CTurbSolver.hpp; path = ../../SU2_CFD/include/solvers/CTurbSolver.hpp; sourceTree = "<group>"; };
+		40303EA5246A5BA700CD7789 /* CAdjTurbSolver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CAdjTurbSolver.hpp; path = ../../SU2_CFD/include/solvers/CAdjTurbSolver.hpp; sourceTree = "<group>"; };
+		40303EA6246A5BA700CD7789 /* CIncEulerSolver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CIncEulerSolver.hpp; path = ../../SU2_CFD/include/solvers/CIncEulerSolver.hpp; sourceTree = "<group>"; };
+		40303EA7246A5BA700CD7789 /* CAdjNSSolver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CAdjNSSolver.hpp; path = ../../SU2_CFD/include/solvers/CAdjNSSolver.hpp; sourceTree = "<group>"; };
+		40303EA8246A5BA700CD7789 /* CIncNSSolver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CIncNSSolver.hpp; path = ../../SU2_CFD/include/solvers/CIncNSSolver.hpp; sourceTree = "<group>"; };
+		40303EA9246A5BA700CD7789 /* CDiscAdjFEASolver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CDiscAdjFEASolver.hpp; path = ../../SU2_CFD/include/solvers/CDiscAdjFEASolver.hpp; sourceTree = "<group>"; };
+		40303EAA246A5BA700CD7789 /* CTemplateSolver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CTemplateSolver.hpp; path = ../../SU2_CFD/include/solvers/CTemplateSolver.hpp; sourceTree = "<group>"; };
+		40303EAB246A5BA700CD7789 /* CNSSolver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CNSSolver.hpp; path = ../../SU2_CFD/include/solvers/CNSSolver.hpp; sourceTree = "<group>"; };
+		40303EAC246A5BFC00CD7789 /* CRadP1Variable.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CRadP1Variable.hpp; path = ../../SU2_CFD/include/variables/CRadP1Variable.hpp; sourceTree = "<group>"; };
+		40303EAD246A5BFC00CD7789 /* CRadVariable.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CRadVariable.hpp; path = ../../SU2_CFD/include/variables/CRadVariable.hpp; sourceTree = "<group>"; };
+		40303EAE246A5BFC00CD7789 /* CHeatVariable.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CHeatVariable.hpp; path = ../../SU2_CFD/include/variables/CHeatVariable.hpp; sourceTree = "<group>"; };
+		40303EAF246A5CC000CD7789 /* CConfig.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CConfig.cpp; path = ../../Common/src/CConfig.cpp; sourceTree = "<group>"; };
+		40303EB1246A5CEC00CD7789 /* CMMSNSTwoHalfCirclesSolution.mw */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = CMMSNSTwoHalfCirclesSolution.mw; path = ../../Common/src/toolboxes/MMS/CreateMMSSourceTerms/CMMSNSTwoHalfCirclesSolution.mw; sourceTree = "<group>"; };
+		40303EB2246A5CEC00CD7789 /* CMMSNSTwoHalfSpheresSolution.mw */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = CMMSNSTwoHalfSpheresSolution.mw; path = ../../Common/src/toolboxes/MMS/CreateMMSSourceTerms/CMMSNSTwoHalfSpheresSolution.mw; sourceTree = "<group>"; };
+		40303EB3246A5CEC00CD7789 /* CMMSIncEulerSolution.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; name = CMMSIncEulerSolution.py; path = ../../Common/src/toolboxes/MMS/CreateMMSSourceTerms/CMMSIncEulerSolution.py; sourceTree = "<group>"; };
+		40303EB4246A5CEC00CD7789 /* CMMSNSUnitQuadSolution.mw */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = CMMSNSUnitQuadSolution.mw; path = ../../Common/src/toolboxes/MMS/CreateMMSSourceTerms/CMMSNSUnitQuadSolution.mw; sourceTree = "<group>"; };
+		40303EB5246A5CEC00CD7789 /* CMMSIncNSSolution.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; name = CMMSIncNSSolution.py; path = ../../Common/src/toolboxes/MMS/CreateMMSSourceTerms/CMMSIncNSSolution.py; sourceTree = "<group>"; };
+		40303EB6246A5CEC00CD7789 /* CMMSNSUnitQuadSolutionWallBC.mw */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = CMMSNSUnitQuadSolutionWallBC.mw; path = ../../Common/src/toolboxes/MMS/CreateMMSSourceTerms/CMMSNSUnitQuadSolutionWallBC.mw; sourceTree = "<group>"; };
+		40303EB7246A5D2700CD7789 /* C1DInterpolation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = C1DInterpolation.cpp; path = ../../Common/src/toolboxes/C1DInterpolation.cpp; sourceTree = "<group>"; };
+		40303EB8246A5D2700CD7789 /* CSymmetricMatrix.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CSymmetricMatrix.cpp; path = ../../Common/src/toolboxes/CSymmetricMatrix.cpp; sourceTree = "<group>"; };
+		40303EBB246A5D4800CD7789 /* CPastixWrapper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CPastixWrapper.cpp; path = ../../Common/src/linear_algebra/CPastixWrapper.cpp; sourceTree = "<group>"; };
+		40303EBE246A5D9200CD7789 /* CInterpolator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CInterpolator.cpp; path = ../../Common/src/interface_interpolation/CInterpolator.cpp; sourceTree = "<group>"; };
+		40303EBF246A5D9200CD7789 /* CNearestNeighbor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CNearestNeighbor.cpp; path = ../../Common/src/interface_interpolation/CNearestNeighbor.cpp; sourceTree = "<group>"; };
+		40303EC0246A5D9300CD7789 /* CMirror.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CMirror.cpp; path = ../../Common/src/interface_interpolation/CMirror.cpp; sourceTree = "<group>"; };
+		40303EC1246A5D9300CD7789 /* CIsoparametric.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CIsoparametric.cpp; path = ../../Common/src/interface_interpolation/CIsoparametric.cpp; sourceTree = "<group>"; };
+		40303EC2246A5D9300CD7789 /* CSlidingMesh.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CSlidingMesh.cpp; path = ../../Common/src/interface_interpolation/CSlidingMesh.cpp; sourceTree = "<group>"; };
+		40303EC3246A5D9300CD7789 /* CRadialBasisFunction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CRadialBasisFunction.cpp; path = ../../Common/src/interface_interpolation/CRadialBasisFunction.cpp; sourceTree = "<group>"; };
+		40303EC4246A5D9300CD7789 /* CInterpolatorFactory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CInterpolatorFactory.cpp; path = ../../Common/src/interface_interpolation/CInterpolatorFactory.cpp; sourceTree = "<group>"; };
+		40303ECC246A5DBF00CD7789 /* omp_structure.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = omp_structure.hpp; path = ../../Common/include/omp_structure.hpp; sourceTree = "<group>"; };
+		40303ECD246A5DBF00CD7789 /* CConfig.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CConfig.hpp; path = ../../Common/include/CConfig.hpp; sourceTree = "<group>"; };
+		40303ECE246A5DBF00CD7789 /* option_structure.inl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = option_structure.inl; path = ../../Common/include/option_structure.inl; sourceTree = "<group>"; };
+		40303ECF246A5DBF00CD7789 /* geometry_structure_fem_part.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = geometry_structure_fem_part.hpp; path = ../../Common/include/geometry_structure_fem_part.hpp; sourceTree = "<group>"; };
+		40303ED1246A5E5500CD7789 /* CNearestNeighbor.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CNearestNeighbor.hpp; path = ../../Common/include/interface_interpolation/CNearestNeighbor.hpp; sourceTree = "<group>"; };
+		40303ED2246A5E5500CD7789 /* CInterpolator.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CInterpolator.hpp; path = ../../Common/include/interface_interpolation/CInterpolator.hpp; sourceTree = "<group>"; };
+		40303ED3246A5E5500CD7789 /* CRadialBasisFunction.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CRadialBasisFunction.hpp; path = ../../Common/include/interface_interpolation/CRadialBasisFunction.hpp; sourceTree = "<group>"; };
+		40303ED4246A5E5500CD7789 /* CIsoparametric.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CIsoparametric.hpp; path = ../../Common/include/interface_interpolation/CIsoparametric.hpp; sourceTree = "<group>"; };
+		40303ED5246A5E5500CD7789 /* CMirror.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CMirror.hpp; path = ../../Common/include/interface_interpolation/CMirror.hpp; sourceTree = "<group>"; };
+		40303ED6246A5E5500CD7789 /* CSlidingMesh.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CSlidingMesh.hpp; path = ../../Common/include/interface_interpolation/CSlidingMesh.hpp; sourceTree = "<group>"; };
+		40303ED7246A5E5500CD7789 /* CInterpolatorFactory.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CInterpolatorFactory.hpp; path = ../../Common/include/interface_interpolation/CInterpolatorFactory.hpp; sourceTree = "<group>"; };
+		40303ED8246A5E6400CD7789 /* CPastixWrapper.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CPastixWrapper.hpp; path = ../../Common/include/linear_algebra/CPastixWrapper.hpp; sourceTree = "<group>"; };
+		40303EDB246A5F6700CD7789 /* geometry_toolbox.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = geometry_toolbox.hpp; path = ../../Common/include/toolboxes/geometry_toolbox.hpp; sourceTree = "<group>"; };
+		40303EDC246A5F6700CD7789 /* graph_toolbox.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = graph_toolbox.hpp; path = ../../Common/include/toolboxes/graph_toolbox.hpp; sourceTree = "<group>"; };
+		40303EEB246A5F6700CD7789 /* CFastFindAndEraseQueue.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CFastFindAndEraseQueue.hpp; path = ../../Common/include/toolboxes/CFastFindAndEraseQueue.hpp; sourceTree = "<group>"; };
+		40303EEC246A5F6800CD7789 /* CSymmetricMatrix.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CSymmetricMatrix.hpp; path = ../../Common/include/toolboxes/CSymmetricMatrix.hpp; sourceTree = "<group>"; };
+		40303EED246A5F6800CD7789 /* C1DInterpolation.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = C1DInterpolation.hpp; path = ../../Common/include/toolboxes/C1DInterpolation.hpp; sourceTree = "<group>"; };
+		40303EEE246A5F6800CD7789 /* CVertexMap.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CVertexMap.hpp; path = ../../Common/include/toolboxes/CVertexMap.hpp; sourceTree = "<group>"; };
+		40303EEF246A5F6800CD7789 /* C2DContainer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = C2DContainer.hpp; path = ../../Common/include/toolboxes/C2DContainer.hpp; sourceTree = "<group>"; };
+		40303EF0246A5F6800CD7789 /* allocation_toolbox.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = allocation_toolbox.hpp; path = ../../Common/include/toolboxes/allocation_toolbox.hpp; sourceTree = "<group>"; };
+		40303EF1246A5FF400CD7789 /* CMultiGridGeometry.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CMultiGridGeometry.hpp; path = ../../Common/include/geometry/CMultiGridGeometry.hpp; sourceTree = "<group>"; };
+		40303EF2246A5FF400CD7789 /* CGeometry.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CGeometry.hpp; path = ../../Common/include/geometry/CGeometry.hpp; sourceTree = "<group>"; };
+		40303EF3246A5FF400CD7789 /* CPhysicalGeometry.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CPhysicalGeometry.hpp; path = ../../Common/include/geometry/CPhysicalGeometry.hpp; sourceTree = "<group>"; };
+		40303EF4246A5FF400CD7789 /* CDummyGeometry.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CDummyGeometry.hpp; path = ../../Common/include/geometry/CDummyGeometry.hpp; sourceTree = "<group>"; };
+		40303EFA246A609B00CD7789 /* CVertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CVertex.hpp; path = ../../Common/include/geometry/dual_grid/CVertex.hpp; sourceTree = "<group>"; };
+		40303EFB246A609B00CD7789 /* CTurboVertex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CTurboVertex.hpp; path = ../../Common/include/geometry/dual_grid/CTurboVertex.hpp; sourceTree = "<group>"; };
+		40303EFC246A609B00CD7789 /* CPoint.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CPoint.hpp; path = ../../Common/include/geometry/dual_grid/CPoint.hpp; sourceTree = "<group>"; };
+		40303EFD246A609B00CD7789 /* CEdge.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CEdge.hpp; path = ../../Common/include/geometry/dual_grid/CEdge.hpp; sourceTree = "<group>"; };
+		40303EFE246A609B00CD7789 /* CDualGrid.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CDualGrid.hpp; path = ../../Common/include/geometry/dual_grid/CDualGrid.hpp; sourceTree = "<group>"; };
+		40303EFF246A60A900CD7789 /* CElementProperty.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CElementProperty.hpp; path = ../../Common/include/geometry/elements/CElementProperty.hpp; sourceTree = "<group>"; };
+		40303F00246A60A900CD7789 /* CElement.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CElement.hpp; path = ../../Common/include/geometry/elements/CElement.hpp; sourceTree = "<group>"; };
+		40303F01246A60A900CD7789 /* CGaussVariable.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CGaussVariable.hpp; path = ../../Common/include/geometry/elements/CGaussVariable.hpp; sourceTree = "<group>"; };
+		40303F02246A60B700CD7789 /* CMeshReaderFVM.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CMeshReaderFVM.hpp; path = ../../Common/include/geometry/meshreader/CMeshReaderFVM.hpp; sourceTree = "<group>"; };
+		40303F03246A60B700CD7789 /* CCGNSMeshReaderFVM.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CCGNSMeshReaderFVM.hpp; path = ../../Common/include/geometry/meshreader/CCGNSMeshReaderFVM.hpp; sourceTree = "<group>"; };
+		40303F04246A60B700CD7789 /* CSU2ASCIIMeshReaderFVM.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CSU2ASCIIMeshReaderFVM.hpp; path = ../../Common/include/geometry/meshreader/CSU2ASCIIMeshReaderFVM.hpp; sourceTree = "<group>"; };
+		40303F05246A60B700CD7789 /* CBoxMeshReaderFVM.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CBoxMeshReaderFVM.hpp; path = ../../Common/include/geometry/meshreader/CBoxMeshReaderFVM.hpp; sourceTree = "<group>"; };
+		40303F06246A60B700CD7789 /* CRectangularMeshReaderFVM.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CRectangularMeshReaderFVM.hpp; path = ../../Common/include/geometry/meshreader/CRectangularMeshReaderFVM.hpp; sourceTree = "<group>"; };
+		40303F07246A60C300CD7789 /* CLine.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CLine.hpp; path = ../../Common/include/geometry/primal_grid/CLine.hpp; sourceTree = "<group>"; };
+		40303F08246A60C300CD7789 /* CTetrahedron.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CTetrahedron.hpp; path = ../../Common/include/geometry/primal_grid/CTetrahedron.hpp; sourceTree = "<group>"; };
+		40303F09246A60C300CD7789 /* CTriangle.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CTriangle.hpp; path = ../../Common/include/geometry/primal_grid/CTriangle.hpp; sourceTree = "<group>"; };
+		40303F0A246A60C300CD7789 /* CQuadrilateral.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CQuadrilateral.hpp; path = ../../Common/include/geometry/primal_grid/CQuadrilateral.hpp; sourceTree = "<group>"; };
+		40303F0B246A60C300CD7789 /* CPrimalGrid.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CPrimalGrid.hpp; path = ../../Common/include/geometry/primal_grid/CPrimalGrid.hpp; sourceTree = "<group>"; };
+		40303F0C246A60C300CD7789 /* CPrimalGridBoundFEM.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CPrimalGridBoundFEM.hpp; path = ../../Common/include/geometry/primal_grid/CPrimalGridBoundFEM.hpp; sourceTree = "<group>"; };
+		40303F0D246A60C300CD7789 /* CPrimalGridFEM.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CPrimalGridFEM.hpp; path = ../../Common/include/geometry/primal_grid/CPrimalGridFEM.hpp; sourceTree = "<group>"; };
+		40303F0E246A60C300CD7789 /* CVertexMPI.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CVertexMPI.hpp; path = ../../Common/include/geometry/primal_grid/CVertexMPI.hpp; sourceTree = "<group>"; };
+		40303F0F246A60C300CD7789 /* CHexahedron.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CHexahedron.hpp; path = ../../Common/include/geometry/primal_grid/CHexahedron.hpp; sourceTree = "<group>"; };
+		40303F10246A60C300CD7789 /* CPrism.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CPrism.hpp; path = ../../Common/include/geometry/primal_grid/CPrism.hpp; sourceTree = "<group>"; };
+		40303F11246A60C300CD7789 /* CPyramid.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CPyramid.hpp; path = ../../Common/include/geometry/primal_grid/CPyramid.hpp; sourceTree = "<group>"; };
 		403426B2235F83B1005B5215 /* CAdjFlowIncOutput.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CAdjFlowIncOutput.cpp; path = ../../SU2_CFD/src/output/CAdjFlowIncOutput.cpp; sourceTree = "<group>"; };
 		403426B3235F83B1005B5215 /* CFlowOutput.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CFlowOutput.cpp; path = ../../SU2_CFD/src/output/CFlowOutput.cpp; sourceTree = "<group>"; };
 		403426B4235F83B1005B5215 /* CFlowIncOutput.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CFlowIncOutput.cpp; path = ../../SU2_CFD/src/output/CFlowIncOutput.cpp; sourceTree = "<group>"; };
@@ -388,6 +528,27 @@
 		4040B292235FC03700843C83 /* CFileWriter.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = CFileWriter.hpp; sourceTree = "<group>"; };
 		4040B293235FC03700843C83 /* CCSVFileWriter.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = CCSVFileWriter.hpp; sourceTree = "<group>"; };
 		4040B294235FC03700843C83 /* CSurfaceFVMDataSorter.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = CSurfaceFVMDataSorter.hpp; sourceTree = "<group>"; };
+		405220AF246A626300D9AB4D /* CTurboVertex.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CTurboVertex.cpp; path = ../../Common/src/geometry/dual_grid/CTurboVertex.cpp; sourceTree = "<group>"; };
+		405220B0246A626300D9AB4D /* CVertex.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CVertex.cpp; path = ../../Common/src/geometry/dual_grid/CVertex.cpp; sourceTree = "<group>"; };
+		405220B1246A626300D9AB4D /* CDualGrid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CDualGrid.cpp; path = ../../Common/src/geometry/dual_grid/CDualGrid.cpp; sourceTree = "<group>"; };
+		405220B2246A626400D9AB4D /* CPoint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CPoint.cpp; path = ../../Common/src/geometry/dual_grid/CPoint.cpp; sourceTree = "<group>"; };
+		405220B3246A626400D9AB4D /* CEdge.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CEdge.cpp; path = ../../Common/src/geometry/dual_grid/CEdge.cpp; sourceTree = "<group>"; };
+		405220B9246A628000D9AB4D /* CCGNSMeshReaderFVM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CCGNSMeshReaderFVM.cpp; path = ../../Common/src/geometry/meshreader/CCGNSMeshReaderFVM.cpp; sourceTree = "<group>"; };
+		405220BA246A628000D9AB4D /* CRectangularMeshReaderFVM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CRectangularMeshReaderFVM.cpp; path = ../../Common/src/geometry/meshreader/CRectangularMeshReaderFVM.cpp; sourceTree = "<group>"; };
+		405220BB246A628000D9AB4D /* CMeshReaderFVM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CMeshReaderFVM.cpp; path = ../../Common/src/geometry/meshreader/CMeshReaderFVM.cpp; sourceTree = "<group>"; };
+		405220BC246A628000D9AB4D /* CBoxMeshReaderFVM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CBoxMeshReaderFVM.cpp; path = ../../Common/src/geometry/meshreader/CBoxMeshReaderFVM.cpp; sourceTree = "<group>"; };
+		405220BD246A628000D9AB4D /* CSU2ASCIIMeshReaderFVM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CSU2ASCIIMeshReaderFVM.cpp; path = ../../Common/src/geometry/meshreader/CSU2ASCIIMeshReaderFVM.cpp; sourceTree = "<group>"; };
+		405220C3246A629000D9AB4D /* CPyramid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CPyramid.cpp; path = ../../Common/src/geometry/primal_grid/CPyramid.cpp; sourceTree = "<group>"; };
+		405220C4246A629100D9AB4D /* CTriangle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CTriangle.cpp; path = ../../Common/src/geometry/primal_grid/CTriangle.cpp; sourceTree = "<group>"; };
+		405220C5246A629100D9AB4D /* CHexahedron.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CHexahedron.cpp; path = ../../Common/src/geometry/primal_grid/CHexahedron.cpp; sourceTree = "<group>"; };
+		405220C6246A629100D9AB4D /* CPrimalGridFEM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CPrimalGridFEM.cpp; path = ../../Common/src/geometry/primal_grid/CPrimalGridFEM.cpp; sourceTree = "<group>"; };
+		405220C7246A629100D9AB4D /* CVertexMPI.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CVertexMPI.cpp; path = ../../Common/src/geometry/primal_grid/CVertexMPI.cpp; sourceTree = "<group>"; };
+		405220C8246A629100D9AB4D /* CPrimalGrid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CPrimalGrid.cpp; path = ../../Common/src/geometry/primal_grid/CPrimalGrid.cpp; sourceTree = "<group>"; };
+		405220C9246A629100D9AB4D /* CTetrahedron.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CTetrahedron.cpp; path = ../../Common/src/geometry/primal_grid/CTetrahedron.cpp; sourceTree = "<group>"; };
+		405220CA246A629100D9AB4D /* CPrism.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CPrism.cpp; path = ../../Common/src/geometry/primal_grid/CPrism.cpp; sourceTree = "<group>"; };
+		405220CB246A629100D9AB4D /* CQuadrilateral.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CQuadrilateral.cpp; path = ../../Common/src/geometry/primal_grid/CQuadrilateral.cpp; sourceTree = "<group>"; };
+		405220CC246A629100D9AB4D /* CPrimalGridBoundFEM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CPrimalGridBoundFEM.cpp; path = ../../Common/src/geometry/primal_grid/CPrimalGridBoundFEM.cpp; sourceTree = "<group>"; };
+		405220CD246A629100D9AB4D /* CLine.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CLine.cpp; path = ../../Common/src/geometry/primal_grid/CLine.cpp; sourceTree = "<group>"; };
 		4063F8122469E40A00DE870E /* CMultiGridIntegration.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CMultiGridIntegration.cpp; path = ../../SU2_CFD/src/integration/CMultiGridIntegration.cpp; sourceTree = "<group>"; };
 		4063F8132469E40A00DE870E /* CSingleGridIntegration.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CSingleGridIntegration.cpp; path = ../../SU2_CFD/src/integration/CSingleGridIntegration.cpp; sourceTree = "<group>"; };
 		4063F8142469E40A00DE870E /* CStructuralIntegration.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CStructuralIntegration.cpp; path = ../../SU2_CFD/src/integration/CStructuralIntegration.cpp; sourceTree = "<group>"; };
@@ -442,7 +603,6 @@
 		E90B4FEB22DFDFE2000ED392 /* CDiscAdjFEAVariable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CDiscAdjFEAVariable.cpp; path = ../../SU2_CFD/src/variables/CDiscAdjFEAVariable.cpp; sourceTree = "<group>"; };
 		E90B4FEC22DFDFE3000ED392 /* CAdjEulerVariable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CAdjEulerVariable.cpp; path = ../../SU2_CFD/src/variables/CAdjEulerVariable.cpp; sourceTree = "<group>"; };
 		E90B4FED22DFDFE3000ED392 /* CIncNSVariable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CIncNSVariable.cpp; path = ../../SU2_CFD/src/variables/CIncNSVariable.cpp; sourceTree = "<group>"; };
-		E90B4FEE22DFDFE3000ED392 /* CHeatFVMVariable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CHeatFVMVariable.cpp; path = ../../SU2_CFD/src/variables/CHeatFVMVariable.cpp; sourceTree = "<group>"; };
 		E90B4FEF22DFDFE3000ED392 /* CEulerVariable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CEulerVariable.cpp; path = ../../SU2_CFD/src/variables/CEulerVariable.cpp; sourceTree = "<group>"; };
 		E90B4FF022DFDFE3000ED392 /* CTurbSSTVariable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CTurbSSTVariable.cpp; path = ../../SU2_CFD/src/variables/CTurbSSTVariable.cpp; sourceTree = "<group>"; };
 		E90B4FF122DFDFE3000ED392 /* CBaselineVariable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CBaselineVariable.cpp; path = ../../SU2_CFD/src/variables/CBaselineVariable.cpp; sourceTree = "<group>"; };
@@ -470,7 +630,6 @@
 		E90B504522DFE4B8000ED392 /* CEulerVariable.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CEulerVariable.hpp; path = ../../SU2_CFD/include/variables/CEulerVariable.hpp; sourceTree = "<group>"; };
 		E90B504622DFE4B8000ED392 /* CTurbVariable.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CTurbVariable.hpp; path = ../../SU2_CFD/include/variables/CTurbVariable.hpp; sourceTree = "<group>"; };
 		E90B504722DFE4B8000ED392 /* CIncNSVariable.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CIncNSVariable.hpp; path = ../../SU2_CFD/include/variables/CIncNSVariable.hpp; sourceTree = "<group>"; };
-		E90B504822DFE4B8000ED392 /* CHeatFVMVariable.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CHeatFVMVariable.hpp; path = ../../SU2_CFD/include/variables/CHeatFVMVariable.hpp; sourceTree = "<group>"; };
 		E90B504922DFE4B8000ED392 /* CBaselineVariable.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CBaselineVariable.hpp; path = ../../SU2_CFD/include/variables/CBaselineVariable.hpp; sourceTree = "<group>"; };
 		E90B504A22DFE4B8000ED392 /* CFEAVariable.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CFEAVariable.hpp; path = ../../SU2_CFD/include/variables/CFEAVariable.hpp; sourceTree = "<group>"; };
 		E90B504B22DFE4B8000ED392 /* CAdjEulerVariable.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CAdjEulerVariable.hpp; path = ../../SU2_CFD/include/variables/CAdjEulerVariable.hpp; sourceTree = "<group>"; };
@@ -520,7 +679,6 @@
 		E9C2835822A701B5007B4E59 /* CRinglebSolution.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CRinglebSolution.hpp; path = ../../Common/include/toolboxes/MMS/CRinglebSolution.hpp; sourceTree = "<group>"; };
 		E9C2835922A701B5007B4E59 /* CTGVSolution.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CTGVSolution.hpp; path = ../../Common/include/toolboxes/MMS/CTGVSolution.hpp; sourceTree = "<group>"; };
 		E9C2835A22A701B6007B4E59 /* CIncTGVSolution.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CIncTGVSolution.hpp; path = ../../Common/include/toolboxes/MMS/CIncTGVSolution.hpp; sourceTree = "<group>"; };
-		E9C2835B22A701B6007B4E59 /* CVerificationSolution.inl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CVerificationSolution.inl; path = ../../Common/include/toolboxes/MMS/CVerificationSolution.inl; sourceTree = "<group>"; };
 		E9C2835C22A701B6007B4E59 /* CMMSIncNSSolution.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CMMSIncNSSolution.hpp; path = ../../Common/include/toolboxes/MMS/CMMSIncNSSolution.hpp; sourceTree = "<group>"; };
 		E9C2835D22A701B6007B4E59 /* CMMSNSUnitQuadSolutionWallBC.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CMMSNSUnitQuadSolutionWallBC.hpp; path = ../../Common/include/toolboxes/MMS/CMMSNSUnitQuadSolutionWallBC.hpp; sourceTree = "<group>"; };
 		E9C830752061E60E004417A9 /* fem_geometry_structure.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = fem_geometry_structure.cpp; path = ../../Common/src/fem_geometry_structure.cpp; sourceTree = "<group>"; };
@@ -535,8 +693,6 @@
 		E9C8308E2061E6B6004417A9 /* fem_standard_element.inl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = fem_standard_element.inl; path = ../../Common/include/fem_standard_element.inl; sourceTree = "<group>"; };
 		E9D6EE5923165FD300618E36 /* CDummyDriver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CDummyDriver.cpp; path = ../../SU2_CFD/src/drivers/CDummyDriver.cpp; sourceTree = "<group>"; };
 		E9D6EE5B23165FE400618E36 /* CDummyDriver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CDummyDriver.hpp; path = ../../SU2_CFD/include/drivers/CDummyDriver.hpp; sourceTree = "<group>"; };
-		E9D6EE5C2316653100618E36 /* CSU2ASCIIMeshReaderFVM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CSU2ASCIIMeshReaderFVM.cpp; path = ../../Common/src/CSU2ASCIIMeshReaderFVM.cpp; sourceTree = "<group>"; };
-		E9D6EE5E2316655400618E36 /* CSU2ASCIIMeshReaderFVM.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CSU2ASCIIMeshReaderFVM.hpp; path = ../../Common/include/CSU2ASCIIMeshReaderFVM.hpp; sourceTree = "<group>"; };
 		E9D6EE652317B80500618E36 /* CMeshSolver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CMeshSolver.cpp; path = ../../SU2_CFD/src/solvers/CMeshSolver.cpp; sourceTree = "<group>"; };
 		E9D6EE662317B80600618E36 /* CDiscAdjMeshSolver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CDiscAdjMeshSolver.cpp; path = ../../SU2_CFD/src/solvers/CDiscAdjMeshSolver.cpp; sourceTree = "<group>"; };
 		E9D6EE6B2317B88F00618E36 /* CDiscAdjMeshBoundVariable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CDiscAdjMeshBoundVariable.cpp; path = ../../SU2_CFD/src/variables/CDiscAdjMeshBoundVariable.cpp; sourceTree = "<group>"; };
@@ -554,22 +710,11 @@
 		E9D85B4B1C3F1B9E0077122F /* ad_structure.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = ad_structure.cpp; path = ../../Common/src/ad_structure.cpp; sourceTree = "<group>"; };
 		E9D85B4D1C3F1BE00077122F /* ad_structure.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; lineEnding = 0; name = ad_structure.hpp; path = ../../Common/include/ad_structure.hpp; sourceTree = "<group>"; };
 		E9D85B4E1C3F1BE00077122F /* ad_structure.inl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; lineEnding = 0; name = ad_structure.inl; path = ../../Common/include/ad_structure.inl; sourceTree = "<group>"; };
-		E9D885A72303F8D000917362 /* CBoxMeshReaderFVM.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CBoxMeshReaderFVM.hpp; path = ../../Common/include/CBoxMeshReaderFVM.hpp; sourceTree = "<group>"; };
-		E9D885A82303F8E400917362 /* CBoxMeshReaderFVM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CBoxMeshReaderFVM.cpp; path = ../../Common/src/CBoxMeshReaderFVM.cpp; sourceTree = "<group>"; };
-		E9D9CE851C62A1A7004119E9 /* interpolation_structure.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = interpolation_structure.cpp; path = ../../Common/src/interpolation_structure.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		E9D9CE971C62A2A7004119E9 /* interpolation_structure.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; lineEnding = 0; name = interpolation_structure.hpp; path = ../../Common/include/interpolation_structure.hpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		E9E51AD522FA313800773E0C /* CLinearPartitioner.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CLinearPartitioner.cpp; path = ../../Common/src/toolboxes/CLinearPartitioner.cpp; sourceTree = "<group>"; };
 		E9E51AD722FA314F00773E0C /* CLinearPartitioner.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CLinearPartitioner.hpp; path = ../../Common/include/toolboxes/CLinearPartitioner.hpp; sourceTree = "<group>"; };
-		E9E51AD822FA603700773E0C /* CMeshReaderFVM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CMeshReaderFVM.cpp; path = ../../Common/src/CMeshReaderFVM.cpp; sourceTree = "<group>"; };
-		E9E51ADA22FA604600773E0C /* CMeshReaderFVM.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CMeshReaderFVM.hpp; path = ../../Common/include/CMeshReaderFVM.hpp; sourceTree = "<group>"; };
-		E9E51ADB22FAB10D00773E0C /* CCGNSMeshReaderFVM.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CCGNSMeshReaderFVM.hpp; path = ../../Common/include/CCGNSMeshReaderFVM.hpp; sourceTree = "<group>"; };
-		E9E51ADC22FAB11700773E0C /* CCGNSMeshReaderFVM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CCGNSMeshReaderFVM.cpp; path = ../../Common/src/CCGNSMeshReaderFVM.cpp; sourceTree = "<group>"; };
 		E9E674332302A2E3009B6A25 /* CMultiGridQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CMultiGridQueue.cpp; path = ../../Common/src/CMultiGridQueue.cpp; sourceTree = "<group>"; };
 		E9E674352302A327009B6A25 /* CMultiGridQueue.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CMultiGridQueue.hpp; path = ../../Common/include/CMultiGridQueue.hpp; sourceTree = "<group>"; };
-		E9E674362302A92C009B6A25 /* CRectangularMeshReaderFVM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CRectangularMeshReaderFVM.cpp; path = ../../Common/src/CRectangularMeshReaderFVM.cpp; sourceTree = "<group>"; };
-		E9E674382302A942009B6A25 /* CRectangularMeshReaderFVM.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CRectangularMeshReaderFVM.hpp; path = ../../Common/include/CRectangularMeshReaderFVM.hpp; sourceTree = "<group>"; };
 		E9FDF6E91D2DD0560066E49C /* adt_structure.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = adt_structure.cpp; path = ../../Common/src/adt_structure.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		E9FDF6EB1D2DD0710066E49C /* adt_structure.inl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; lineEnding = 0; name = adt_structure.inl; path = ../../Common/include/adt_structure.inl; sourceTree = "<group>"; };
 		E9FDF6EC1D2DD0860066E49C /* adt_structure.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; lineEnding = 0; name = adt_structure.hpp; path = ../../Common/include/adt_structure.hpp; sourceTree = "<group>"; };
 		EB14FF9422F790500045FB27 /* CSinglezoneDriver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CSinglezoneDriver.cpp; path = ../../SU2_CFD/src/drivers/CSinglezoneDriver.cpp; sourceTree = "<group>"; };
 		EB14FF9522F790500045FB27 /* CDiscAdjSinglezoneDriver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CDiscAdjSinglezoneDriver.cpp; path = ../../SU2_CFD/src/drivers/CDiscAdjSinglezoneDriver.cpp; sourceTree = "<group>"; };
@@ -668,18 +813,15 @@
 		0530E57317FDF97F00733CE8 /* Geometry */ = {
 			isa = PBXGroup;
 			children = (
+				405220AE246A623500D9AB4D /* DualGrid */,
 				356E2E2523999AF50039E9B5 /* Elements */,
+				405220AD246A622F00D9AB4D /* MeshReader */,
+				405220AC246A622900D9AB4D /* PrimalGrid */,
 				356E2E1F23999AEA0039E9B5 /* CDummyGeometry.cpp */,
 				356E2E1D23999AEA0039E9B5 /* CGeometry.cpp */,
 				356E2E2023999AEA0039E9B5 /* CMultiGridGeometry.cpp */,
 				356E2E1E23999AEA0039E9B5 /* CPhysicalGeometry.cpp */,
-				E9D885A82303F8E400917362 /* CBoxMeshReaderFVM.cpp */,
-				E9E51ADC22FAB11700773E0C /* CCGNSMeshReaderFVM.cpp */,
-				E9E51AD822FA603700773E0C /* CMeshReaderFVM.cpp */,
 				E9E674332302A2E3009B6A25 /* CMultiGridQueue.cpp */,
-				E9E674362302A92C009B6A25 /* CRectangularMeshReaderFVM.cpp */,
-				E9D6EE5C2316653100618E36 /* CSU2ASCIIMeshReaderFVM.cpp */,
-				05E6DB8A17EB61E600FA1F7E /* dual_grid_structure.cpp */,
 				E96FAF132189FECA0046BF5D /* fem_cgns_elements.cpp */,
 				E96FAF122189FECA0046BF5D /* fem_gauss_jacobi_quadrature.cpp */,
 				E9C830752061E60E004417A9 /* fem_geometry_structure.cpp */,
@@ -691,7 +833,6 @@
 				E96FAF112189FECA0046BF5D /* graph_coloring_structure.cpp */,
 				05E6DB8C17EB61E600FA1F7E /* grid_adaptation_structure.cpp */,
 				05E6DB8D17EB61E600FA1F7E /* grid_movement_structure.cpp */,
-				05E6DB9017EB61E600FA1F7E /* primal_grid_structure.cpp */,
 			);
 			name = Geometry;
 			sourceTree = "<group>";
@@ -700,24 +841,17 @@
 			isa = PBXGroup;
 			children = (
 				E9D85B4E1C3F1BE00077122F /* ad_structure.inl */,
-				E9FDF6EB1D2DD0710066E49C /* adt_structure.inl */,
-				05E6DA9F17EB603F00FA1F7E /* config_structure.inl */,
 				E90B504F22DFE541000ED392 /* CSysMatrix.inl */,
-				E9C2835B22A701B6007B4E59 /* CVerificationSolution.inl */,
 				E941BB961B71D1AB005C6C06 /* datatype_structure.inl */,
-				05E6DAA017EB603F00FA1F7E /* dual_grid_structure.inl */,
 				E96FAF1B2189FF620046BF5D /* fem_gauss_jacobi_quadrature.inl */,
 				E9C8308C2061E6B6004417A9 /* fem_geometry_structure.inl */,
 				E9C8308E2061E6B6004417A9 /* fem_standard_element.inl */,
 				05F108A01978D2D700F2F288 /* fluid_model.inl */,
 				05E6DAA217EB603F00FA1F7E /* grid_adaptation_structure.inl */,
 				05E6DAA317EB603F00FA1F7E /* grid_movement_structure.inl */,
-				05E6DBB017EB624700FA1F7E /* integration_structure.inl */,
 				E941BBA61B71D1AB005C6C06 /* mpi_structure.inl */,
-				05E6DBB117EB624700FA1F7E /* numerics_structure.inl */,
-				05E6DAA617EB603F00FA1F7E /* primal_grid_structure.inl */,
+				40303ECE246A5DBF00CD7789 /* option_structure.inl */,
 				355D2C9D2172BDE100C10535 /* sgs_model.inl */,
-				05E6DBB217EB624700FA1F7E /* solver_structure.inl */,
 				E90B501522DFE0CC000ED392 /* task_definition.inl */,
 				05F108A11978D2D700F2F288 /* transport_model.inl */,
 				3599C5D62121FAF4003AAF05 /* wall_model.inl */,
@@ -728,34 +862,18 @@
 		0541ABE51370DC5E002D668B /* Include */ = {
 			isa = PBXGroup;
 			children = (
-				E96766A0237365E1009FBEE1 /* CMarkerProfileReaderFVM.hpp */,
 				E9D85B4D1C3F1BE00077122F /* ad_structure.hpp */,
 				E9FDF6EC1D2DD0860066E49C /* adt_structure.hpp */,
 				E96FAF1A2189FF620046BF5D /* blas_structure.hpp */,
-				E9D885A72303F8D000917362 /* CBoxMeshReaderFVM.hpp */,
-				E9E51ADB22FAB10D00773E0C /* CCGNSMeshReaderFVM.hpp */,
-				E9D6EE7A2317B8B000618E36 /* CDiscAdjMeshSolver.hpp */,
-				E9C2835A22A701B6007B4E59 /* CIncTGVSolution.hpp */,
-				E9C2835722A701B5007B4E59 /* CInviscidVortexSolution.hpp */,
-				E9E51AD722FA314F00773E0C /* CLinearPartitioner.hpp */,
+				40303ECD246A5DBF00CD7789 /* CConfig.hpp */,
+				40303E6E246A580700CD7789 /* CLimiterDetails.hpp */,
+				E96766A0237365E1009FBEE1 /* CMarkerProfileReaderFVM.hpp */,
 				E9D6EE7C2317B8CC00618E36 /* CMeshElement.hpp */,
-				E9E51ADA22FA604600773E0C /* CMeshReaderFVM.hpp */,
-				E9D6EE7B2317B8B000618E36 /* CMeshSolver.hpp */,
-				E9C2835222A701B5007B4E59 /* CMMSIncEulerSolution.hpp */,
-				E9C2835C22A701B6007B4E59 /* CMMSIncNSSolution.hpp */,
-				E9C2835122A701B5007B4E59 /* CMMSNSTwoHalfCirclesSolution.hpp */,
-				E9C2835022A701B5007B4E59 /* CMMSNSTwoHalfSpheresSolution.hpp */,
-				E9C2835322A701B5007B4E59 /* CMMSNSUnitQuadSolution.hpp */,
-				E9C2835D22A701B6007B4E59 /* CMMSNSUnitQuadSolutionWallBC.hpp */,
 				E9E674352302A327009B6A25 /* CMultiGridQueue.hpp */,
-				E9C2835622A701B5007B4E59 /* CNSUnitQuadSolution.hpp */,
-				05E6DAC517EB608000FA1F7E /* config_structure.hpp */,
-				E9E674382302A942009B6A25 /* CRectangularMeshReaderFVM.hpp */,
-				E9C2835822A701B5007B4E59 /* CRinglebSolution.hpp */,
-				E9D6EE5E2316655400618E36 /* CSU2ASCIIMeshReaderFVM.hpp */,
-				E9C2835922A701B5007B4E59 /* CTGVSolution.hpp */,
-				E9C2835422A701B5007B4E59 /* CUserDefinedSolution.hpp */,
-				E9C2835522A701B5007B4E59 /* CVerificationSolution.hpp */,
+				40303E65246A079A00CD7789 /* computeGradientsGreenGauss.hpp */,
+				40303E66246A079A00CD7789 /* computeGradientsLeastSquares.hpp */,
+				40303E6F246A580700CD7789 /* computeLimiters_impl.hpp */,
+				40303E70246A580700CD7789 /* computeLimiters.hpp */,
 				E941BB951B71D1AB005C6C06 /* datatype_structure.hpp */,
 				E941BB971B71D1AB005C6C06 /* datatypes */,
 				05E6DBB417EB627400FA1F7E /* definition_structure.hpp */,
@@ -765,23 +883,25 @@
 				E9C8308B2061E6B6004417A9 /* fem_geometry_structure.hpp */,
 				E9C8308D2061E6B6004417A9 /* fem_standard_element.hpp */,
 				05F1089E1978D2CE00F2F288 /* fluid_model.hpp */,
+				40303EF5246A602600CD7789 /* Geometry */,
+				40303ECF246A5DBF00CD7789 /* geometry_structure_fem_part.hpp */,
 				E96FAF192189FF620046BF5D /* graph_coloring_structure.hpp */,
 				05E6DAC817EB608000FA1F7E /* grid_adaptation_structure.hpp */,
 				05E6DAC917EB608000FA1F7E /* grid_movement_structure.hpp */,
-				05E6DBB517EB627400FA1F7E /* integration_structure.hpp */,
+				40303E67246A07B300CD7789 /* Integration */,
 				4040B268235FBF1B00843C83 /* Interfaces */,
-				E9D9CE971C62A2A7004119E9 /* interpolation_structure.hpp */,
+				40303ED0246A5E3700CD7789 /* InterfaceInterpolation */,
 				05E6DBB617EB627400FA1F7E /* iteration_structure.hpp */,
 				E90B505622DFE54B000ED392 /* LinearSolver */,
 				E941BBA51B71D1AB005C6C06 /* mpi_structure.hpp */,
-				05E6DBB717EB627400FA1F7E /* numerics_structure.hpp */,
+				40303E71246A583000CD7789 /* Numerics */,
+				40303ECC246A5DBF00CD7789 /* omp_structure.hpp */,
 				05E6DACC17EB608000FA1F7E /* option_structure.hpp */,
 				403426D3235F857D005B5215 /* Output */,
-				05E6DACD17EB608000FA1F7E /* primal_grid_structure.hpp */,
-				400CEC2F21FA81B60019B790 /* printing_toolbox.hpp */,
+				40303E93246A5B9200CD7789 /* Solvers */,
 				355D2C9E2172BDE100C10535 /* sgs_model.hpp */,
-				05E6DBB917EB627400FA1F7E /* solver_structure.hpp */,
 				05E6DBBA17EB627400FA1F7E /* SU2_CFD.hpp */,
+				40303ED9246A5E8900CD7789 /* Toolboxes */,
 				E90B501422DFE0CB000ED392 /* task_definition.hpp */,
 				05F1089F1978D2CE00F2F288 /* transport_model.hpp */,
 				E90B504E22DFE4C5000ED392 /* Variable */,
@@ -853,9 +973,11 @@
 				E9D85B4B1C3F1B9E0077122F /* ad_structure.cpp */,
 				E9FDF6E91D2DD0560066E49C /* adt_structure.cpp */,
 				E96FAF0F2189FE9C0046BF5D /* blas_structure.cpp */,
+				40303EB7246A5D2700CD7789 /* C1DInterpolation.cpp */,
+				40303EAF246A5CC000CD7789 /* CConfig.cpp */,
 				4063F823246A03AE00DE870E /* CLimiterDetails.cpp */,
 				E9E51AD522FA313800773E0C /* CLinearPartitioner.cpp */,
-				05E6DB8917EB61E600FA1F7E /* config_structure.cpp */,
+				40303EB8246A5D2700CD7789 /* CSymmetricMatrix.cpp */,
 				05E6DBBC17EB62A000FA1F7E /* definition_structure.cpp */,
 				EB14FF9322F790320045FB27 /* Driver */,
 				05F108951978D28F00F2F288 /* FluidModel */,
@@ -863,10 +985,10 @@
 				052D51AA17A22E15003BE8B2 /* Integration */,
 				05E6DBC017EB62A100FA1F7E /* iteration_structure.cpp */,
 				4040B249235FB87300843C83 /* Interfaces */,
+				40303EBD246A5D5B00CD7789 /* InterfaceInterpolation */,
 				E90B501322DFE060000ED392 /* LinearSolver */,
 				E90B4FE522DFDF9C000ED392 /* MMS */,
 				E941BB911B71D124005C6C06 /* mpi_structure.cpp */,
-				E9D9CE841C62A16D004119E9 /* MultiZone */,
 				05D28619178BCA1200DD76AE /* Numerics */,
 				052D51AB17A22E24003BE8B2 /* Output */,
 				400CEC2D21FA81A10019B790 /* printing_toolbox.cpp */,
@@ -926,6 +1048,248 @@
 			name = Drivers;
 			sourceTree = "<group>";
 		};
+		40303E67246A07B300CD7789 /* Integration */ = {
+			isa = PBXGroup;
+			children = (
+				40303E6D246A07D300CD7789 /* CFEM_DG_Integration.hpp */,
+				40303E6C246A07D300CD7789 /* CIntegration.hpp */,
+				40303E68246A07D300CD7789 /* CIntegrationFactory.hpp */,
+				40303E69246A07D300CD7789 /* CMultiGridIntegration.hpp */,
+				40303E6A246A07D300CD7789 /* CSingleGridIntegration.hpp */,
+				40303E6B246A07D300CD7789 /* CStructuralIntegration.hpp */,
+			);
+			name = Integration;
+			sourceTree = "<group>";
+		};
+		40303E71246A583000CD7789 /* Numerics */ = {
+			isa = PBXGroup;
+			children = (
+				40303E82246A589C00CD7789 /* CNumerics.hpp */,
+				40303E76246A589B00CD7789 /* heat.hpp */,
+				40303E85246A589C00CD7789 /* radiation.hpp */,
+				40303E7A246A589B00CD7789 /* template.hpp */,
+				40303E81246A589C00CD7789 /* transition.hpp */,
+				40303E75246A585E00CD7789 /* ContinuousAdjoint */,
+				40303E74246A585600CD7789 /* Elasticity */,
+				40303E73246A585000CD7789 /* Flow */,
+				40303E72246A584600CD7789 /* Turbulent */,
+			);
+			name = Numerics;
+			sourceTree = "<group>";
+		};
+		40303E72246A584600CD7789 /* Turbulent */ = {
+			isa = PBXGroup;
+			children = (
+				40303E7E246A589B00CD7789 /* turb_convection.hpp */,
+				40303E89246A589C00CD7789 /* turb_diffusion.hpp */,
+				40303E7B246A589B00CD7789 /* turb_sources.hpp */,
+			);
+			name = Turbulent;
+			sourceTree = "<group>";
+		};
+		40303E73246A585000CD7789 /* Flow */ = {
+			isa = PBXGroup;
+			children = (
+				40303E8C246A589C00CD7789 /* ausm_slau.hpp */,
+				40303E7F246A589C00CD7789 /* centered.hpp */,
+				40303E84246A589C00CD7789 /* cusp.hpp */,
+				40303E77246A589B00CD7789 /* fds.hpp */,
+				40303E83246A589C00CD7789 /* flow_diffusion.hpp */,
+				40303E86246A589C00CD7789 /* flow_sources.hpp */,
+				40303E8D246A589C00CD7789 /* fvs.hpp */,
+				40303E78246A589B00CD7789 /* hllc.hpp */,
+				40303E79246A589B00CD7789 /* roe.hpp */,
+			);
+			name = Flow;
+			sourceTree = "<group>";
+		};
+		40303E74246A585600CD7789 /* Elasticity */ = {
+			isa = PBXGroup;
+			children = (
+				40303E8A246A589C00CD7789 /* CFEAElasticity.hpp */,
+				40303E88246A589C00CD7789 /* CFEALinearElasticity.hpp */,
+				40303E87246A589C00CD7789 /* CFEANonlinearElasticity.hpp */,
+				40303E7D246A589B00CD7789 /* nonlinear_models.hpp */,
+			);
+			name = Elasticity;
+			sourceTree = "<group>";
+		};
+		40303E75246A585E00CD7789 /* ContinuousAdjoint */ = {
+			isa = PBXGroup;
+			children = (
+				40303E8B246A589C00CD7789 /* adj_convection.hpp */,
+				40303E80246A589C00CD7789 /* adj_diffusion.hpp */,
+				40303E7C246A589B00CD7789 /* adj_sources.hpp */,
+			);
+			name = ContinuousAdjoint;
+			sourceTree = "<group>";
+		};
+		40303E93246A5B9200CD7789 /* Solvers */ = {
+			isa = PBXGroup;
+			children = (
+				40303E9D246A5BA700CD7789 /* CAdjEulerSolver.hpp */,
+				40303EA7246A5BA700CD7789 /* CAdjNSSolver.hpp */,
+				40303EA5246A5BA700CD7789 /* CAdjTurbSolver.hpp */,
+				40303EA3246A5BA700CD7789 /* CBaselineSolver_FEM.hpp */,
+				40303E99246A5BA700CD7789 /* CBaselineSolver.hpp */,
+				40303EA9246A5BA700CD7789 /* CDiscAdjFEASolver.hpp */,
+				E9D6EE7A2317B8B000618E36 /* CDiscAdjMeshSolver.hpp */,
+				40303E95246A5BA700CD7789 /* CDiscAdjSolver.hpp */,
+				40303E9B246A5BA700CD7789 /* CEulerSolver.hpp */,
+				40303E9E246A5BA700CD7789 /* CFEASolver.hpp */,
+				40303EA2246A5BA700CD7789 /* CFEM_DG_EulerSolver.hpp */,
+				40303E9C246A5BA700CD7789 /* CFEM_DG_NSSolver.hpp */,
+				40303E9F246A5BA700CD7789 /* CHeatSolver.hpp */,
+				40303EA6246A5BA700CD7789 /* CIncEulerSolver.hpp */,
+				40303EA8246A5BA700CD7789 /* CIncNSSolver.hpp */,
+				E9D6EE7B2317B8B000618E36 /* CMeshSolver.hpp */,
+				40303EAB246A5BA700CD7789 /* CNSSolver.hpp */,
+				40303E96246A5BA700CD7789 /* CRadP1Solver.hpp */,
+				40303EA1246A5BA700CD7789 /* CRadSolver.hpp */,
+				40303EA0246A5BA700CD7789 /* CSolver.hpp */,
+				40303E97246A5BA700CD7789 /* CSolverFactory.hpp */,
+				40303EAA246A5BA700CD7789 /* CTemplateSolver.hpp */,
+				40303E98246A5BA700CD7789 /* CTransLMSolver.hpp */,
+				40303E9A246A5BA700CD7789 /* CTurbSASolver.hpp */,
+				40303EA4246A5BA700CD7789 /* CTurbSolver.hpp */,
+				40303E94246A5BA700CD7789 /* CTurbSSTSolver.hpp */,
+			);
+			name = Solvers;
+			sourceTree = "<group>";
+		};
+		40303EBD246A5D5B00CD7789 /* InterfaceInterpolation */ = {
+			isa = PBXGroup;
+			children = (
+				40303EBE246A5D9200CD7789 /* CInterpolator.cpp */,
+				40303EC4246A5D9300CD7789 /* CInterpolatorFactory.cpp */,
+				40303EC1246A5D9300CD7789 /* CIsoparametric.cpp */,
+				40303EC0246A5D9300CD7789 /* CMirror.cpp */,
+				40303EBF246A5D9200CD7789 /* CNearestNeighbor.cpp */,
+				40303EC3246A5D9300CD7789 /* CRadialBasisFunction.cpp */,
+				40303EC2246A5D9300CD7789 /* CSlidingMesh.cpp */,
+			);
+			name = InterfaceInterpolation;
+			sourceTree = "<group>";
+		};
+		40303ED0246A5E3700CD7789 /* InterfaceInterpolation */ = {
+			isa = PBXGroup;
+			children = (
+				40303ED2246A5E5500CD7789 /* CInterpolator.hpp */,
+				40303ED7246A5E5500CD7789 /* CInterpolatorFactory.hpp */,
+				40303ED4246A5E5500CD7789 /* CIsoparametric.hpp */,
+				40303ED5246A5E5500CD7789 /* CMirror.hpp */,
+				40303ED1246A5E5500CD7789 /* CNearestNeighbor.hpp */,
+				40303ED3246A5E5500CD7789 /* CRadialBasisFunction.hpp */,
+				40303ED6246A5E5500CD7789 /* CSlidingMesh.hpp */,
+			);
+			name = InterfaceInterpolation;
+			sourceTree = "<group>";
+		};
+		40303ED9246A5E8900CD7789 /* Toolboxes */ = {
+			isa = PBXGroup;
+			children = (
+				40303EDA246A5E9100CD7789 /* MMS */,
+				40303EF0246A5F6800CD7789 /* allocation_toolbox.hpp */,
+				40303EED246A5F6800CD7789 /* C1DInterpolation.hpp */,
+				40303EEF246A5F6800CD7789 /* C2DContainer.hpp */,
+				40303EEB246A5F6700CD7789 /* CFastFindAndEraseQueue.hpp */,
+				E9E51AD722FA314F00773E0C /* CLinearPartitioner.hpp */,
+				40303EEC246A5F6800CD7789 /* CSymmetricMatrix.hpp */,
+				40303EEE246A5F6800CD7789 /* CVertexMap.hpp */,
+				40303EDB246A5F6700CD7789 /* geometry_toolbox.hpp */,
+				40303EDC246A5F6700CD7789 /* graph_toolbox.hpp */,
+				400CEC2F21FA81B60019B790 /* printing_toolbox.hpp */,
+			);
+			name = Toolboxes;
+			sourceTree = "<group>";
+		};
+		40303EDA246A5E9100CD7789 /* MMS */ = {
+			isa = PBXGroup;
+			children = (
+				E9C2835A22A701B6007B4E59 /* CIncTGVSolution.hpp */,
+				E9C2835722A701B5007B4E59 /* CInviscidVortexSolution.hpp */,
+				E9C2835222A701B5007B4E59 /* CMMSIncEulerSolution.hpp */,
+				E9C2835C22A701B6007B4E59 /* CMMSIncNSSolution.hpp */,
+				E9C2835122A701B5007B4E59 /* CMMSNSTwoHalfCirclesSolution.hpp */,
+				E9C2835022A701B5007B4E59 /* CMMSNSTwoHalfSpheresSolution.hpp */,
+				E9C2835322A701B5007B4E59 /* CMMSNSUnitQuadSolution.hpp */,
+				E9C2835D22A701B6007B4E59 /* CMMSNSUnitQuadSolutionWallBC.hpp */,
+				E9C2835622A701B5007B4E59 /* CNSUnitQuadSolution.hpp */,
+				E9C2835822A701B5007B4E59 /* CRinglebSolution.hpp */,
+				E9C2835922A701B5007B4E59 /* CTGVSolution.hpp */,
+				E9C2835422A701B5007B4E59 /* CUserDefinedSolution.hpp */,
+				E9C2835522A701B5007B4E59 /* CVerificationSolution.hpp */,
+			);
+			name = MMS;
+			sourceTree = "<group>";
+		};
+		40303EF5246A602600CD7789 /* Geometry */ = {
+			isa = PBXGroup;
+			children = (
+				40303EF9246A608600CD7789 /* DualGrid */,
+				40303EF8246A607F00CD7789 /* Elements */,
+				40303EF7246A607900CD7789 /* MeshReader */,
+				40303EF6246A607100CD7789 /* PrimalGrid */,
+				40303EF4246A5FF400CD7789 /* CDummyGeometry.hpp */,
+				40303EF2246A5FF400CD7789 /* CGeometry.hpp */,
+				40303EF1246A5FF400CD7789 /* CMultiGridGeometry.hpp */,
+				40303EF3246A5FF400CD7789 /* CPhysicalGeometry.hpp */,
+			);
+			name = Geometry;
+			sourceTree = "<group>";
+		};
+		40303EF6246A607100CD7789 /* PrimalGrid */ = {
+			isa = PBXGroup;
+			children = (
+				40303F0F246A60C300CD7789 /* CHexahedron.hpp */,
+				40303F07246A60C300CD7789 /* CLine.hpp */,
+				40303F0B246A60C300CD7789 /* CPrimalGrid.hpp */,
+				40303F0C246A60C300CD7789 /* CPrimalGridBoundFEM.hpp */,
+				40303F0D246A60C300CD7789 /* CPrimalGridFEM.hpp */,
+				40303F10246A60C300CD7789 /* CPrism.hpp */,
+				40303F11246A60C300CD7789 /* CPyramid.hpp */,
+				40303F0A246A60C300CD7789 /* CQuadrilateral.hpp */,
+				40303F08246A60C300CD7789 /* CTetrahedron.hpp */,
+				40303F09246A60C300CD7789 /* CTriangle.hpp */,
+				40303F0E246A60C300CD7789 /* CVertexMPI.hpp */,
+			);
+			name = PrimalGrid;
+			sourceTree = "<group>";
+		};
+		40303EF7246A607900CD7789 /* MeshReader */ = {
+			isa = PBXGroup;
+			children = (
+				40303F05246A60B700CD7789 /* CBoxMeshReaderFVM.hpp */,
+				40303F03246A60B700CD7789 /* CCGNSMeshReaderFVM.hpp */,
+				40303F02246A60B700CD7789 /* CMeshReaderFVM.hpp */,
+				40303F06246A60B700CD7789 /* CRectangularMeshReaderFVM.hpp */,
+				40303F04246A60B700CD7789 /* CSU2ASCIIMeshReaderFVM.hpp */,
+			);
+			name = MeshReader;
+			sourceTree = "<group>";
+		};
+		40303EF8246A607F00CD7789 /* Elements */ = {
+			isa = PBXGroup;
+			children = (
+				40303F00246A60A900CD7789 /* CElement.hpp */,
+				40303EFF246A60A900CD7789 /* CElementProperty.hpp */,
+				40303F01246A60A900CD7789 /* CGaussVariable.hpp */,
+			);
+			name = Elements;
+			sourceTree = "<group>";
+		};
+		40303EF9246A608600CD7789 /* DualGrid */ = {
+			isa = PBXGroup;
+			children = (
+				40303EFE246A609B00CD7789 /* CDualGrid.hpp */,
+				40303EFD246A609B00CD7789 /* CEdge.hpp */,
+				40303EFC246A609B00CD7789 /* CPoint.hpp */,
+				40303EFB246A609B00CD7789 /* CTurboVertex.hpp */,
+				40303EFA246A609B00CD7789 /* CVertex.hpp */,
+			);
+			name = DualGrid;
+			sourceTree = "<group>";
+		};
 		403426D3235F857D005B5215 /* Output */ = {
 			isa = PBXGroup;
 			children = (
@@ -944,7 +1308,9 @@
 				403426D4235F85D5005B5215 /* CMeshOutput.hpp */,
 				403426D6235F85D5005B5215 /* CMultizoneOutput.hpp */,
 				403426D7235F85D5005B5215 /* COutput.hpp */,
+				40303E90246A5A4900CD7789 /* COutputFactory.hpp */,
 				403426D8235F85D5005B5215 /* COutputLegacy.hpp */,
+				40303E92246A5A4900CD7789 /* CWindowingTools.hpp */,
 				403426E2235F85D6005B5215 /* output_structure_legacy.inl */,
 			);
 			name = Output;
@@ -1010,23 +1376,68 @@
 		4040B286235FC03700843C83 /* filewriter */ = {
 			isa = PBXGroup;
 			children = (
-				4040B287235FC03700843C83 /* CParaviewFileWriter.hpp */,
-				4040B288235FC03700843C83 /* CTecplotFileWriter.hpp */,
-				4040B289235FC03700843C83 /* CSurfaceFEMDataSorter.hpp */,
-				4040B28A235FC03700843C83 /* CSU2MeshFileWriter.hpp */,
-				4040B28B235FC03700843C83 /* CTecplotBinaryFileWriter.hpp */,
-				4040B28C235FC03700843C83 /* CSU2FileWriter.hpp */,
+				4040B293235FC03700843C83 /* CCSVFileWriter.hpp */,
+				4040B28F235FC03700843C83 /* CFEMDataSorter.hpp */,
+				4040B292235FC03700843C83 /* CFileWriter.hpp */,
 				4040B28D235FC03700843C83 /* CFVMDataSorter.hpp */,
 				4040B28E235FC03700843C83 /* CParallelDataSorter.hpp */,
-				4040B28F235FC03700843C83 /* CFEMDataSorter.hpp */,
 				4040B290235FC03700843C83 /* CParaviewBinaryFileWriter.hpp */,
+				4040B287235FC03700843C83 /* CParaviewFileWriter.hpp */,
+				40303E8E246A5A4900CD7789 /* CParaviewVTMFileWriter.hpp */,
+				40303E91246A5A4900CD7789 /* CParaviewXMLFileWriter.hpp */,
+				40303E8F246A5A4900CD7789 /* CSTLFileWriter.hpp */,
 				4040B291235FC03700843C83 /* CSU2BinaryFileWriter.hpp */,
-				4040B292235FC03700843C83 /* CFileWriter.hpp */,
-				4040B293235FC03700843C83 /* CCSVFileWriter.hpp */,
+				4040B28C235FC03700843C83 /* CSU2FileWriter.hpp */,
+				4040B28A235FC03700843C83 /* CSU2MeshFileWriter.hpp */,
+				4040B289235FC03700843C83 /* CSurfaceFEMDataSorter.hpp */,
 				4040B294235FC03700843C83 /* CSurfaceFVMDataSorter.hpp */,
+				4040B28B235FC03700843C83 /* CTecplotBinaryFileWriter.hpp */,
+				4040B288235FC03700843C83 /* CTecplotFileWriter.hpp */,
 			);
 			name = filewriter;
 			path = ../../SU2_CFD/include/output/filewriter;
+			sourceTree = "<group>";
+		};
+		405220AC246A622900D9AB4D /* PrimalGrid */ = {
+			isa = PBXGroup;
+			children = (
+				405220C5246A629100D9AB4D /* CHexahedron.cpp */,
+				405220CD246A629100D9AB4D /* CLine.cpp */,
+				405220C8246A629100D9AB4D /* CPrimalGrid.cpp */,
+				405220CC246A629100D9AB4D /* CPrimalGridBoundFEM.cpp */,
+				405220C6246A629100D9AB4D /* CPrimalGridFEM.cpp */,
+				405220CA246A629100D9AB4D /* CPrism.cpp */,
+				405220C3246A629000D9AB4D /* CPyramid.cpp */,
+				405220CB246A629100D9AB4D /* CQuadrilateral.cpp */,
+				405220C9246A629100D9AB4D /* CTetrahedron.cpp */,
+				405220C4246A629100D9AB4D /* CTriangle.cpp */,
+				405220C7246A629100D9AB4D /* CVertexMPI.cpp */,
+			);
+			name = PrimalGrid;
+			sourceTree = "<group>";
+		};
+		405220AD246A622F00D9AB4D /* MeshReader */ = {
+			isa = PBXGroup;
+			children = (
+				405220BC246A628000D9AB4D /* CBoxMeshReaderFVM.cpp */,
+				405220B9246A628000D9AB4D /* CCGNSMeshReaderFVM.cpp */,
+				405220BB246A628000D9AB4D /* CMeshReaderFVM.cpp */,
+				405220BA246A628000D9AB4D /* CRectangularMeshReaderFVM.cpp */,
+				405220BD246A628000D9AB4D /* CSU2ASCIIMeshReaderFVM.cpp */,
+			);
+			name = MeshReader;
+			sourceTree = "<group>";
+		};
+		405220AE246A623500D9AB4D /* DualGrid */ = {
+			isa = PBXGroup;
+			children = (
+				405220B1246A626300D9AB4D /* CDualGrid.cpp */,
+				405220B3246A626400D9AB4D /* CEdge.cpp */,
+				405220B2246A626400D9AB4D /* CPoint.cpp */,
+				405220AF246A626300D9AB4D /* CTurboVertex.cpp */,
+				405220B0246A626300D9AB4D /* CVertex.cpp */,
+			);
+			name = DualGrid;
 			sourceTree = "<group>";
 		};
 		4063F84F246A042500DE870E /* Turbulent */ = {
@@ -1070,6 +1481,12 @@
 			children = (
 				E90B4FCF22DFDF93000ED392 /* CIncTGVSolution.cpp */,
 				E90B4FD222DFDF93000ED392 /* CInviscidVortexSolution.cpp */,
+				40303EB3246A5CEC00CD7789 /* CMMSIncEulerSolution.py */,
+				40303EB5246A5CEC00CD7789 /* CMMSIncNSSolution.py */,
+				40303EB1246A5CEC00CD7789 /* CMMSNSTwoHalfCirclesSolution.mw */,
+				40303EB2246A5CEC00CD7789 /* CMMSNSTwoHalfSpheresSolution.mw */,
+				40303EB4246A5CEC00CD7789 /* CMMSNSUnitQuadSolution.mw */,
+				40303EB6246A5CEC00CD7789 /* CMMSNSUnitQuadSolutionWallBC.mw */,
 				E90B4FD422DFDF93000ED392 /* CMMSIncEulerSolution.cpp */,
 				E90B4FCB22DFDF92000ED392 /* CMMSIncNSSolution.cpp */,
 				E90B4FD522DFDF93000ED392 /* CMMSNSTwoHalfCirclesSolution.cpp */,
@@ -1099,7 +1516,6 @@
 				E90B4FEF22DFDFE3000ED392 /* CEulerVariable.cpp */,
 				E90B4FF622DFDFE4000ED392 /* CFEABoundVariable.cpp */,
 				E90B4FF422DFDFE4000ED392 /* CFEAVariable.cpp */,
-				E90B4FEE22DFDFE3000ED392 /* CHeatFVMVariable.cpp */,
 				40303E5E246A064900CD7789 /* CHeatVariable.cpp */,
 				E90B4FE722DFDFE2000ED392 /* CIncEulerVariable.cpp */,
 				E90B4FED22DFDFE3000ED392 /* CIncNSVariable.cpp */,
@@ -1121,6 +1537,7 @@
 		E90B501322DFE060000ED392 /* LinearSolver */ = {
 			isa = PBXGroup;
 			children = (
+				40303EBB246A5D4800CD7789 /* CPastixWrapper.cpp */,
 				E90B500C22DFE042000ED392 /* CSysMatrix.cpp */,
 				E90B500D22DFE043000ED392 /* CSysSolve_b.cpp */,
 				E90B500E22DFE043000ED392 /* CSysSolve.cpp */,
@@ -1143,12 +1560,14 @@
 				E90B504522DFE4B8000ED392 /* CEulerVariable.hpp */,
 				E90B504322DFE4B7000ED392 /* CFEABoundVariable.hpp */,
 				E90B504A22DFE4B8000ED392 /* CFEAVariable.hpp */,
-				E90B504822DFE4B8000ED392 /* CHeatFVMVariable.hpp */,
+				40303EAE246A5BFC00CD7789 /* CHeatVariable.hpp */,
 				E90B504222DFE4B7000ED392 /* CIncEulerVariable.hpp */,
 				E90B504722DFE4B8000ED392 /* CIncNSVariable.hpp */,
 				E9D6EE822317B8CC00618E36 /* CMeshBoundVariable.hpp */,
 				E9D6EE7F2317B8CC00618E36 /* CMeshVariable.hpp */,
 				E90B504122DFE4B7000ED392 /* CNSVariable.hpp */,
+				40303EAC246A5BFC00CD7789 /* CRadP1Variable.hpp */,
+				40303EAD246A5BFC00CD7789 /* CRadVariable.hpp */,
 				E90B504D22DFE4B9000ED392 /* CTransLMVariable.hpp */,
 				E90B503F22DFE4B7000ED392 /* CTurbSAVariable.hpp */,
 				E90B503D22DFE4B7000ED392 /* CTurbSSTVariable.hpp */,
@@ -1162,6 +1581,7 @@
 			isa = PBXGroup;
 			children = (
 				E90B505422DFE541000ED392 /* CMatrixVectorProduct.hpp */,
+				40303ED8246A5E6400CD7789 /* CPastixWrapper.hpp */,
 				E90B505322DFE541000ED392 /* CPreconditioner.hpp */,
 				E90B505122DFE541000ED392 /* CSysMatrix.hpp */,
 				E90B505022DFE541000ED392 /* CSysSolve_b.hpp */,
@@ -1193,14 +1613,6 @@
 			);
 			name = datatypes;
 			path = ../../Common/include/datatypes;
-			sourceTree = "<group>";
-		};
-		E9D9CE841C62A16D004119E9 /* MultiZone */ = {
-			isa = PBXGroup;
-			children = (
-				E9D9CE851C62A1A7004119E9 /* interpolation_structure.cpp */,
-			);
-			name = MultiZone;
 			sourceTree = "<group>";
 		};
 		EB14FF9322F790320045FB27 /* Driver */ = {
@@ -1269,6 +1681,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				40303EBC246A5D4800CD7789 /* CPastixWrapper.cpp in Sources */,
 				4063F85A246A053400DE870E /* CParaviewVTMFileWriter.cpp in Sources */,
 				40303E50246A05EC00CD7789 /* CTurbSolver.cpp in Sources */,
 				4063F842246A03F800DE870E /* flow_diffusion.cpp in Sources */,
@@ -1276,23 +1689,24 @@
 				4063F858246A053400DE870E /* CSTLFileWriter.cpp in Sources */,
 				EB14FF9A22F790500045FB27 /* CDriver.cpp in Sources */,
 				356E2E3323999B140039E9B5 /* CPYRAM5.cpp in Sources */,
+				40303ECB246A5D9300CD7789 /* CInterpolatorFactory.cpp in Sources */,
 				E90B4FE222DFDF94000ED392 /* CMMSNSTwoHalfCirclesSolution.cpp in Sources */,
 				E90B500722DFDFE4000ED392 /* CNSVariable.cpp in Sources */,
-				05E6DB9217EB61E600FA1F7E /* config_structure.cpp in Sources */,
 				356E2E182399979F0039E9B5 /* CFEAElasticity.cpp in Sources */,
 				E96FAF142189FECA0046BF5D /* graph_coloring_structure.cpp in Sources */,
 				4040B27F235FBFF200843C83 /* CTecplotBinaryFileWriter.cpp in Sources */,
-				05E6DB9317EB61E600FA1F7E /* dual_grid_structure.cpp in Sources */,
 				40303E56246A05EC00CD7789 /* CBaselineSolver_FEM.cpp in Sources */,
 				E96FAF152189FECA0046BF5D /* fem_gauss_jacobi_quadrature.cpp in Sources */,
 				4040B261235FBEFD00843C83 /* CDiscAdjFlowTractionInterface.cpp in Sources */,
-				E9D6EE5D2316653200618E36 /* CSU2ASCIIMeshReaderFVM.cpp in Sources */,
+				405220D1246A629100D9AB4D /* CPrimalGridFEM.cpp in Sources */,
 				356E2E2E23999B140039E9B5 /* CTRIA1.cpp in Sources */,
 				E90B4FFE22DFDFE4000ED392 /* CAdjEulerVariable.cpp in Sources */,
 				4040B260235FBEFD00843C83 /* CFlowTractionInterface.cpp in Sources */,
 				E90B500522DFDFE4000ED392 /* CTransLMVariable.cpp in Sources */,
 				4063F84B246A03F800DE870E /* adj_sources.cpp in Sources */,
 				05E6DB9517EB61E600FA1F7E /* grid_adaptation_structure.cpp in Sources */,
+				405220C2246A628000D9AB4D /* CSU2ASCIIMeshReaderFVM.cpp in Sources */,
+				40303ECA246A5D9300CD7789 /* CRadialBasisFunction.cpp in Sources */,
 				E9E674342302A2E4009B6A25 /* CMultiGridQueue.cpp in Sources */,
 				E90B500322DFDFE4000ED392 /* CBaselineVariable.cpp in Sources */,
 				4040B27B235FBFF200843C83 /* CParallelDataSorter.cpp in Sources */,
@@ -1304,7 +1718,7 @@
 				E90B4FDF22DFDF94000ED392 /* CInviscidVortexSolution.cpp in Sources */,
 				4040B280235FBFF200843C83 /* CSU2FileWriter.cpp in Sources */,
 				4063F84A246A03F800DE870E /* centered.cpp in Sources */,
-				05E6DB9917EB61E600FA1F7E /* primal_grid_structure.cpp in Sources */,
+				405220C1246A628000D9AB4D /* CBoxMeshReaderFVM.cpp in Sources */,
 				E90B4FDC22DFDF94000ED392 /* CIncTGVSolution.cpp in Sources */,
 				E90B500622DFDFE4000ED392 /* CFEAVariable.cpp in Sources */,
 				05F8F2682008A1C8000FEA01 /* python_wrapper_structure.cpp in Sources */,
@@ -1317,26 +1731,26 @@
 				4063F843246A03F800DE870E /* CNumerics.cpp in Sources */,
 				E9D6EE782317B88F00618E36 /* CMeshVariable.cpp in Sources */,
 				403426CA235F83B2005B5215 /* CFlowCompOutput.cpp in Sources */,
-				E9E51ADD22FAB11800773E0C /* CCGNSMeshReaderFVM.cpp in Sources */,
 				40303E58246A05EC00CD7789 /* CTurbSSTSolver.cpp in Sources */,
-				E9E674372302A92C009B6A25 /* CRectangularMeshReaderFVM.cpp in Sources */,
 				40303E4E246A05EC00CD7789 /* CTransLMSolver.cpp in Sources */,
 				4063F840246A03F800DE870E /* hllc.cpp in Sources */,
 				40303E51246A05EC00CD7789 /* CIncEulerSolver.cpp in Sources */,
 				EB14FF9822F790500045FB27 /* CSinglezoneDriver.cpp in Sources */,
 				E90B4FE322DFDF94000ED392 /* CRinglebSolution.cpp in Sources */,
 				356E2E2423999AEA0039E9B5 /* CMultiGridGeometry.cpp in Sources */,
+				405220B7246A626400D9AB4D /* CPoint.cpp in Sources */,
 				4040B25F235FBEFD00843C83 /* CDisplacementsInterface.cpp in Sources */,
 				40303E59246A05EC00CD7789 /* CFEASolver.cpp in Sources */,
 				356E2E2D23999B140039E9B5 /* CElement.cpp in Sources */,
 				4063F847246A03F800DE870E /* nonlinear_models.cpp in Sources */,
 				E9D6EE572316522800618E36 /* (null) in Sources */,
 				05F1089B1978D2AE00F2F288 /* fluid_model_ppr.cpp in Sources */,
+				405220D5246A629100D9AB4D /* CPrism.cpp in Sources */,
 				05E6DC0517EB62A100FA1F7E /* iteration_structure.cpp in Sources */,
 				403426CC235F83B2005B5215 /* CFlowCompFEMOutput.cpp in Sources */,
+				405220D6246A629100D9AB4D /* CQuadrilateral.cpp in Sources */,
 				40303E63246A064900CD7789 /* CRadVariable.cpp in Sources */,
 				403426CB235F83B2005B5215 /* output_structure_legacy.cpp in Sources */,
-				E90B500022DFDFE4000ED392 /* CHeatFVMVariable.cpp in Sources */,
 				40303E4B246A05EC00CD7789 /* CTemplateSolver.cpp in Sources */,
 				E90B500922DFDFE4000ED392 /* CTurbSAVariable.cpp in Sources */,
 				05F108A41978D2F200F2F288 /* transport_model.cpp in Sources */,
@@ -1345,6 +1759,7 @@
 				4040B282235FBFF200843C83 /* CParaviewFileWriter.cpp in Sources */,
 				40303E46246A05EC00CD7789 /* CHeatSolver.cpp in Sources */,
 				E967669F237365CA009FBEE1 /* CMarkerProfileReaderFVM.cpp in Sources */,
+				405220B6246A626400D9AB4D /* CDualGrid.cpp in Sources */,
 				E9FDF6EA1D2DD0560066E49C /* adt_structure.cpp in Sources */,
 				4063F8192469E40B00DE870E /* CSingleGridIntegration.cpp in Sources */,
 				356E2E2223999AEA0039E9B5 /* CPhysicalGeometry.cpp in Sources */,
@@ -1364,6 +1779,8 @@
 				403426C8235F83B2005B5215 /* CAdjElasticityOutput.cpp in Sources */,
 				4040B265235FBEFD00843C83 /* CSlidingInterface.cpp in Sources */,
 				E90B4FD922DFDF94000ED392 /* CMMSNSUnitQuadSolutionWallBC.cpp in Sources */,
+				405220BE246A628000D9AB4D /* CCGNSMeshReaderFVM.cpp in Sources */,
+				40303EC6246A5D9300CD7789 /* CNearestNeighbor.cpp in Sources */,
 				40303E52246A05EC00CD7789 /* CRadP1Solver.cpp in Sources */,
 				E9D6EE762317B88F00618E36 /* CMeshElement.cpp in Sources */,
 				E90B4FFA22DFDFE4000ED392 /* CAdjTurbVariable.cpp in Sources */,
@@ -1371,45 +1788,53 @@
 				E90B4FD822DFDF94000ED392 /* CMMSIncNSSolution.cpp in Sources */,
 				4040B267235FBEFD00843C83 /* CInterface.cpp in Sources */,
 				E9D6EE752317B88F00618E36 /* CDiscAdjFEABoundVariable.cpp in Sources */,
-				E9D885A92303F8E400917362 /* CBoxMeshReaderFVM.cpp in Sources */,
+				405220D4246A629100D9AB4D /* CTetrahedron.cpp in Sources */,
 				40303E49246A05EC00CD7789 /* CDiscAdjFEASolver.cpp in Sources */,
 				4040B284235FBFF200843C83 /* CTecplotFileWriter.cpp in Sources */,
 				403426C9235F83B2005B5215 /* CElasticityOutput.cpp in Sources */,
 				40303E61246A064900CD7789 /* CHeatVariable.cpp in Sources */,
+				405220BF246A628000D9AB4D /* CRectangularMeshReaderFVM.cpp in Sources */,
+				40303EB9246A5D2700CD7789 /* C1DInterpolation.cpp in Sources */,
 				E9C830812061E60E004417A9 /* fem_standard_element.cpp in Sources */,
 				4063F81A2469E40B00DE870E /* CStructuralIntegration.cpp in Sources */,
 				403426ED235F8E29005B5215 /* CDiscAdjMultizoneDriver.cpp in Sources */,
 				E96FAF102189FE9C0046BF5D /* blas_structure.cpp in Sources */,
 				E90B4FFC22DFDFE4000ED392 /* CDiscAdjVariable.cpp in Sources */,
 				4063F8182469E40B00DE870E /* CMultiGridIntegration.cpp in Sources */,
+				405220B4246A626400D9AB4D /* CTurboVertex.cpp in Sources */,
 				E9C830822061E60E004417A9 /* fem_wall_distance.cpp in Sources */,
+				405220B8246A626400D9AB4D /* CEdge.cpp in Sources */,
 				40303E53246A05EC00CD7789 /* CBaselineSolver.cpp in Sources */,
 				E90B4FF922DFDFE4000ED392 /* CIncEulerVariable.cpp in Sources */,
 				40303E4A246A05EC00CD7789 /* CNSSolver.cpp in Sources */,
 				4063F83B246A03F800DE870E /* turb_convection.cpp in Sources */,
 				4063F848246A03F800DE870E /* cusp.cpp in Sources */,
+				405220C0246A628000D9AB4D /* CMeshReaderFVM.cpp in Sources */,
 				40303E47246A05EC00CD7789 /* CAdjEulerSolver.cpp in Sources */,
 				4063F81B2469E40B00DE870E /* CIntegrationFactory.cpp in Sources */,
 				E90B500122DFDFE4000ED392 /* CEulerVariable.cpp in Sources */,
 				E90B501022DFE043000ED392 /* CSysMatrix.cpp in Sources */,
+				405220D8246A629100D9AB4D /* CLine.cpp in Sources */,
 				E9C8307F2061E60E004417A9 /* fem_geometry_structure.cpp in Sources */,
 				E96FAF162189FECA0046BF5D /* fem_cgns_elements.cpp in Sources */,
-				E9E51AD922FA603800773E0C /* CMeshReaderFVM.cpp in Sources */,
 				4063F83C246A03F800DE870E /* adj_diffusion.cpp in Sources */,
 				E90B4FFF22DFDFE4000ED392 /* CIncNSVariable.cpp in Sources */,
 				4040B283235FBFF200843C83 /* CSurfaceFEMDataSorter.cpp in Sources */,
 				3599C5D32121FAC9003AAF05 /* wall_model.cpp in Sources */,
 				4040B278235FBFF200843C83 /* CCSVFileWriter.cpp in Sources */,
-				E9D9CE861C62A1A7004119E9 /* interpolation_structure.cpp in Sources */,
+				405220D2246A629100D9AB4D /* CVertexMPI.cpp in Sources */,
 				05F1089C1978D2AE00F2F288 /* fluid_model_pvdw.cpp in Sources */,
 				40303E5B246A05EC00CD7789 /* CFEM_DG_EulerSolver.cpp in Sources */,
 				4063F83E246A03F800DE870E /* heat.cpp in Sources */,
+				40303EBA246A5D2700CD7789 /* CSymmetricMatrix.cpp in Sources */,
 				E90B4FDB22DFDF94000ED392 /* CTGVSolution.cpp in Sources */,
 				E90B500822DFDFE4000ED392 /* CFEABoundVariable.cpp in Sources */,
 				403426CD235F83B2005B5215 /* CAdjFlowCompOutput.cpp in Sources */,
 				40303E4C246A05EC00CD7789 /* CDiscAdjSolver.cpp in Sources */,
 				403426D0235F83B2005B5215 /* CAdjHeatOutput.cpp in Sources */,
 				403426C2235F83B2005B5215 /* CAdjFlowIncOutput.cpp in Sources */,
+				40303EC7246A5D9300CD7789 /* CMirror.cpp in Sources */,
+				405220D7246A629100D9AB4D /* CPrimalGridBoundFEM.cpp in Sources */,
 				403426C3235F83B2005B5215 /* CFlowOutput.cpp in Sources */,
 				4063F83F246A03F800DE870E /* adj_convection.cpp in Sources */,
 				40303E57246A05EC00CD7789 /* CAdjNSSolver.cpp in Sources */,
@@ -1420,6 +1845,7 @@
 				4063F84C246A03F800DE870E /* flow_sources.cpp in Sources */,
 				4063F845246A03F800DE870E /* turb_sources.cpp in Sources */,
 				4040B27D235FBFF200843C83 /* CFEMDataSorter.cpp in Sources */,
+				405220CF246A629100D9AB4D /* CTriangle.cpp in Sources */,
 				4063F846246A03F800DE870E /* template.cpp in Sources */,
 				4040B27E235FBFF200843C83 /* CSU2BinaryFileWriter.cpp in Sources */,
 				E90B4FDE22DFDF94000ED392 /* CMMSNSTwoHalfSpheresSolution.cpp in Sources */,
@@ -1429,19 +1855,24 @@
 				40303E4F246A05EC00CD7789 /* CTurbSASolver.cpp in Sources */,
 				40303E4D246A05EC00CD7789 /* CAdjTurbSolver.cpp in Sources */,
 				E90B4FF822DFDFE4000ED392 /* CVariable.cpp in Sources */,
+				405220D3246A629100D9AB4D /* CPrimalGrid.cpp in Sources */,
 				4063F859246A053400DE870E /* COutputFactory.cpp in Sources */,
 				4040B262235FBEFD00843C83 /* CMixingPlaneInterface.cpp in Sources */,
 				356E2E3123999B140039E9B5 /* CTETRA1.cpp in Sources */,
 				E90B4FE122DFDF94000ED392 /* CMMSIncEulerSolution.cpp in Sources */,
 				4063F84E246A03F800DE870E /* ausm_slau.cpp in Sources */,
+				405220B5246A626400D9AB4D /* CVertex.cpp in Sources */,
 				E9C830852061E60E004417A9 /* geometry_structure_fem_part.cpp in Sources */,
 				E9D6EE672317B80600618E36 /* CMeshSolver.cpp in Sources */,
 				40303E62246A064900CD7789 /* CRadP1Variable.cpp in Sources */,
 				4063F844246A03F800DE870E /* fds.cpp in Sources */,
+				40303EC5246A5D9300CD7789 /* CInterpolator.cpp in Sources */,
 				E90B500222DFDFE4000ED392 /* CTurbSSTVariable.cpp in Sources */,
 				EB14FF9922F790500045FB27 /* CDiscAdjSinglezoneDriver.cpp in Sources */,
 				403426C4235F83B2005B5215 /* CFlowIncOutput.cpp in Sources */,
+				405220CE246A629100D9AB4D /* CPyramid.cpp in Sources */,
 				E941BB941B71D124005C6C06 /* mpi_structure.cpp in Sources */,
+				40303EB0246A5CC000CD7789 /* CConfig.cpp in Sources */,
 				403426C5235F83B2005B5215 /* CHeatOutput.cpp in Sources */,
 				4063F81C2469E40B00DE870E /* CIntegration.cpp in Sources */,
 				4063F84D246A03F800DE870E /* roe.cpp in Sources */,
@@ -1449,6 +1880,7 @@
 				EB14FF9B22F790500045FB27 /* CMultizoneDriver.cpp in Sources */,
 				356E2E2123999AEA0039E9B5 /* CGeometry.cpp in Sources */,
 				05E6DC3117EB62A100FA1F7E /* SU2_CFD.cpp in Sources */,
+				405220D0246A629100D9AB4D /* CHexahedron.cpp in Sources */,
 				40303E48246A05EC00CD7789 /* CIncNSSolver.cpp in Sources */,
 				356E2E2F23999B140039E9B5 /* CQUAD4.cpp in Sources */,
 				4040B279235FBFF200843C83 /* CSurfaceFVMDataSorter.cpp in Sources */,
@@ -1463,8 +1895,10 @@
 				4063F83D246A03F800DE870E /* fvs.cpp in Sources */,
 				E9D6EE722317B88F00618E36 /* CDiscAdjMeshBoundVariable.cpp in Sources */,
 				E90B4FFB22DFDFE4000ED392 /* CAdjNSVariable.cpp in Sources */,
+				40303EC8246A5D9300CD7789 /* CIsoparametric.cpp in Sources */,
 				403426C7235F83B2005B5215 /* CMeshOutput.cpp in Sources */,
 				E90B500F22DFE043000ED392 /* CSysVector.cpp in Sources */,
+				40303EC9246A5D9300CD7789 /* CSlidingMesh.cpp in Sources */,
 				E90B4FDA22DFDF94000ED392 /* CNSUnitQuadSolution.cpp in Sources */,
 				E9C830802061E60E004417A9 /* fem_integration_rules.cpp in Sources */,
 				E90B501222DFE043000ED392 /* CSysSolve.cpp in Sources */,

--- a/SU2_IDE/Xcode/SU2_CFD.xcodeproj/project.pbxproj
+++ b/SU2_IDE/Xcode/SU2_CFD.xcodeproj/project.pbxproj
@@ -7,32 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0530E56A17FDF7AC00733CE8 /* solver_direct_elasticity.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0530E56917FDF7AC00733CE8 /* solver_direct_elasticity.cpp */; };
 		05E6DB9217EB61E600FA1F7E /* config_structure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DB8917EB61E600FA1F7E /* config_structure.cpp */; };
 		05E6DB9317EB61E600FA1F7E /* dual_grid_structure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DB8A17EB61E600FA1F7E /* dual_grid_structure.cpp */; };
 		05E6DB9517EB61E600FA1F7E /* grid_adaptation_structure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DB8C17EB61E600FA1F7E /* grid_adaptation_structure.cpp */; };
 		05E6DB9617EB61E600FA1F7E /* grid_movement_structure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DB8D17EB61E600FA1F7E /* grid_movement_structure.cpp */; };
 		05E6DB9917EB61E600FA1F7E /* primal_grid_structure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DB9017EB61E600FA1F7E /* primal_grid_structure.cpp */; };
 		05E6DC0117EB62A100FA1F7E /* definition_structure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DBBC17EB62A000FA1F7E /* definition_structure.cpp */; };
-		05E6DC0317EB62A100FA1F7E /* integration_structure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DBBE17EB62A100FA1F7E /* integration_structure.cpp */; };
-		05E6DC0417EB62A100FA1F7E /* integration_time.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DBBF17EB62A100FA1F7E /* integration_time.cpp */; };
 		05E6DC0517EB62A100FA1F7E /* iteration_structure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DBC017EB62A100FA1F7E /* iteration_structure.cpp */; };
-		05E6DC0817EB62A100FA1F7E /* numerics_adjoint_mean.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DBC317EB62A100FA1F7E /* numerics_adjoint_mean.cpp */; };
-		05E6DC0B17EB62A100FA1F7E /* numerics_adjoint_turbulent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DBC617EB62A100FA1F7E /* numerics_adjoint_turbulent.cpp */; };
-		05E6DC0E17EB62A100FA1F7E /* numerics_direct_heat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DBC917EB62A100FA1F7E /* numerics_direct_heat.cpp */; };
-		05E6DC1017EB62A100FA1F7E /* numerics_direct_mean.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DBCB17EB62A100FA1F7E /* numerics_direct_mean.cpp */; };
-		05E6DC1317EB62A100FA1F7E /* numerics_direct_transition.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DBCE17EB62A100FA1F7E /* numerics_direct_transition.cpp */; };
-		05E6DC1417EB62A100FA1F7E /* numerics_direct_turbulent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DBCF17EB62A100FA1F7E /* numerics_direct_turbulent.cpp */; };
-		05E6DC1817EB62A100FA1F7E /* numerics_structure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DBD317EB62A100FA1F7E /* numerics_structure.cpp */; };
-		05E6DC1917EB62A100FA1F7E /* numerics_template.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DBD417EB62A100FA1F7E /* numerics_template.cpp */; };
-		05E6DC1F17EB62A100FA1F7E /* solver_adjoint_mean.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DBDA17EB62A100FA1F7E /* solver_adjoint_mean.cpp */; };
-		05E6DC2217EB62A100FA1F7E /* solver_adjoint_turbulent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DBDD17EB62A100FA1F7E /* solver_adjoint_turbulent.cpp */; };
-		05E6DC2517EB62A100FA1F7E /* solver_direct_heat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DBE017EB62A100FA1F7E /* solver_direct_heat.cpp */; };
-		05E6DC2717EB62A100FA1F7E /* solver_direct_mean.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DBE217EB62A100FA1F7E /* solver_direct_mean.cpp */; };
-		05E6DC2A17EB62A100FA1F7E /* solver_direct_transition.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DBE517EB62A100FA1F7E /* solver_direct_transition.cpp */; };
-		05E6DC2B17EB62A100FA1F7E /* solver_direct_turbulent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DBE617EB62A100FA1F7E /* solver_direct_turbulent.cpp */; };
-		05E6DC2F17EB62A100FA1F7E /* solver_structure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DBEA17EB62A100FA1F7E /* solver_structure.cpp */; };
-		05E6DC3017EB62A100FA1F7E /* solver_template.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DBEB17EB62A100FA1F7E /* solver_template.cpp */; };
 		05E6DC3117EB62A100FA1F7E /* SU2_CFD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05E6DBEC17EB62A100FA1F7E /* SU2_CFD.cpp */; };
 		05F1089A1978D2AE00F2F288 /* fluid_model_pig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05F108961978D2AE00F2F288 /* fluid_model_pig.cpp */; };
 		05F1089B1978D2AE00F2F288 /* fluid_model_ppr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05F108971978D2AE00F2F288 /* fluid_model_ppr.cpp */; };
@@ -42,12 +23,7 @@
 		05F8F2682008A1C8000FEA01 /* python_wrapper_structure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05F8F2672008A1C7000FEA01 /* python_wrapper_structure.cpp */; };
 		356E2E152399979F0039E9B5 /* CFEANonlinearElasticity.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 356E2E0D2399979F0039E9B5 /* CFEANonlinearElasticity.cpp */; };
 		356E2E162399979F0039E9B5 /* CFEALinearElasticity.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 356E2E0E2399979F0039E9B5 /* CFEALinearElasticity.cpp */; };
-		356E2E172399979F0039E9B5 /* CFEM_DielectricElastomer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 356E2E0F2399979F0039E9B5 /* CFEM_DielectricElastomer.cpp */; };
 		356E2E182399979F0039E9B5 /* CFEAElasticity.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 356E2E102399979F0039E9B5 /* CFEAElasticity.cpp */; };
-		356E2E192399979F0039E9B5 /* CFEAMeshElasticity.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 356E2E112399979F0039E9B5 /* CFEAMeshElasticity.cpp */; };
-		356E2E1A2399979F0039E9B5 /* CFEM_IdealDE.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 356E2E122399979F0039E9B5 /* CFEM_IdealDE.cpp */; };
-		356E2E1B2399979F0039E9B5 /* CFEM_Knowles_NearInc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 356E2E132399979F0039E9B5 /* CFEM_Knowles_NearInc.cpp */; };
-		356E2E1C2399979F0039E9B5 /* CFEM_NeoHookean_Comp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 356E2E142399979F0039E9B5 /* CFEM_NeoHookean_Comp.cpp */; };
 		356E2E2123999AEA0039E9B5 /* CGeometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 356E2E1D23999AEA0039E9B5 /* CGeometry.cpp */; };
 		356E2E2223999AEA0039E9B5 /* CPhysicalGeometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 356E2E1E23999AEA0039E9B5 /* CPhysicalGeometry.cpp */; };
 		356E2E2323999AEA0039E9B5 /* CDummyGeometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 356E2E1F23999AEA0039E9B5 /* CDummyGeometry.cpp */; };
@@ -61,6 +37,33 @@
 		356E2E3323999B140039E9B5 /* CPYRAM5.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 356E2E2C23999B140039E9B5 /* CPYRAM5.cpp */; };
 		3599C5D32121FAC9003AAF05 /* wall_model.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3599C5D12121FAC9003AAF05 /* wall_model.cpp */; };
 		400CEC2E21FA81A10019B790 /* printing_toolbox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 400CEC2D21FA81A10019B790 /* printing_toolbox.cpp */; };
+		40303E46246A05EC00CD7789 /* CHeatSolver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E2E246A05EB00CD7789 /* CHeatSolver.cpp */; };
+		40303E47246A05EC00CD7789 /* CAdjEulerSolver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E2F246A05EB00CD7789 /* CAdjEulerSolver.cpp */; };
+		40303E48246A05EC00CD7789 /* CIncNSSolver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E30246A05EB00CD7789 /* CIncNSSolver.cpp */; };
+		40303E49246A05EC00CD7789 /* CDiscAdjFEASolver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E31246A05EB00CD7789 /* CDiscAdjFEASolver.cpp */; };
+		40303E4A246A05EC00CD7789 /* CNSSolver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E32246A05EB00CD7789 /* CNSSolver.cpp */; };
+		40303E4B246A05EC00CD7789 /* CTemplateSolver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E33246A05EC00CD7789 /* CTemplateSolver.cpp */; };
+		40303E4C246A05EC00CD7789 /* CDiscAdjSolver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E34246A05EC00CD7789 /* CDiscAdjSolver.cpp */; };
+		40303E4D246A05EC00CD7789 /* CAdjTurbSolver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E35246A05EC00CD7789 /* CAdjTurbSolver.cpp */; };
+		40303E4E246A05EC00CD7789 /* CTransLMSolver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E36246A05EC00CD7789 /* CTransLMSolver.cpp */; };
+		40303E4F246A05EC00CD7789 /* CTurbSASolver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E37246A05EC00CD7789 /* CTurbSASolver.cpp */; };
+		40303E50246A05EC00CD7789 /* CTurbSolver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E38246A05EC00CD7789 /* CTurbSolver.cpp */; };
+		40303E51246A05EC00CD7789 /* CIncEulerSolver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E39246A05EC00CD7789 /* CIncEulerSolver.cpp */; };
+		40303E52246A05EC00CD7789 /* CRadP1Solver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E3A246A05EC00CD7789 /* CRadP1Solver.cpp */; };
+		40303E53246A05EC00CD7789 /* CBaselineSolver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E3B246A05EC00CD7789 /* CBaselineSolver.cpp */; };
+		40303E54246A05EC00CD7789 /* CRadSolver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E3C246A05EC00CD7789 /* CRadSolver.cpp */; };
+		40303E55246A05EC00CD7789 /* CEulerSolver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E3D246A05EC00CD7789 /* CEulerSolver.cpp */; };
+		40303E56246A05EC00CD7789 /* CBaselineSolver_FEM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E3E246A05EC00CD7789 /* CBaselineSolver_FEM.cpp */; };
+		40303E57246A05EC00CD7789 /* CAdjNSSolver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E3F246A05EC00CD7789 /* CAdjNSSolver.cpp */; };
+		40303E58246A05EC00CD7789 /* CTurbSSTSolver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E40246A05EC00CD7789 /* CTurbSSTSolver.cpp */; };
+		40303E59246A05EC00CD7789 /* CFEASolver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E41246A05EC00CD7789 /* CFEASolver.cpp */; };
+		40303E5A246A05EC00CD7789 /* CFEM_DG_NSSolver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E42246A05EC00CD7789 /* CFEM_DG_NSSolver.cpp */; };
+		40303E5B246A05EC00CD7789 /* CFEM_DG_EulerSolver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E43246A05EC00CD7789 /* CFEM_DG_EulerSolver.cpp */; };
+		40303E5C246A05EC00CD7789 /* CSolver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E44246A05EC00CD7789 /* CSolver.cpp */; };
+		40303E5D246A05EC00CD7789 /* CSolverFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E45246A05EC00CD7789 /* CSolverFactory.cpp */; };
+		40303E61246A064900CD7789 /* CHeatVariable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E5E246A064900CD7789 /* CHeatVariable.cpp */; };
+		40303E62246A064900CD7789 /* CRadP1Variable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E5F246A064900CD7789 /* CRadP1Variable.cpp */; };
+		40303E63246A064900CD7789 /* CRadVariable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40303E60246A064900CD7789 /* CRadVariable.cpp */; };
 		403426C2235F83B2005B5215 /* CAdjFlowIncOutput.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 403426B2235F83B1005B5215 /* CAdjFlowIncOutput.cpp */; };
 		403426C3235F83B2005B5215 /* CFlowOutput.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 403426B3235F83B1005B5215 /* CFlowOutput.cpp */; };
 		403426C4235F83B2005B5215 /* CFlowIncOutput.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 403426B4235F83B1005B5215 /* CFlowIncOutput.cpp */; };
@@ -78,12 +81,10 @@
 		403426D0235F83B2005B5215 /* CAdjHeatOutput.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 403426C0235F83B2005B5215 /* CAdjHeatOutput.cpp */; };
 		403426D1235F83B2005B5215 /* CBaselineOutput.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 403426C1235F83B2005B5215 /* CBaselineOutput.cpp */; };
 		403426ED235F8E29005B5215 /* CDiscAdjMultizoneDriver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 403426EC235F8E29005B5215 /* CDiscAdjMultizoneDriver.cpp */; };
-		4040B25E235FBEFD00843C83 /* CDisplacementsInterfaceLegacy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4040B254235FBEFD00843C83 /* CDisplacementsInterfaceLegacy.cpp */; };
 		4040B25F235FBEFD00843C83 /* CDisplacementsInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4040B255235FBEFD00843C83 /* CDisplacementsInterface.cpp */; };
 		4040B260235FBEFD00843C83 /* CFlowTractionInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4040B256235FBEFD00843C83 /* CFlowTractionInterface.cpp */; };
 		4040B261235FBEFD00843C83 /* CDiscAdjFlowTractionInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4040B257235FBEFD00843C83 /* CDiscAdjFlowTractionInterface.cpp */; };
 		4040B262235FBEFD00843C83 /* CMixingPlaneInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4040B258235FBEFD00843C83 /* CMixingPlaneInterface.cpp */; };
-		4040B263235FBEFD00843C83 /* CDiscAdjDisplacementsInterfaceLegacy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4040B259235FBEFD00843C83 /* CDiscAdjDisplacementsInterfaceLegacy.cpp */; };
 		4040B264235FBEFD00843C83 /* CConjugateHeatInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4040B25A235FBEFD00843C83 /* CConjugateHeatInterface.cpp */; };
 		4040B265235FBEFD00843C83 /* CSlidingInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4040B25B235FBEFD00843C83 /* CSlidingInterface.cpp */; };
 		4040B266235FBEFD00843C83 /* CConservativeVarsInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4040B25C235FBEFD00843C83 /* CConservativeVarsInterface.cpp */; };
@@ -102,6 +103,39 @@
 		4040B283235FBFF200843C83 /* CSurfaceFEMDataSorter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4040B275235FBFF200843C83 /* CSurfaceFEMDataSorter.cpp */; };
 		4040B284235FBFF200843C83 /* CTecplotFileWriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4040B276235FBFF200843C83 /* CTecplotFileWriter.cpp */; };
 		4040B285235FBFF200843C83 /* CSU2MeshFileWriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4040B277235FBFF200843C83 /* CSU2MeshFileWriter.cpp */; };
+		4063F8182469E40B00DE870E /* CMultiGridIntegration.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F8122469E40A00DE870E /* CMultiGridIntegration.cpp */; };
+		4063F8192469E40B00DE870E /* CSingleGridIntegration.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F8132469E40A00DE870E /* CSingleGridIntegration.cpp */; };
+		4063F81A2469E40B00DE870E /* CStructuralIntegration.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F8142469E40A00DE870E /* CStructuralIntegration.cpp */; };
+		4063F81B2469E40B00DE870E /* CIntegrationFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F8152469E40A00DE870E /* CIntegrationFactory.cpp */; };
+		4063F81C2469E40B00DE870E /* CIntegration.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F8162469E40A00DE870E /* CIntegration.cpp */; };
+		4063F81D2469E40B00DE870E /* CFEM_DG_Integration.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F8172469E40A00DE870E /* CFEM_DG_Integration.cpp */; };
+		4063F824246A03AE00DE870E /* CLimiterDetails.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F823246A03AE00DE870E /* CLimiterDetails.cpp */; };
+		4063F83A246A03F800DE870E /* transition.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F825246A03F700DE870E /* transition.cpp */; };
+		4063F83B246A03F800DE870E /* turb_convection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F826246A03F700DE870E /* turb_convection.cpp */; };
+		4063F83C246A03F800DE870E /* adj_diffusion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F827246A03F700DE870E /* adj_diffusion.cpp */; };
+		4063F83D246A03F800DE870E /* fvs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F828246A03F700DE870E /* fvs.cpp */; };
+		4063F83E246A03F800DE870E /* heat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F829246A03F700DE870E /* heat.cpp */; };
+		4063F83F246A03F800DE870E /* adj_convection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F82A246A03F700DE870E /* adj_convection.cpp */; };
+		4063F840246A03F800DE870E /* hllc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F82B246A03F700DE870E /* hllc.cpp */; };
+		4063F841246A03F800DE870E /* turb_diffusion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F82C246A03F700DE870E /* turb_diffusion.cpp */; };
+		4063F842246A03F800DE870E /* flow_diffusion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F82D246A03F700DE870E /* flow_diffusion.cpp */; };
+		4063F843246A03F800DE870E /* CNumerics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F82E246A03F700DE870E /* CNumerics.cpp */; };
+		4063F844246A03F800DE870E /* fds.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F82F246A03F700DE870E /* fds.cpp */; };
+		4063F845246A03F800DE870E /* turb_sources.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F830246A03F700DE870E /* turb_sources.cpp */; };
+		4063F846246A03F800DE870E /* template.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F831246A03F700DE870E /* template.cpp */; };
+		4063F847246A03F800DE870E /* nonlinear_models.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F832246A03F700DE870E /* nonlinear_models.cpp */; };
+		4063F848246A03F800DE870E /* cusp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F833246A03F700DE870E /* cusp.cpp */; };
+		4063F849246A03F800DE870E /* radiation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F834246A03F700DE870E /* radiation.cpp */; };
+		4063F84A246A03F800DE870E /* centered.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F835246A03F700DE870E /* centered.cpp */; };
+		4063F84B246A03F800DE870E /* adj_sources.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F836246A03F700DE870E /* adj_sources.cpp */; };
+		4063F84C246A03F800DE870E /* flow_sources.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F837246A03F800DE870E /* flow_sources.cpp */; };
+		4063F84D246A03F800DE870E /* roe.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F838246A03F800DE870E /* roe.cpp */; };
+		4063F84E246A03F800DE870E /* ausm_slau.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F839246A03F800DE870E /* ausm_slau.cpp */; };
+		4063F857246A053400DE870E /* CParaviewXMLFileWriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F852246A053400DE870E /* CParaviewXMLFileWriter.cpp */; };
+		4063F858246A053400DE870E /* CSTLFileWriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F853246A053400DE870E /* CSTLFileWriter.cpp */; };
+		4063F859246A053400DE870E /* COutputFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F854246A053400DE870E /* COutputFactory.cpp */; };
+		4063F85A246A053400DE870E /* CParaviewVTMFileWriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F855246A053400DE870E /* CParaviewVTMFileWriter.cpp */; };
+		4063F85B246A053400DE870E /* CWindowingTools.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4063F856246A053400DE870E /* CWindowingTools.cpp */; };
 		E90B4FD822DFDF94000ED392 /* CMMSIncNSSolution.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E90B4FCB22DFDF92000ED392 /* CMMSIncNSSolution.cpp */; };
 		E90B4FD922DFDF94000ED392 /* CMMSNSUnitQuadSolutionWallBC.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E90B4FCC22DFDF93000ED392 /* CMMSNSUnitQuadSolutionWallBC.cpp */; };
 		E90B4FDA22DFDF94000ED392 /* CNSUnitQuadSolution.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E90B4FCD22DFDF93000ED392 /* CNSUnitQuadSolution.cpp */; };
@@ -138,8 +172,6 @@
 		E90B501122DFE043000ED392 /* CSysSolve_b.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E90B500D22DFE043000ED392 /* CSysSolve_b.cpp */; };
 		E90B501222DFE043000ED392 /* CSysSolve.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E90B500E22DFE043000ED392 /* CSysSolve.cpp */; };
 		E90D35F7203F9C5800A3290D /* fluid_model_inc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E90D35F6203F9C5800A3290D /* fluid_model_inc.cpp */; };
-		E9225F761FCBC36D002F3682 /* solver_adjoint_elasticity.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9225F741FCBC36D002F3682 /* solver_adjoint_elasticity.cpp */; };
-		E941BB8E1B71D0D0005C6C06 /* solver_adjoint_discrete.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E941BB8D1B71D0D0005C6C06 /* solver_adjoint_discrete.cpp */; };
 		E941BB941B71D124005C6C06 /* mpi_structure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E941BB911B71D124005C6C06 /* mpi_structure.cpp */; };
 		E967669F237365CA009FBEE1 /* CMarkerProfileReaderFVM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E967669E237365CA009FBEE1 /* CMarkerProfileReaderFVM.cpp */; };
 		E96FAF102189FE9C0046BF5D /* blas_structure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E96FAF0F2189FE9C0046BF5D /* blas_structure.cpp */; };
@@ -152,7 +184,6 @@
 		E9C830822061E60E004417A9 /* fem_wall_distance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9C830782061E60E004417A9 /* fem_wall_distance.cpp */; };
 		E9C830832061E60E004417A9 /* fem_work_estimate_metis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9C830792061E60E004417A9 /* fem_work_estimate_metis.cpp */; };
 		E9C830852061E60E004417A9 /* geometry_structure_fem_part.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9C8307B2061E60E004417A9 /* geometry_structure_fem_part.cpp */; };
-		E9C830932061E799004417A9 /* solver_direct_mean_fem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9C830922061E799004417A9 /* solver_direct_mean_fem.cpp */; };
 		E9D6EE572316522800618E36 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		E9D6EE5A23165FD300618E36 /* CDummyDriver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9D6EE5923165FD300618E36 /* CDummyDriver.cpp */; };
 		E9D6EE5D2316653200618E36 /* CSU2ASCIIMeshReaderFVM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9D6EE5C2316653100618E36 /* CSU2ASCIIMeshReaderFVM.cpp */; };
@@ -171,8 +202,6 @@
 		E9E51ADD22FAB11800773E0C /* CCGNSMeshReaderFVM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9E51ADC22FAB11700773E0C /* CCGNSMeshReaderFVM.cpp */; };
 		E9E674342302A2E4009B6A25 /* CMultiGridQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9E674332302A2E3009B6A25 /* CMultiGridQueue.cpp */; };
 		E9E674372302A92C009B6A25 /* CRectangularMeshReaderFVM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9E674362302A92C009B6A25 /* CRectangularMeshReaderFVM.cpp */; };
-		E9F130CC1D513DA300EC8963 /* numerics_direct_mean_inc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9F130C61D513DA300EC8963 /* numerics_direct_mean_inc.cpp */; };
-		E9F130CE1D513DA300EC8963 /* solver_direct_mean_inc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9F130C81D513DA300EC8963 /* solver_direct_mean_inc.cpp */; };
 		E9FDF6EA1D2DD0560066E49C /* adt_structure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E9FDF6E91D2DD0560066E49C /* adt_structure.cpp */; };
 		EB14FF9822F790500045FB27 /* CSinglezoneDriver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB14FF9422F790500045FB27 /* CSinglezoneDriver.cpp */; };
 		EB14FF9922F790500045FB27 /* CDiscAdjSinglezoneDriver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB14FF9522F790500045FB27 /* CDiscAdjSinglezoneDriver.cpp */; };
@@ -193,7 +222,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		0530E56917FDF7AC00733CE8 /* solver_direct_elasticity.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = solver_direct_elasticity.cpp; path = ../../SU2_CFD/src/solver_direct_elasticity.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		0541ABEE1370F5A6002D668B /* SU2_CFD */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = SU2_CFD; sourceTree = BUILT_PRODUCTS_DIR; };
 		05E6DA9F17EB603F00FA1F7E /* config_structure.inl */ = {isa = PBXFileReference; lastKnownFileType = text; lineEnding = 0; name = config_structure.inl; path = ../../Common/include/config_structure.inl; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		05E6DAA017EB603F00FA1F7E /* dual_grid_structure.inl */ = {isa = PBXFileReference; lastKnownFileType = text; lineEnding = 0; name = dual_grid_structure.inl; path = ../../Common/include/dual_grid_structure.inl; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
@@ -201,7 +229,6 @@
 		05E6DAA317EB603F00FA1F7E /* grid_movement_structure.inl */ = {isa = PBXFileReference; lastKnownFileType = text; lineEnding = 0; name = grid_movement_structure.inl; path = ../../Common/include/grid_movement_structure.inl; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		05E6DAA617EB603F00FA1F7E /* primal_grid_structure.inl */ = {isa = PBXFileReference; lastKnownFileType = text; lineEnding = 0; name = primal_grid_structure.inl; path = ../../Common/include/primal_grid_structure.inl; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		05E6DAC517EB608000FA1F7E /* config_structure.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; lineEnding = 0; name = config_structure.hpp; path = ../../Common/include/config_structure.hpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DAC617EB608000FA1F7E /* dual_grid_structure.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; lineEnding = 0; name = dual_grid_structure.hpp; path = ../../Common/include/dual_grid_structure.hpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		05E6DAC817EB608000FA1F7E /* grid_adaptation_structure.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; lineEnding = 0; name = grid_adaptation_structure.hpp; path = ../../Common/include/grid_adaptation_structure.hpp; sourceTree = "<group>"; };
 		05E6DAC917EB608000FA1F7E /* grid_movement_structure.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; lineEnding = 0; name = grid_movement_structure.hpp; path = ../../Common/include/grid_movement_structure.hpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		05E6DACC17EB608000FA1F7E /* option_structure.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; lineEnding = 0; name = option_structure.hpp; path = ../../Common/include/option_structure.hpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
@@ -221,25 +248,7 @@
 		05E6DBB917EB627400FA1F7E /* solver_structure.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; lineEnding = 0; name = solver_structure.hpp; path = ../../SU2_CFD/include/solver_structure.hpp; sourceTree = "<group>"; };
 		05E6DBBA17EB627400FA1F7E /* SU2_CFD.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; lineEnding = 0; name = SU2_CFD.hpp; path = ../../SU2_CFD/include/SU2_CFD.hpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		05E6DBBC17EB62A000FA1F7E /* definition_structure.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = definition_structure.cpp; path = ../../SU2_CFD/src/definition_structure.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DBBE17EB62A100FA1F7E /* integration_structure.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = integration_structure.cpp; path = ../../SU2_CFD/src/integration_structure.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DBBF17EB62A100FA1F7E /* integration_time.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = integration_time.cpp; path = ../../SU2_CFD/src/integration_time.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		05E6DBC017EB62A100FA1F7E /* iteration_structure.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = iteration_structure.cpp; path = ../../SU2_CFD/src/iteration_structure.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DBC317EB62A100FA1F7E /* numerics_adjoint_mean.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = numerics_adjoint_mean.cpp; path = ../../SU2_CFD/src/numerics_adjoint_mean.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DBC617EB62A100FA1F7E /* numerics_adjoint_turbulent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = numerics_adjoint_turbulent.cpp; path = ../../SU2_CFD/src/numerics_adjoint_turbulent.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DBC917EB62A100FA1F7E /* numerics_direct_heat.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = numerics_direct_heat.cpp; path = ../../SU2_CFD/src/numerics_direct_heat.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DBCB17EB62A100FA1F7E /* numerics_direct_mean.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = numerics_direct_mean.cpp; path = ../../SU2_CFD/src/numerics_direct_mean.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DBCE17EB62A100FA1F7E /* numerics_direct_transition.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = numerics_direct_transition.cpp; path = ../../SU2_CFD/src/numerics_direct_transition.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DBCF17EB62A100FA1F7E /* numerics_direct_turbulent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = numerics_direct_turbulent.cpp; path = ../../SU2_CFD/src/numerics_direct_turbulent.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DBD317EB62A100FA1F7E /* numerics_structure.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = numerics_structure.cpp; path = ../../SU2_CFD/src/numerics_structure.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DBD417EB62A100FA1F7E /* numerics_template.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = numerics_template.cpp; path = ../../SU2_CFD/src/numerics_template.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DBDA17EB62A100FA1F7E /* solver_adjoint_mean.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = solver_adjoint_mean.cpp; path = ../../SU2_CFD/src/solver_adjoint_mean.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DBDD17EB62A100FA1F7E /* solver_adjoint_turbulent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = solver_adjoint_turbulent.cpp; path = ../../SU2_CFD/src/solver_adjoint_turbulent.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DBE017EB62A100FA1F7E /* solver_direct_heat.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = solver_direct_heat.cpp; path = ../../SU2_CFD/src/solver_direct_heat.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DBE217EB62A100FA1F7E /* solver_direct_mean.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = solver_direct_mean.cpp; path = ../../SU2_CFD/src/solver_direct_mean.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DBE517EB62A100FA1F7E /* solver_direct_transition.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = solver_direct_transition.cpp; path = ../../SU2_CFD/src/solver_direct_transition.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DBE617EB62A100FA1F7E /* solver_direct_turbulent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = solver_direct_turbulent.cpp; path = ../../SU2_CFD/src/solver_direct_turbulent.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
-		05E6DBEA17EB62A100FA1F7E /* solver_structure.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = solver_structure.cpp; path = ../../SU2_CFD/src/solver_structure.cpp; sourceTree = "<group>"; };
-		05E6DBEB17EB62A100FA1F7E /* solver_template.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = solver_template.cpp; path = ../../SU2_CFD/src/solver_template.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		05E6DBEC17EB62A100FA1F7E /* SU2_CFD.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = SU2_CFD.cpp; path = ../../SU2_CFD/src/SU2_CFD.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		05F108961978D2AE00F2F288 /* fluid_model_pig.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = fluid_model_pig.cpp; path = ../../SU2_CFD/src/fluid_model_pig.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		05F108971978D2AE00F2F288 /* fluid_model_ppr.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = fluid_model_ppr.cpp; path = ../../SU2_CFD/src/fluid_model_ppr.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
@@ -255,12 +264,7 @@
 		355D2C9E2172BDE100C10535 /* sgs_model.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = sgs_model.hpp; path = ../../SU2_CFD/include/sgs_model.hpp; sourceTree = "<group>"; };
 		356E2E0D2399979F0039E9B5 /* CFEANonlinearElasticity.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CFEANonlinearElasticity.cpp; path = ../../SU2_CFD/src/numerics/elasticity/CFEANonlinearElasticity.cpp; sourceTree = "<group>"; };
 		356E2E0E2399979F0039E9B5 /* CFEALinearElasticity.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CFEALinearElasticity.cpp; path = ../../SU2_CFD/src/numerics/elasticity/CFEALinearElasticity.cpp; sourceTree = "<group>"; };
-		356E2E0F2399979F0039E9B5 /* CFEM_DielectricElastomer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CFEM_DielectricElastomer.cpp; path = ../../SU2_CFD/src/numerics/elasticity/CFEM_DielectricElastomer.cpp; sourceTree = "<group>"; };
 		356E2E102399979F0039E9B5 /* CFEAElasticity.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CFEAElasticity.cpp; path = ../../SU2_CFD/src/numerics/elasticity/CFEAElasticity.cpp; sourceTree = "<group>"; };
-		356E2E112399979F0039E9B5 /* CFEAMeshElasticity.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CFEAMeshElasticity.cpp; path = ../../SU2_CFD/src/numerics/elasticity/CFEAMeshElasticity.cpp; sourceTree = "<group>"; };
-		356E2E122399979F0039E9B5 /* CFEM_IdealDE.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CFEM_IdealDE.cpp; path = ../../SU2_CFD/src/numerics/elasticity/CFEM_IdealDE.cpp; sourceTree = "<group>"; };
-		356E2E132399979F0039E9B5 /* CFEM_Knowles_NearInc.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CFEM_Knowles_NearInc.cpp; path = ../../SU2_CFD/src/numerics/elasticity/CFEM_Knowles_NearInc.cpp; sourceTree = "<group>"; };
-		356E2E142399979F0039E9B5 /* CFEM_NeoHookean_Comp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CFEM_NeoHookean_Comp.cpp; path = ../../SU2_CFD/src/numerics/elasticity/CFEM_NeoHookean_Comp.cpp; sourceTree = "<group>"; };
 		356E2E1D23999AEA0039E9B5 /* CGeometry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CGeometry.cpp; path = ../../Common/src/geometry/CGeometry.cpp; sourceTree = "<group>"; };
 		356E2E1E23999AEA0039E9B5 /* CPhysicalGeometry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CPhysicalGeometry.cpp; path = ../../Common/src/geometry/CPhysicalGeometry.cpp; sourceTree = "<group>"; };
 		356E2E1F23999AEA0039E9B5 /* CDummyGeometry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CDummyGeometry.cpp; path = ../../Common/src/geometry/CDummyGeometry.cpp; sourceTree = "<group>"; };
@@ -277,6 +281,33 @@
 		3599C5D62121FAF4003AAF05 /* wall_model.inl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = wall_model.inl; path = ../../Common/include/wall_model.inl; sourceTree = "<group>"; };
 		400CEC2D21FA81A10019B790 /* printing_toolbox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = printing_toolbox.cpp; path = ../../Common/src/toolboxes/printing_toolbox.cpp; sourceTree = "<group>"; };
 		400CEC2F21FA81B60019B790 /* printing_toolbox.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = printing_toolbox.hpp; path = ../../Common/include/toolboxes/printing_toolbox.hpp; sourceTree = "<group>"; };
+		40303E2E246A05EB00CD7789 /* CHeatSolver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CHeatSolver.cpp; path = ../../SU2_CFD/src/solvers/CHeatSolver.cpp; sourceTree = "<group>"; };
+		40303E2F246A05EB00CD7789 /* CAdjEulerSolver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CAdjEulerSolver.cpp; path = ../../SU2_CFD/src/solvers/CAdjEulerSolver.cpp; sourceTree = "<group>"; };
+		40303E30246A05EB00CD7789 /* CIncNSSolver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CIncNSSolver.cpp; path = ../../SU2_CFD/src/solvers/CIncNSSolver.cpp; sourceTree = "<group>"; };
+		40303E31246A05EB00CD7789 /* CDiscAdjFEASolver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CDiscAdjFEASolver.cpp; path = ../../SU2_CFD/src/solvers/CDiscAdjFEASolver.cpp; sourceTree = "<group>"; };
+		40303E32246A05EB00CD7789 /* CNSSolver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CNSSolver.cpp; path = ../../SU2_CFD/src/solvers/CNSSolver.cpp; sourceTree = "<group>"; };
+		40303E33246A05EC00CD7789 /* CTemplateSolver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CTemplateSolver.cpp; path = ../../SU2_CFD/src/solvers/CTemplateSolver.cpp; sourceTree = "<group>"; };
+		40303E34246A05EC00CD7789 /* CDiscAdjSolver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CDiscAdjSolver.cpp; path = ../../SU2_CFD/src/solvers/CDiscAdjSolver.cpp; sourceTree = "<group>"; };
+		40303E35246A05EC00CD7789 /* CAdjTurbSolver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CAdjTurbSolver.cpp; path = ../../SU2_CFD/src/solvers/CAdjTurbSolver.cpp; sourceTree = "<group>"; };
+		40303E36246A05EC00CD7789 /* CTransLMSolver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CTransLMSolver.cpp; path = ../../SU2_CFD/src/solvers/CTransLMSolver.cpp; sourceTree = "<group>"; };
+		40303E37246A05EC00CD7789 /* CTurbSASolver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CTurbSASolver.cpp; path = ../../SU2_CFD/src/solvers/CTurbSASolver.cpp; sourceTree = "<group>"; };
+		40303E38246A05EC00CD7789 /* CTurbSolver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CTurbSolver.cpp; path = ../../SU2_CFD/src/solvers/CTurbSolver.cpp; sourceTree = "<group>"; };
+		40303E39246A05EC00CD7789 /* CIncEulerSolver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CIncEulerSolver.cpp; path = ../../SU2_CFD/src/solvers/CIncEulerSolver.cpp; sourceTree = "<group>"; };
+		40303E3A246A05EC00CD7789 /* CRadP1Solver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CRadP1Solver.cpp; path = ../../SU2_CFD/src/solvers/CRadP1Solver.cpp; sourceTree = "<group>"; };
+		40303E3B246A05EC00CD7789 /* CBaselineSolver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CBaselineSolver.cpp; path = ../../SU2_CFD/src/solvers/CBaselineSolver.cpp; sourceTree = "<group>"; };
+		40303E3C246A05EC00CD7789 /* CRadSolver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CRadSolver.cpp; path = ../../SU2_CFD/src/solvers/CRadSolver.cpp; sourceTree = "<group>"; };
+		40303E3D246A05EC00CD7789 /* CEulerSolver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CEulerSolver.cpp; path = ../../SU2_CFD/src/solvers/CEulerSolver.cpp; sourceTree = "<group>"; };
+		40303E3E246A05EC00CD7789 /* CBaselineSolver_FEM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CBaselineSolver_FEM.cpp; path = ../../SU2_CFD/src/solvers/CBaselineSolver_FEM.cpp; sourceTree = "<group>"; };
+		40303E3F246A05EC00CD7789 /* CAdjNSSolver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CAdjNSSolver.cpp; path = ../../SU2_CFD/src/solvers/CAdjNSSolver.cpp; sourceTree = "<group>"; };
+		40303E40246A05EC00CD7789 /* CTurbSSTSolver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CTurbSSTSolver.cpp; path = ../../SU2_CFD/src/solvers/CTurbSSTSolver.cpp; sourceTree = "<group>"; };
+		40303E41246A05EC00CD7789 /* CFEASolver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CFEASolver.cpp; path = ../../SU2_CFD/src/solvers/CFEASolver.cpp; sourceTree = "<group>"; };
+		40303E42246A05EC00CD7789 /* CFEM_DG_NSSolver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CFEM_DG_NSSolver.cpp; path = ../../SU2_CFD/src/solvers/CFEM_DG_NSSolver.cpp; sourceTree = "<group>"; };
+		40303E43246A05EC00CD7789 /* CFEM_DG_EulerSolver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CFEM_DG_EulerSolver.cpp; path = ../../SU2_CFD/src/solvers/CFEM_DG_EulerSolver.cpp; sourceTree = "<group>"; };
+		40303E44246A05EC00CD7789 /* CSolver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CSolver.cpp; path = ../../SU2_CFD/src/solvers/CSolver.cpp; sourceTree = "<group>"; };
+		40303E45246A05EC00CD7789 /* CSolverFactory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CSolverFactory.cpp; path = ../../SU2_CFD/src/solvers/CSolverFactory.cpp; sourceTree = "<group>"; };
+		40303E5E246A064900CD7789 /* CHeatVariable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CHeatVariable.cpp; path = ../../SU2_CFD/src/variables/CHeatVariable.cpp; sourceTree = "<group>"; };
+		40303E5F246A064900CD7789 /* CRadP1Variable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CRadP1Variable.cpp; path = ../../SU2_CFD/src/variables/CRadP1Variable.cpp; sourceTree = "<group>"; };
+		40303E60246A064900CD7789 /* CRadVariable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CRadVariable.cpp; path = ../../SU2_CFD/src/variables/CRadVariable.cpp; sourceTree = "<group>"; };
 		403426B2235F83B1005B5215 /* CAdjFlowIncOutput.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CAdjFlowIncOutput.cpp; path = ../../SU2_CFD/src/output/CAdjFlowIncOutput.cpp; sourceTree = "<group>"; };
 		403426B3235F83B1005B5215 /* CFlowOutput.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CFlowOutput.cpp; path = ../../SU2_CFD/src/output/CFlowOutput.cpp; sourceTree = "<group>"; };
 		403426B4235F83B1005B5215 /* CFlowIncOutput.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CFlowIncOutput.cpp; path = ../../SU2_CFD/src/output/CFlowIncOutput.cpp; sourceTree = "<group>"; };
@@ -321,12 +352,10 @@
 		4040B251235FBEC300843C83 /* CFlowTractionInterface.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CFlowTractionInterface.hpp; path = ../../SU2_CFD/include/interfaces/fsi/CFlowTractionInterface.hpp; sourceTree = "<group>"; };
 		4040B252235FBEC300843C83 /* CInterface.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CInterface.hpp; path = ../../SU2_CFD/include/interfaces/CInterface.hpp; sourceTree = "<group>"; };
 		4040B253235FBEC300843C83 /* CDisplacementsInterface.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CDisplacementsInterface.hpp; path = ../../SU2_CFD/include/interfaces/fsi/CDisplacementsInterface.hpp; sourceTree = "<group>"; };
-		4040B254235FBEFD00843C83 /* CDisplacementsInterfaceLegacy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CDisplacementsInterfaceLegacy.cpp; path = ../../SU2_CFD/src/interfaces/fsi/CDisplacementsInterfaceLegacy.cpp; sourceTree = "<group>"; };
 		4040B255235FBEFD00843C83 /* CDisplacementsInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CDisplacementsInterface.cpp; path = ../../SU2_CFD/src/interfaces/fsi/CDisplacementsInterface.cpp; sourceTree = "<group>"; };
 		4040B256235FBEFD00843C83 /* CFlowTractionInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CFlowTractionInterface.cpp; path = ../../SU2_CFD/src/interfaces/fsi/CFlowTractionInterface.cpp; sourceTree = "<group>"; };
 		4040B257235FBEFD00843C83 /* CDiscAdjFlowTractionInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CDiscAdjFlowTractionInterface.cpp; path = ../../SU2_CFD/src/interfaces/fsi/CDiscAdjFlowTractionInterface.cpp; sourceTree = "<group>"; };
 		4040B258235FBEFD00843C83 /* CMixingPlaneInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CMixingPlaneInterface.cpp; path = ../../SU2_CFD/src/interfaces/cfd/CMixingPlaneInterface.cpp; sourceTree = "<group>"; };
-		4040B259235FBEFD00843C83 /* CDiscAdjDisplacementsInterfaceLegacy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CDiscAdjDisplacementsInterfaceLegacy.cpp; path = ../../SU2_CFD/src/interfaces/fsi/CDiscAdjDisplacementsInterfaceLegacy.cpp; sourceTree = "<group>"; };
 		4040B25A235FBEFD00843C83 /* CConjugateHeatInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CConjugateHeatInterface.cpp; path = ../../SU2_CFD/src/interfaces/cht/CConjugateHeatInterface.cpp; sourceTree = "<group>"; };
 		4040B25B235FBEFD00843C83 /* CSlidingInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CSlidingInterface.cpp; path = ../../SU2_CFD/src/interfaces/cfd/CSlidingInterface.cpp; sourceTree = "<group>"; };
 		4040B25C235FBEFD00843C83 /* CConservativeVarsInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CConservativeVarsInterface.cpp; path = ../../SU2_CFD/src/interfaces/cfd/CConservativeVarsInterface.cpp; sourceTree = "<group>"; };
@@ -359,6 +388,39 @@
 		4040B292235FC03700843C83 /* CFileWriter.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = CFileWriter.hpp; sourceTree = "<group>"; };
 		4040B293235FC03700843C83 /* CCSVFileWriter.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = CCSVFileWriter.hpp; sourceTree = "<group>"; };
 		4040B294235FC03700843C83 /* CSurfaceFVMDataSorter.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = CSurfaceFVMDataSorter.hpp; sourceTree = "<group>"; };
+		4063F8122469E40A00DE870E /* CMultiGridIntegration.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CMultiGridIntegration.cpp; path = ../../SU2_CFD/src/integration/CMultiGridIntegration.cpp; sourceTree = "<group>"; };
+		4063F8132469E40A00DE870E /* CSingleGridIntegration.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CSingleGridIntegration.cpp; path = ../../SU2_CFD/src/integration/CSingleGridIntegration.cpp; sourceTree = "<group>"; };
+		4063F8142469E40A00DE870E /* CStructuralIntegration.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CStructuralIntegration.cpp; path = ../../SU2_CFD/src/integration/CStructuralIntegration.cpp; sourceTree = "<group>"; };
+		4063F8152469E40A00DE870E /* CIntegrationFactory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CIntegrationFactory.cpp; path = ../../SU2_CFD/src/integration/CIntegrationFactory.cpp; sourceTree = "<group>"; };
+		4063F8162469E40A00DE870E /* CIntegration.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CIntegration.cpp; path = ../../SU2_CFD/src/integration/CIntegration.cpp; sourceTree = "<group>"; };
+		4063F8172469E40A00DE870E /* CFEM_DG_Integration.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CFEM_DG_Integration.cpp; path = ../../SU2_CFD/src/integration/CFEM_DG_Integration.cpp; sourceTree = "<group>"; };
+		4063F823246A03AE00DE870E /* CLimiterDetails.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CLimiterDetails.cpp; path = ../../SU2_CFD/src/limiters/CLimiterDetails.cpp; sourceTree = "<group>"; };
+		4063F825246A03F700DE870E /* transition.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = transition.cpp; path = ../../SU2_CFD/src/numerics/transition.cpp; sourceTree = "<group>"; };
+		4063F826246A03F700DE870E /* turb_convection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = turb_convection.cpp; path = ../../SU2_CFD/src/numerics/turbulent/turb_convection.cpp; sourceTree = "<group>"; };
+		4063F827246A03F700DE870E /* adj_diffusion.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = adj_diffusion.cpp; path = ../../SU2_CFD/src/numerics/continuous_adjoint/adj_diffusion.cpp; sourceTree = "<group>"; };
+		4063F828246A03F700DE870E /* fvs.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = fvs.cpp; path = ../../SU2_CFD/src/numerics/flow/convection/fvs.cpp; sourceTree = "<group>"; };
+		4063F829246A03F700DE870E /* heat.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = heat.cpp; path = ../../SU2_CFD/src/numerics/heat.cpp; sourceTree = "<group>"; };
+		4063F82A246A03F700DE870E /* adj_convection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = adj_convection.cpp; path = ../../SU2_CFD/src/numerics/continuous_adjoint/adj_convection.cpp; sourceTree = "<group>"; };
+		4063F82B246A03F700DE870E /* hllc.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = hllc.cpp; path = ../../SU2_CFD/src/numerics/flow/convection/hllc.cpp; sourceTree = "<group>"; };
+		4063F82C246A03F700DE870E /* turb_diffusion.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = turb_diffusion.cpp; path = ../../SU2_CFD/src/numerics/turbulent/turb_diffusion.cpp; sourceTree = "<group>"; };
+		4063F82D246A03F700DE870E /* flow_diffusion.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = flow_diffusion.cpp; path = ../../SU2_CFD/src/numerics/flow/flow_diffusion.cpp; sourceTree = "<group>"; };
+		4063F82E246A03F700DE870E /* CNumerics.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CNumerics.cpp; path = ../../SU2_CFD/src/numerics/CNumerics.cpp; sourceTree = "<group>"; };
+		4063F82F246A03F700DE870E /* fds.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = fds.cpp; path = ../../SU2_CFD/src/numerics/flow/convection/fds.cpp; sourceTree = "<group>"; };
+		4063F830246A03F700DE870E /* turb_sources.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = turb_sources.cpp; path = ../../SU2_CFD/src/numerics/turbulent/turb_sources.cpp; sourceTree = "<group>"; };
+		4063F831246A03F700DE870E /* template.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = template.cpp; path = ../../SU2_CFD/src/numerics/template.cpp; sourceTree = "<group>"; };
+		4063F832246A03F700DE870E /* nonlinear_models.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = nonlinear_models.cpp; path = ../../SU2_CFD/src/numerics/elasticity/nonlinear_models.cpp; sourceTree = "<group>"; };
+		4063F833246A03F700DE870E /* cusp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = cusp.cpp; path = ../../SU2_CFD/src/numerics/flow/convection/cusp.cpp; sourceTree = "<group>"; };
+		4063F834246A03F700DE870E /* radiation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = radiation.cpp; path = ../../SU2_CFD/src/numerics/radiation.cpp; sourceTree = "<group>"; };
+		4063F835246A03F700DE870E /* centered.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = centered.cpp; path = ../../SU2_CFD/src/numerics/flow/convection/centered.cpp; sourceTree = "<group>"; };
+		4063F836246A03F700DE870E /* adj_sources.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = adj_sources.cpp; path = ../../SU2_CFD/src/numerics/continuous_adjoint/adj_sources.cpp; sourceTree = "<group>"; };
+		4063F837246A03F800DE870E /* flow_sources.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = flow_sources.cpp; path = ../../SU2_CFD/src/numerics/flow/flow_sources.cpp; sourceTree = "<group>"; };
+		4063F838246A03F800DE870E /* roe.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = roe.cpp; path = ../../SU2_CFD/src/numerics/flow/convection/roe.cpp; sourceTree = "<group>"; };
+		4063F839246A03F800DE870E /* ausm_slau.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ausm_slau.cpp; path = ../../SU2_CFD/src/numerics/flow/convection/ausm_slau.cpp; sourceTree = "<group>"; };
+		4063F852246A053400DE870E /* CParaviewXMLFileWriter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CParaviewXMLFileWriter.cpp; sourceTree = "<group>"; };
+		4063F853246A053400DE870E /* CSTLFileWriter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CSTLFileWriter.cpp; sourceTree = "<group>"; };
+		4063F854246A053400DE870E /* COutputFactory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = COutputFactory.cpp; path = ../../SU2_CFD/src/output/COutputFactory.cpp; sourceTree = "<group>"; };
+		4063F855246A053400DE870E /* CParaviewVTMFileWriter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CParaviewVTMFileWriter.cpp; sourceTree = "<group>"; };
+		4063F856246A053400DE870E /* CWindowingTools.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CWindowingTools.cpp; path = ../../SU2_CFD/src/output/tools/CWindowingTools.cpp; sourceTree = "<group>"; };
 		E90B4FCB22DFDF92000ED392 /* CMMSIncNSSolution.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CMMSIncNSSolution.cpp; path = ../../Common/src/toolboxes/MMS/CMMSIncNSSolution.cpp; sourceTree = "<group>"; };
 		E90B4FCC22DFDF93000ED392 /* CMMSNSUnitQuadSolutionWallBC.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CMMSNSUnitQuadSolutionWallBC.cpp; path = ../../Common/src/toolboxes/MMS/CMMSNSUnitQuadSolutionWallBC.cpp; sourceTree = "<group>"; };
 		E90B4FCD22DFDF93000ED392 /* CNSUnitQuadSolution.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CNSUnitQuadSolution.cpp; path = ../../Common/src/toolboxes/MMS/CNSUnitQuadSolution.cpp; sourceTree = "<group>"; };
@@ -424,8 +486,6 @@
 		E90D35F6203F9C5800A3290D /* fluid_model_inc.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = fluid_model_inc.cpp; path = ../../SU2_CFD/src/fluid_model_inc.cpp; sourceTree = "<group>"; };
 		E91CAD081B8C117A00EE3FCC /* inv_NACA0012.cfg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = inv_NACA0012.cfg; sourceTree = "<group>"; };
 		E91CAD091B8C117A00EE3FCC /* mesh_NACA0012_inv.su2 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = mesh_NACA0012_inv.su2; sourceTree = "<group>"; };
-		E9225F741FCBC36D002F3682 /* solver_adjoint_elasticity.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = solver_adjoint_elasticity.cpp; path = ../../SU2_CFD/src/solver_adjoint_elasticity.cpp; sourceTree = "<group>"; };
-		E941BB8D1B71D0D0005C6C06 /* solver_adjoint_discrete.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = solver_adjoint_discrete.cpp; path = ../../SU2_CFD/src/solver_adjoint_discrete.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		E941BB911B71D124005C6C06 /* mpi_structure.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = mpi_structure.cpp; path = ../../Common/src/mpi_structure.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		E941BB951B71D1AB005C6C06 /* datatype_structure.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; lineEnding = 0; name = datatype_structure.hpp; path = ../../Common/include/datatype_structure.hpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		E941BB961B71D1AB005C6C06 /* datatype_structure.inl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; lineEnding = 0; name = datatype_structure.inl; path = ../../Common/include/datatype_structure.inl; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
@@ -473,7 +533,6 @@
 		E9C8308C2061E6B6004417A9 /* fem_geometry_structure.inl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = fem_geometry_structure.inl; path = ../../Common/include/fem_geometry_structure.inl; sourceTree = "<group>"; };
 		E9C8308D2061E6B6004417A9 /* fem_standard_element.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = fem_standard_element.hpp; path = ../../Common/include/fem_standard_element.hpp; sourceTree = "<group>"; };
 		E9C8308E2061E6B6004417A9 /* fem_standard_element.inl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = fem_standard_element.inl; path = ../../Common/include/fem_standard_element.inl; sourceTree = "<group>"; };
-		E9C830922061E799004417A9 /* solver_direct_mean_fem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = solver_direct_mean_fem.cpp; path = ../../SU2_CFD/src/solver_direct_mean_fem.cpp; sourceTree = "<group>"; };
 		E9D6EE5923165FD300618E36 /* CDummyDriver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CDummyDriver.cpp; path = ../../SU2_CFD/src/drivers/CDummyDriver.cpp; sourceTree = "<group>"; };
 		E9D6EE5B23165FE400618E36 /* CDummyDriver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CDummyDriver.hpp; path = ../../SU2_CFD/include/drivers/CDummyDriver.hpp; sourceTree = "<group>"; };
 		E9D6EE5C2316653100618E36 /* CSU2ASCIIMeshReaderFVM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CSU2ASCIIMeshReaderFVM.cpp; path = ../../Common/src/CSU2ASCIIMeshReaderFVM.cpp; sourceTree = "<group>"; };
@@ -509,8 +568,6 @@
 		E9E674352302A327009B6A25 /* CMultiGridQueue.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CMultiGridQueue.hpp; path = ../../Common/include/CMultiGridQueue.hpp; sourceTree = "<group>"; };
 		E9E674362302A92C009B6A25 /* CRectangularMeshReaderFVM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CRectangularMeshReaderFVM.cpp; path = ../../Common/src/CRectangularMeshReaderFVM.cpp; sourceTree = "<group>"; };
 		E9E674382302A942009B6A25 /* CRectangularMeshReaderFVM.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = CRectangularMeshReaderFVM.hpp; path = ../../Common/include/CRectangularMeshReaderFVM.hpp; sourceTree = "<group>"; };
-		E9F130C61D513DA300EC8963 /* numerics_direct_mean_inc.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = numerics_direct_mean_inc.cpp; path = ../../SU2_CFD/src/numerics_direct_mean_inc.cpp; sourceTree = "<group>"; };
-		E9F130C81D513DA300EC8963 /* solver_direct_mean_inc.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = solver_direct_mean_inc.cpp; path = ../../SU2_CFD/src/solver_direct_mean_inc.cpp; sourceTree = "<group>"; };
 		E9FDF6E91D2DD0560066E49C /* adt_structure.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = adt_structure.cpp; path = ../../Common/src/adt_structure.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		E9FDF6EB1D2DD0710066E49C /* adt_structure.inl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; lineEnding = 0; name = adt_structure.inl; path = ../../Common/include/adt_structure.inl; sourceTree = "<group>"; };
 		E9FDF6EC1D2DD0860066E49C /* adt_structure.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; lineEnding = 0; name = adt_structure.hpp; path = ../../Common/include/adt_structure.hpp; sourceTree = "<group>"; };
@@ -538,22 +595,33 @@
 		052D517F17A21FAC003BE8B2 /* Solver */ = {
 			isa = PBXGroup;
 			children = (
-				E967669E237365CA009FBEE1 /* CMarkerProfileReaderFVM.cpp */,
+				40303E2F246A05EB00CD7789 /* CAdjEulerSolver.cpp */,
+				40303E3F246A05EC00CD7789 /* CAdjNSSolver.cpp */,
+				40303E35246A05EC00CD7789 /* CAdjTurbSolver.cpp */,
+				40303E3E246A05EC00CD7789 /* CBaselineSolver_FEM.cpp */,
+				40303E3B246A05EC00CD7789 /* CBaselineSolver.cpp */,
+				40303E31246A05EB00CD7789 /* CDiscAdjFEASolver.cpp */,
 				E9D6EE662317B80600618E36 /* CDiscAdjMeshSolver.cpp */,
+				40303E34246A05EC00CD7789 /* CDiscAdjSolver.cpp */,
+				40303E3D246A05EC00CD7789 /* CEulerSolver.cpp */,
+				40303E41246A05EC00CD7789 /* CFEASolver.cpp */,
+				40303E43246A05EC00CD7789 /* CFEM_DG_EulerSolver.cpp */,
+				40303E42246A05EC00CD7789 /* CFEM_DG_NSSolver.cpp */,
+				40303E2E246A05EB00CD7789 /* CHeatSolver.cpp */,
+				40303E39246A05EC00CD7789 /* CIncEulerSolver.cpp */,
+				40303E30246A05EB00CD7789 /* CIncNSSolver.cpp */,
+				E967669E237365CA009FBEE1 /* CMarkerProfileReaderFVM.cpp */,
 				E9D6EE652317B80500618E36 /* CMeshSolver.cpp */,
-				E941BB8D1B71D0D0005C6C06 /* solver_adjoint_discrete.cpp */,
-				E9225F741FCBC36D002F3682 /* solver_adjoint_elasticity.cpp */,
-				05E6DBDA17EB62A100FA1F7E /* solver_adjoint_mean.cpp */,
-				05E6DBDD17EB62A100FA1F7E /* solver_adjoint_turbulent.cpp */,
-				0530E56917FDF7AC00733CE8 /* solver_direct_elasticity.cpp */,
-				05E6DBE017EB62A100FA1F7E /* solver_direct_heat.cpp */,
-				E9C830922061E799004417A9 /* solver_direct_mean_fem.cpp */,
-				E9F130C81D513DA300EC8963 /* solver_direct_mean_inc.cpp */,
-				05E6DBE217EB62A100FA1F7E /* solver_direct_mean.cpp */,
-				05E6DBE517EB62A100FA1F7E /* solver_direct_transition.cpp */,
-				05E6DBE617EB62A100FA1F7E /* solver_direct_turbulent.cpp */,
-				05E6DBEA17EB62A100FA1F7E /* solver_structure.cpp */,
-				05E6DBEB17EB62A100FA1F7E /* solver_template.cpp */,
+				40303E32246A05EB00CD7789 /* CNSSolver.cpp */,
+				40303E3A246A05EC00CD7789 /* CRadP1Solver.cpp */,
+				40303E3C246A05EC00CD7789 /* CRadSolver.cpp */,
+				40303E44246A05EC00CD7789 /* CSolver.cpp */,
+				40303E45246A05EC00CD7789 /* CSolverFactory.cpp */,
+				40303E33246A05EC00CD7789 /* CTemplateSolver.cpp */,
+				40303E36246A05EC00CD7789 /* CTransLMSolver.cpp */,
+				40303E37246A05EC00CD7789 /* CTurbSASolver.cpp */,
+				40303E38246A05EC00CD7789 /* CTurbSolver.cpp */,
+				40303E40246A05EC00CD7789 /* CTurbSSTSolver.cpp */,
 			);
 			name = Solver;
 			sourceTree = "<group>";
@@ -561,8 +629,12 @@
 		052D51AA17A22E15003BE8B2 /* Integration */ = {
 			isa = PBXGroup;
 			children = (
-				05E6DBBE17EB62A100FA1F7E /* integration_structure.cpp */,
-				05E6DBBF17EB62A100FA1F7E /* integration_time.cpp */,
+				4063F8172469E40A00DE870E /* CFEM_DG_Integration.cpp */,
+				4063F8162469E40A00DE870E /* CIntegration.cpp */,
+				4063F8152469E40A00DE870E /* CIntegrationFactory.cpp */,
+				4063F8122469E40A00DE870E /* CMultiGridIntegration.cpp */,
+				4063F8132469E40A00DE870E /* CSingleGridIntegration.cpp */,
+				4063F8142469E40A00DE870E /* CStructuralIntegration.cpp */,
 			);
 			name = Integration;
 			sourceTree = "<group>";
@@ -585,6 +657,8 @@
 				403426B7235F83B1005B5215 /* CMeshOutput.cpp */,
 				403426B6235F83B1005B5215 /* CMultizoneOutput.cpp */,
 				403426BE235F83B1005B5215 /* COutput.cpp */,
+				4063F854246A053400DE870E /* COutputFactory.cpp */,
+				4063F856246A053400DE870E /* CWindowingTools.cpp */,
 				403426BF235F83B2005B5215 /* output_physics.cpp */,
 				403426BB235F83B1005B5215 /* output_structure_legacy.cpp */,
 			);
@@ -661,10 +735,6 @@
 				E9D885A72303F8D000917362 /* CBoxMeshReaderFVM.hpp */,
 				E9E51ADB22FAB10D00773E0C /* CCGNSMeshReaderFVM.hpp */,
 				E9D6EE7A2317B8B000618E36 /* CDiscAdjMeshSolver.hpp */,
-				403426E6235F88ED005B5215 /* CDiscAdjMultizoneDriver.hpp */,
-				EB14FF9C22F790720045FB27 /* CDiscAdjSinglezoneDriver.hpp */,
-				EB14FF9D22F790720045FB27 /* CDriver.hpp */,
-				E9D6EE5B23165FE400618E36 /* CDummyDriver.hpp */,
 				E9C2835A22A701B6007B4E59 /* CIncTGVSolution.hpp */,
 				E9C2835722A701B5007B4E59 /* CInviscidVortexSolution.hpp */,
 				E9E51AD722FA314F00773E0C /* CLinearPartitioner.hpp */,
@@ -678,12 +748,10 @@
 				E9C2835322A701B5007B4E59 /* CMMSNSUnitQuadSolution.hpp */,
 				E9C2835D22A701B6007B4E59 /* CMMSNSUnitQuadSolutionWallBC.hpp */,
 				E9E674352302A327009B6A25 /* CMultiGridQueue.hpp */,
-				EB14FF9F22F790720045FB27 /* CMultizoneDriver.hpp */,
 				E9C2835622A701B5007B4E59 /* CNSUnitQuadSolution.hpp */,
 				05E6DAC517EB608000FA1F7E /* config_structure.hpp */,
 				E9E674382302A942009B6A25 /* CRectangularMeshReaderFVM.hpp */,
 				E9C2835822A701B5007B4E59 /* CRinglebSolution.hpp */,
-				EB14FF9E22F790720045FB27 /* CSinglezoneDriver.hpp */,
 				E9D6EE5E2316655400618E36 /* CSU2ASCIIMeshReaderFVM.hpp */,
 				E9C2835922A701B5007B4E59 /* CTGVSolution.hpp */,
 				E9C2835422A701B5007B4E59 /* CUserDefinedSolution.hpp */,
@@ -691,7 +759,7 @@
 				E941BB951B71D1AB005C6C06 /* datatype_structure.hpp */,
 				E941BB971B71D1AB005C6C06 /* datatypes */,
 				05E6DBB417EB627400FA1F7E /* definition_structure.hpp */,
-				05E6DAC617EB608000FA1F7E /* dual_grid_structure.hpp */,
+				40303E64246A069700CD7789 /* Drivers */,
 				E96FAF1C2189FF620046BF5D /* fem_cgns_elements.hpp */,
 				E96FAF1D2189FF620046BF5D /* fem_gauss_jacobi_quadrature.hpp */,
 				E9C8308B2061E6B6004417A9 /* fem_geometry_structure.hpp */,
@@ -725,16 +793,15 @@
 		05D28619178BCA1200DD76AE /* Numerics */ = {
 			isa = PBXGroup;
 			children = (
+				4063F851246A043700DE870E /* ContinuousAdjoint */,
 				356E2E0C2399977F0039E9B5 /* Elasticity */,
-				05E6DBC317EB62A100FA1F7E /* numerics_adjoint_mean.cpp */,
-				05E6DBC617EB62A100FA1F7E /* numerics_adjoint_turbulent.cpp */,
-				05E6DBC917EB62A100FA1F7E /* numerics_direct_heat.cpp */,
-				E9F130C61D513DA300EC8963 /* numerics_direct_mean_inc.cpp */,
-				05E6DBCB17EB62A100FA1F7E /* numerics_direct_mean.cpp */,
-				05E6DBCE17EB62A100FA1F7E /* numerics_direct_transition.cpp */,
-				05E6DBCF17EB62A100FA1F7E /* numerics_direct_turbulent.cpp */,
-				05E6DBD317EB62A100FA1F7E /* numerics_structure.cpp */,
-				05E6DBD417EB62A100FA1F7E /* numerics_template.cpp */,
+				4063F850246A043000DE870E /* Flow */,
+				4063F84F246A042500DE870E /* Turbulent */,
+				4063F82E246A03F700DE870E /* CNumerics.cpp */,
+				4063F829246A03F700DE870E /* heat.cpp */,
+				4063F834246A03F700DE870E /* radiation.cpp */,
+				4063F831246A03F700DE870E /* template.cpp */,
+				4063F825246A03F700DE870E /* transition.cpp */,
 			);
 			name = Numerics;
 			sourceTree = "<group>";
@@ -786,6 +853,7 @@
 				E9D85B4B1C3F1B9E0077122F /* ad_structure.cpp */,
 				E9FDF6E91D2DD0560066E49C /* adt_structure.cpp */,
 				E96FAF0F2189FE9C0046BF5D /* blas_structure.cpp */,
+				4063F823246A03AE00DE870E /* CLimiterDetails.cpp */,
 				E9E51AD522FA313800773E0C /* CLinearPartitioner.cpp */,
 				05E6DB8917EB61E600FA1F7E /* config_structure.cpp */,
 				05E6DBBC17EB62A000FA1F7E /* definition_structure.cpp */,
@@ -825,12 +893,8 @@
 			children = (
 				356E2E102399979F0039E9B5 /* CFEAElasticity.cpp */,
 				356E2E0E2399979F0039E9B5 /* CFEALinearElasticity.cpp */,
-				356E2E112399979F0039E9B5 /* CFEAMeshElasticity.cpp */,
 				356E2E0D2399979F0039E9B5 /* CFEANonlinearElasticity.cpp */,
-				356E2E0F2399979F0039E9B5 /* CFEM_DielectricElastomer.cpp */,
-				356E2E122399979F0039E9B5 /* CFEM_IdealDE.cpp */,
-				356E2E132399979F0039E9B5 /* CFEM_Knowles_NearInc.cpp */,
-				356E2E142399979F0039E9B5 /* CFEM_NeoHookean_Comp.cpp */,
+				4063F832246A03F700DE870E /* nonlinear_models.cpp */,
 			);
 			name = Elasticity;
 			sourceTree = "<group>";
@@ -847,6 +911,19 @@
 				356E2E2723999B140039E9B5 /* CTRIA1.cpp */,
 			);
 			name = Elements;
+			sourceTree = "<group>";
+		};
+		40303E64246A069700CD7789 /* Drivers */ = {
+			isa = PBXGroup;
+			children = (
+				403426E6235F88ED005B5215 /* CDiscAdjMultizoneDriver.hpp */,
+				EB14FF9C22F790720045FB27 /* CDiscAdjSinglezoneDriver.hpp */,
+				EB14FF9D22F790720045FB27 /* CDriver.hpp */,
+				E9D6EE5B23165FE400618E36 /* CDummyDriver.hpp */,
+				EB14FF9F22F790720045FB27 /* CMultizoneDriver.hpp */,
+				EB14FF9E22F790720045FB27 /* CSinglezoneDriver.hpp */,
+			);
+			name = Drivers;
 			sourceTree = "<group>";
 		};
 		403426D3235F857D005B5215 /* Output */ = {
@@ -878,10 +955,8 @@
 			children = (
 				4040B25A235FBEFD00843C83 /* CConjugateHeatInterface.cpp */,
 				4040B25C235FBEFD00843C83 /* CConservativeVarsInterface.cpp */,
-				4040B259235FBEFD00843C83 /* CDiscAdjDisplacementsInterfaceLegacy.cpp */,
 				4040B257235FBEFD00843C83 /* CDiscAdjFlowTractionInterface.cpp */,
 				4040B255235FBEFD00843C83 /* CDisplacementsInterface.cpp */,
-				4040B254235FBEFD00843C83 /* CDisplacementsInterfaceLegacy.cpp */,
 				4040B256235FBEFD00843C83 /* CFlowTractionInterface.cpp */,
 				4040B25D235FBEFD00843C83 /* CInterface.cpp */,
 				4040B258235FBEFD00843C83 /* CMixingPlaneInterface.cpp */,
@@ -911,11 +986,14 @@
 			isa = PBXGroup;
 			children = (
 				4040B26A235FBFF200843C83 /* CCSVFileWriter.cpp */,
+				4040B26F235FBFF200843C83 /* CFEMDataSorter.cpp */,
 				4040B26B235FBFF200843C83 /* CSurfaceFVMDataSorter.cpp */,
 				4040B26C235FBFF200843C83 /* CParallelFileWriter.cpp */,
 				4040B26D235FBFF200843C83 /* CParallelDataSorter.cpp */,
 				4040B26E235FBFF200843C83 /* CParaviewBinaryFileWriter.cpp */,
-				4040B26F235FBFF200843C83 /* CFEMDataSorter.cpp */,
+				4063F855246A053400DE870E /* CParaviewVTMFileWriter.cpp */,
+				4063F852246A053400DE870E /* CParaviewXMLFileWriter.cpp */,
+				4063F853246A053400DE870E /* CSTLFileWriter.cpp */,
 				4040B270235FBFF200843C83 /* CSU2BinaryFileWriter.cpp */,
 				4040B271235FBFF200843C83 /* CTecplotBinaryFileWriter.cpp */,
 				4040B272235FBFF200843C83 /* CSU2FileWriter.cpp */,
@@ -949,6 +1027,42 @@
 			);
 			name = filewriter;
 			path = ../../SU2_CFD/include/output/filewriter;
+			sourceTree = "<group>";
+		};
+		4063F84F246A042500DE870E /* Turbulent */ = {
+			isa = PBXGroup;
+			children = (
+				4063F826246A03F700DE870E /* turb_convection.cpp */,
+				4063F82C246A03F700DE870E /* turb_diffusion.cpp */,
+				4063F830246A03F700DE870E /* turb_sources.cpp */,
+			);
+			name = Turbulent;
+			sourceTree = "<group>";
+		};
+		4063F850246A043000DE870E /* Flow */ = {
+			isa = PBXGroup;
+			children = (
+				4063F839246A03F800DE870E /* ausm_slau.cpp */,
+				4063F835246A03F700DE870E /* centered.cpp */,
+				4063F833246A03F700DE870E /* cusp.cpp */,
+				4063F82F246A03F700DE870E /* fds.cpp */,
+				4063F82D246A03F700DE870E /* flow_diffusion.cpp */,
+				4063F837246A03F800DE870E /* flow_sources.cpp */,
+				4063F828246A03F700DE870E /* fvs.cpp */,
+				4063F82B246A03F700DE870E /* hllc.cpp */,
+				4063F838246A03F800DE870E /* roe.cpp */,
+			);
+			name = Flow;
+			sourceTree = "<group>";
+		};
+		4063F851246A043700DE870E /* ContinuousAdjoint */ = {
+			isa = PBXGroup;
+			children = (
+				4063F82A246A03F700DE870E /* adj_convection.cpp */,
+				4063F827246A03F700DE870E /* adj_diffusion.cpp */,
+				4063F836246A03F700DE870E /* adj_sources.cpp */,
+			);
+			name = ContinuousAdjoint;
 			sourceTree = "<group>";
 		};
 		E90B4FE522DFDF9C000ED392 /* MMS */ = {
@@ -986,12 +1100,15 @@
 				E90B4FF622DFDFE4000ED392 /* CFEABoundVariable.cpp */,
 				E90B4FF422DFDFE4000ED392 /* CFEAVariable.cpp */,
 				E90B4FEE22DFDFE3000ED392 /* CHeatFVMVariable.cpp */,
+				40303E5E246A064900CD7789 /* CHeatVariable.cpp */,
 				E90B4FE722DFDFE2000ED392 /* CIncEulerVariable.cpp */,
 				E90B4FED22DFDFE3000ED392 /* CIncNSVariable.cpp */,
 				E9D6EE702317B88F00618E36 /* CMeshBoundVariable.cpp */,
 				E9D6EE6F2317B88F00618E36 /* CMeshElement.cpp */,
 				E9D6EE712317B88F00618E36 /* CMeshVariable.cpp */,
 				E90B4FF522DFDFE4000ED392 /* CNSVariable.cpp */,
+				40303E5F246A064900CD7789 /* CRadP1Variable.cpp */,
+				40303E60246A064900CD7789 /* CRadVariable.cpp */,
 				E90B4FF322DFDFE3000ED392 /* CTransLMVariable.cpp */,
 				E90B4FF722DFDFE4000ED392 /* CTurbSAVariable.cpp */,
 				E90B4FF022DFDFE3000ED392 /* CTurbSSTVariable.cpp */,
@@ -1152,6 +1269,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4063F85A246A053400DE870E /* CParaviewVTMFileWriter.cpp in Sources */,
+				40303E50246A05EC00CD7789 /* CTurbSolver.cpp in Sources */,
+				4063F842246A03F800DE870E /* flow_diffusion.cpp in Sources */,
+				4063F81D2469E40B00DE870E /* CFEM_DG_Integration.cpp in Sources */,
+				4063F858246A053400DE870E /* CSTLFileWriter.cpp in Sources */,
 				EB14FF9A22F790500045FB27 /* CDriver.cpp in Sources */,
 				356E2E3323999B140039E9B5 /* CPYRAM5.cpp in Sources */,
 				E90B4FE222DFDF94000ED392 /* CMMSNSTwoHalfCirclesSolution.cpp in Sources */,
@@ -1161,6 +1283,7 @@
 				E96FAF142189FECA0046BF5D /* graph_coloring_structure.cpp in Sources */,
 				4040B27F235FBFF200843C83 /* CTecplotBinaryFileWriter.cpp in Sources */,
 				05E6DB9317EB61E600FA1F7E /* dual_grid_structure.cpp in Sources */,
+				40303E56246A05EC00CD7789 /* CBaselineSolver_FEM.cpp in Sources */,
 				E96FAF152189FECA0046BF5D /* fem_gauss_jacobi_quadrature.cpp in Sources */,
 				4040B261235FBEFD00843C83 /* CDiscAdjFlowTractionInterface.cpp in Sources */,
 				E9D6EE5D2316653200618E36 /* CSU2ASCIIMeshReaderFVM.cpp in Sources */,
@@ -1168,74 +1291,80 @@
 				E90B4FFE22DFDFE4000ED392 /* CAdjEulerVariable.cpp in Sources */,
 				4040B260235FBEFD00843C83 /* CFlowTractionInterface.cpp in Sources */,
 				E90B500522DFDFE4000ED392 /* CTransLMVariable.cpp in Sources */,
+				4063F84B246A03F800DE870E /* adj_sources.cpp in Sources */,
 				05E6DB9517EB61E600FA1F7E /* grid_adaptation_structure.cpp in Sources */,
 				E9E674342302A2E4009B6A25 /* CMultiGridQueue.cpp in Sources */,
 				E90B500322DFDFE4000ED392 /* CBaselineVariable.cpp in Sources */,
 				4040B27B235FBFF200843C83 /* CParallelDataSorter.cpp in Sources */,
-				0530E56A17FDF7AC00733CE8 /* solver_direct_elasticity.cpp in Sources */,
 				4040B27C235FBFF200843C83 /* CParaviewBinaryFileWriter.cpp in Sources */,
 				05E6DB9617EB61E600FA1F7E /* grid_movement_structure.cpp in Sources */,
 				403426CF235F83B2005B5215 /* output_physics.cpp in Sources */,
-				4040B25E235FBEFD00843C83 /* CDisplacementsInterfaceLegacy.cpp in Sources */,
+				40303E55246A05EC00CD7789 /* CEulerSolver.cpp in Sources */,
 				356E2E3223999B140039E9B5 /* CPRISM6.cpp in Sources */,
 				E90B4FDF22DFDF94000ED392 /* CInviscidVortexSolution.cpp in Sources */,
 				4040B280235FBFF200843C83 /* CSU2FileWriter.cpp in Sources */,
+				4063F84A246A03F800DE870E /* centered.cpp in Sources */,
 				05E6DB9917EB61E600FA1F7E /* primal_grid_structure.cpp in Sources */,
 				E90B4FDC22DFDF94000ED392 /* CIncTGVSolution.cpp in Sources */,
 				E90B500622DFDFE4000ED392 /* CFEAVariable.cpp in Sources */,
 				05F8F2682008A1C8000FEA01 /* python_wrapper_structure.cpp in Sources */,
 				E90B4FE422DFDF94000ED392 /* CVerificationSolution.cpp in Sources */,
 				E90B4FE022DFDF94000ED392 /* CMMSNSUnitQuadSolution.cpp in Sources */,
-				E9225F761FCBC36D002F3682 /* solver_adjoint_elasticity.cpp in Sources */,
+				40303E5D246A05EC00CD7789 /* CSolverFactory.cpp in Sources */,
 				E9E51AD622FA313900773E0C /* CLinearPartitioner.cpp in Sources */,
 				4040B281235FBFF200843C83 /* CFVMDataSorter.cpp in Sources */,
 				05E6DC0117EB62A100FA1F7E /* definition_structure.cpp in Sources */,
-				05E6DC0317EB62A100FA1F7E /* integration_structure.cpp in Sources */,
+				4063F843246A03F800DE870E /* CNumerics.cpp in Sources */,
 				E9D6EE782317B88F00618E36 /* CMeshVariable.cpp in Sources */,
 				403426CA235F83B2005B5215 /* CFlowCompOutput.cpp in Sources */,
 				E9E51ADD22FAB11800773E0C /* CCGNSMeshReaderFVM.cpp in Sources */,
+				40303E58246A05EC00CD7789 /* CTurbSSTSolver.cpp in Sources */,
 				E9E674372302A92C009B6A25 /* CRectangularMeshReaderFVM.cpp in Sources */,
+				40303E4E246A05EC00CD7789 /* CTransLMSolver.cpp in Sources */,
+				4063F840246A03F800DE870E /* hllc.cpp in Sources */,
+				40303E51246A05EC00CD7789 /* CIncEulerSolver.cpp in Sources */,
 				EB14FF9822F790500045FB27 /* CSinglezoneDriver.cpp in Sources */,
 				E90B4FE322DFDF94000ED392 /* CRinglebSolution.cpp in Sources */,
-				05E6DC0417EB62A100FA1F7E /* integration_time.cpp in Sources */,
 				356E2E2423999AEA0039E9B5 /* CMultiGridGeometry.cpp in Sources */,
 				4040B25F235FBEFD00843C83 /* CDisplacementsInterface.cpp in Sources */,
+				40303E59246A05EC00CD7789 /* CFEASolver.cpp in Sources */,
 				356E2E2D23999B140039E9B5 /* CElement.cpp in Sources */,
+				4063F847246A03F800DE870E /* nonlinear_models.cpp in Sources */,
 				E9D6EE572316522800618E36 /* (null) in Sources */,
 				05F1089B1978D2AE00F2F288 /* fluid_model_ppr.cpp in Sources */,
-				E941BB8E1B71D0D0005C6C06 /* solver_adjoint_discrete.cpp in Sources */,
 				05E6DC0517EB62A100FA1F7E /* iteration_structure.cpp in Sources */,
 				403426CC235F83B2005B5215 /* CFlowCompFEMOutput.cpp in Sources */,
-				356E2E1A2399979F0039E9B5 /* CFEM_IdealDE.cpp in Sources */,
-				05E6DC0817EB62A100FA1F7E /* numerics_adjoint_mean.cpp in Sources */,
+				40303E63246A064900CD7789 /* CRadVariable.cpp in Sources */,
 				403426CB235F83B2005B5215 /* output_structure_legacy.cpp in Sources */,
 				E90B500022DFDFE4000ED392 /* CHeatFVMVariable.cpp in Sources */,
+				40303E4B246A05EC00CD7789 /* CTemplateSolver.cpp in Sources */,
 				E90B500922DFDFE4000ED392 /* CTurbSAVariable.cpp in Sources */,
-				05E6DC0B17EB62A100FA1F7E /* numerics_adjoint_turbulent.cpp in Sources */,
 				05F108A41978D2F200F2F288 /* transport_model.cpp in Sources */,
+				40303E5C246A05EC00CD7789 /* CSolver.cpp in Sources */,
 				E9D6EE682317B80600618E36 /* CDiscAdjMeshSolver.cpp in Sources */,
 				4040B282235FBFF200843C83 /* CParaviewFileWriter.cpp in Sources */,
+				40303E46246A05EC00CD7789 /* CHeatSolver.cpp in Sources */,
 				E967669F237365CA009FBEE1 /* CMarkerProfileReaderFVM.cpp in Sources */,
 				E9FDF6EA1D2DD0560066E49C /* adt_structure.cpp in Sources */,
-				05E6DC0E17EB62A100FA1F7E /* numerics_direct_heat.cpp in Sources */,
-				356E2E172399979F0039E9B5 /* CFEM_DielectricElastomer.cpp in Sources */,
+				4063F8192469E40B00DE870E /* CSingleGridIntegration.cpp in Sources */,
 				356E2E2223999AEA0039E9B5 /* CPhysicalGeometry.cpp in Sources */,
 				E90B500422DFDFE4000ED392 /* CTurbVariable.cpp in Sources */,
 				E90D35F7203F9C5800A3290D /* fluid_model_inc.cpp in Sources */,
 				05F1089A1978D2AE00F2F288 /* fluid_model_pig.cpp in Sources */,
-				05E6DC1017EB62A100FA1F7E /* numerics_direct_mean.cpp in Sources */,
 				4040B27A235FBFF200843C83 /* CParallelFileWriter.cpp in Sources */,
 				E9D85B4C1C3F1B9E0077122F /* ad_structure.cpp in Sources */,
-				4040B263235FBEFD00843C83 /* CDiscAdjDisplacementsInterfaceLegacy.cpp in Sources */,
 				E90B4FDD22DFDF94000ED392 /* CUserDefinedSolution.cpp in Sources */,
 				403426C6235F83B2005B5215 /* CMultizoneOutput.cpp in Sources */,
+				4063F841246A03F800DE870E /* turb_diffusion.cpp in Sources */,
 				05F1089D1978D2AE00F2F288 /* fluid_model.cpp in Sources */,
 				4040B264235FBEFD00843C83 /* CConjugateHeatInterface.cpp in Sources */,
 				356E2E162399979F0039E9B5 /* CFEALinearElasticity.cpp in Sources */,
+				4063F857246A053400DE870E /* CParaviewXMLFileWriter.cpp in Sources */,
 				4040B285235FBFF200843C83 /* CSU2MeshFileWriter.cpp in Sources */,
 				403426C8235F83B2005B5215 /* CAdjElasticityOutput.cpp in Sources */,
 				4040B265235FBEFD00843C83 /* CSlidingInterface.cpp in Sources */,
 				E90B4FD922DFDF94000ED392 /* CMMSNSUnitQuadSolutionWallBC.cpp in Sources */,
+				40303E52246A05EC00CD7789 /* CRadP1Solver.cpp in Sources */,
 				E9D6EE762317B88F00618E36 /* CMeshElement.cpp in Sources */,
 				E90B4FFA22DFDFE4000ED392 /* CAdjTurbVariable.cpp in Sources */,
 				356E2E3023999B140039E9B5 /* CHEXA8.cpp in Sources */,
@@ -1243,78 +1372,95 @@
 				4040B267235FBEFD00843C83 /* CInterface.cpp in Sources */,
 				E9D6EE752317B88F00618E36 /* CDiscAdjFEABoundVariable.cpp in Sources */,
 				E9D885A92303F8E400917362 /* CBoxMeshReaderFVM.cpp in Sources */,
+				40303E49246A05EC00CD7789 /* CDiscAdjFEASolver.cpp in Sources */,
 				4040B284235FBFF200843C83 /* CTecplotFileWriter.cpp in Sources */,
-				356E2E1B2399979F0039E9B5 /* CFEM_Knowles_NearInc.cpp in Sources */,
 				403426C9235F83B2005B5215 /* CElasticityOutput.cpp in Sources */,
+				40303E61246A064900CD7789 /* CHeatVariable.cpp in Sources */,
 				E9C830812061E60E004417A9 /* fem_standard_element.cpp in Sources */,
-				05E6DC1317EB62A100FA1F7E /* numerics_direct_transition.cpp in Sources */,
-				05E6DC1417EB62A100FA1F7E /* numerics_direct_turbulent.cpp in Sources */,
+				4063F81A2469E40B00DE870E /* CStructuralIntegration.cpp in Sources */,
 				403426ED235F8E29005B5215 /* CDiscAdjMultizoneDriver.cpp in Sources */,
 				E96FAF102189FE9C0046BF5D /* blas_structure.cpp in Sources */,
 				E90B4FFC22DFDFE4000ED392 /* CDiscAdjVariable.cpp in Sources */,
-				05E6DC1817EB62A100FA1F7E /* numerics_structure.cpp in Sources */,
-				05E6DC1917EB62A100FA1F7E /* numerics_template.cpp in Sources */,
+				4063F8182469E40B00DE870E /* CMultiGridIntegration.cpp in Sources */,
 				E9C830822061E60E004417A9 /* fem_wall_distance.cpp in Sources */,
+				40303E53246A05EC00CD7789 /* CBaselineSolver.cpp in Sources */,
 				E90B4FF922DFDFE4000ED392 /* CIncEulerVariable.cpp in Sources */,
+				40303E4A246A05EC00CD7789 /* CNSSolver.cpp in Sources */,
+				4063F83B246A03F800DE870E /* turb_convection.cpp in Sources */,
+				4063F848246A03F800DE870E /* cusp.cpp in Sources */,
+				40303E47246A05EC00CD7789 /* CAdjEulerSolver.cpp in Sources */,
+				4063F81B2469E40B00DE870E /* CIntegrationFactory.cpp in Sources */,
 				E90B500122DFDFE4000ED392 /* CEulerVariable.cpp in Sources */,
 				E90B501022DFE043000ED392 /* CSysMatrix.cpp in Sources */,
 				E9C8307F2061E60E004417A9 /* fem_geometry_structure.cpp in Sources */,
 				E96FAF162189FECA0046BF5D /* fem_cgns_elements.cpp in Sources */,
 				E9E51AD922FA603800773E0C /* CMeshReaderFVM.cpp in Sources */,
+				4063F83C246A03F800DE870E /* adj_diffusion.cpp in Sources */,
 				E90B4FFF22DFDFE4000ED392 /* CIncNSVariable.cpp in Sources */,
 				4040B283235FBFF200843C83 /* CSurfaceFEMDataSorter.cpp in Sources */,
 				3599C5D32121FAC9003AAF05 /* wall_model.cpp in Sources */,
 				4040B278235FBFF200843C83 /* CCSVFileWriter.cpp in Sources */,
 				E9D9CE861C62A1A7004119E9 /* interpolation_structure.cpp in Sources */,
 				05F1089C1978D2AE00F2F288 /* fluid_model_pvdw.cpp in Sources */,
-				05E6DC1F17EB62A100FA1F7E /* solver_adjoint_mean.cpp in Sources */,
-				05E6DC2217EB62A100FA1F7E /* solver_adjoint_turbulent.cpp in Sources */,
+				40303E5B246A05EC00CD7789 /* CFEM_DG_EulerSolver.cpp in Sources */,
+				4063F83E246A03F800DE870E /* heat.cpp in Sources */,
 				E90B4FDB22DFDF94000ED392 /* CTGVSolution.cpp in Sources */,
-				05E6DC2517EB62A100FA1F7E /* solver_direct_heat.cpp in Sources */,
 				E90B500822DFDFE4000ED392 /* CFEABoundVariable.cpp in Sources */,
 				403426CD235F83B2005B5215 /* CAdjFlowCompOutput.cpp in Sources */,
+				40303E4C246A05EC00CD7789 /* CDiscAdjSolver.cpp in Sources */,
 				403426D0235F83B2005B5215 /* CAdjHeatOutput.cpp in Sources */,
-				05E6DC2717EB62A100FA1F7E /* solver_direct_mean.cpp in Sources */,
 				403426C2235F83B2005B5215 /* CAdjFlowIncOutput.cpp in Sources */,
 				403426C3235F83B2005B5215 /* CFlowOutput.cpp in Sources */,
+				4063F83F246A03F800DE870E /* adj_convection.cpp in Sources */,
+				40303E57246A05EC00CD7789 /* CAdjNSSolver.cpp in Sources */,
 				356E2E2323999AEA0039E9B5 /* CDummyGeometry.cpp in Sources */,
+				4063F824246A03AE00DE870E /* CLimiterDetails.cpp in Sources */,
+				40303E54246A05EC00CD7789 /* CRadSolver.cpp in Sources */,
 				403426CE235F83B2005B5215 /* COutput.cpp in Sources */,
+				4063F84C246A03F800DE870E /* flow_sources.cpp in Sources */,
+				4063F845246A03F800DE870E /* turb_sources.cpp in Sources */,
 				4040B27D235FBFF200843C83 /* CFEMDataSorter.cpp in Sources */,
+				4063F846246A03F800DE870E /* template.cpp in Sources */,
 				4040B27E235FBFF200843C83 /* CSU2BinaryFileWriter.cpp in Sources */,
 				E90B4FDE22DFDF94000ED392 /* CMMSNSTwoHalfSpheresSolution.cpp in Sources */,
 				356E2E152399979F0039E9B5 /* CFEANonlinearElasticity.cpp in Sources */,
 				4040B266235FBEFD00843C83 /* CConservativeVarsInterface.cpp in Sources */,
 				E90B4FFD22DFDFE4000ED392 /* CDiscAdjFEAVariable.cpp in Sources */,
-				05E6DC2A17EB62A100FA1F7E /* solver_direct_transition.cpp in Sources */,
-				356E2E1C2399979F0039E9B5 /* CFEM_NeoHookean_Comp.cpp in Sources */,
+				40303E4F246A05EC00CD7789 /* CTurbSASolver.cpp in Sources */,
+				40303E4D246A05EC00CD7789 /* CAdjTurbSolver.cpp in Sources */,
 				E90B4FF822DFDFE4000ED392 /* CVariable.cpp in Sources */,
+				4063F859246A053400DE870E /* COutputFactory.cpp in Sources */,
 				4040B262235FBEFD00843C83 /* CMixingPlaneInterface.cpp in Sources */,
 				356E2E3123999B140039E9B5 /* CTETRA1.cpp in Sources */,
 				E90B4FE122DFDF94000ED392 /* CMMSIncEulerSolution.cpp in Sources */,
-				E9F130CC1D513DA300EC8963 /* numerics_direct_mean_inc.cpp in Sources */,
+				4063F84E246A03F800DE870E /* ausm_slau.cpp in Sources */,
 				E9C830852061E60E004417A9 /* geometry_structure_fem_part.cpp in Sources */,
 				E9D6EE672317B80600618E36 /* CMeshSolver.cpp in Sources */,
-				05E6DC2B17EB62A100FA1F7E /* solver_direct_turbulent.cpp in Sources */,
+				40303E62246A064900CD7789 /* CRadP1Variable.cpp in Sources */,
+				4063F844246A03F800DE870E /* fds.cpp in Sources */,
 				E90B500222DFDFE4000ED392 /* CTurbSSTVariable.cpp in Sources */,
 				EB14FF9922F790500045FB27 /* CDiscAdjSinglezoneDriver.cpp in Sources */,
 				403426C4235F83B2005B5215 /* CFlowIncOutput.cpp in Sources */,
 				E941BB941B71D124005C6C06 /* mpi_structure.cpp in Sources */,
 				403426C5235F83B2005B5215 /* CHeatOutput.cpp in Sources */,
-				05E6DC2F17EB62A100FA1F7E /* solver_structure.cpp in Sources */,
+				4063F81C2469E40B00DE870E /* CIntegration.cpp in Sources */,
+				4063F84D246A03F800DE870E /* roe.cpp in Sources */,
 				E9D6EE5A23165FD300618E36 /* CDummyDriver.cpp in Sources */,
-				05E6DC3017EB62A100FA1F7E /* solver_template.cpp in Sources */,
-				356E2E192399979F0039E9B5 /* CFEAMeshElasticity.cpp in Sources */,
 				EB14FF9B22F790500045FB27 /* CMultizoneDriver.cpp in Sources */,
 				356E2E2123999AEA0039E9B5 /* CGeometry.cpp in Sources */,
 				05E6DC3117EB62A100FA1F7E /* SU2_CFD.cpp in Sources */,
+				40303E48246A05EC00CD7789 /* CIncNSSolver.cpp in Sources */,
 				356E2E2F23999B140039E9B5 /* CQUAD4.cpp in Sources */,
 				4040B279235FBFF200843C83 /* CSurfaceFVMDataSorter.cpp in Sources */,
 				400CEC2E21FA81A10019B790 /* printing_toolbox.cpp in Sources */,
-				E9C830932061E799004417A9 /* solver_direct_mean_fem.cpp in Sources */,
+				4063F83A246A03F800DE870E /* transition.cpp in Sources */,
+				40303E5A246A05EC00CD7789 /* CFEM_DG_NSSolver.cpp in Sources */,
 				E90B501122DFE043000ED392 /* CSysSolve_b.cpp in Sources */,
+				4063F849246A03F800DE870E /* radiation.cpp in Sources */,
 				E9D6EE772317B88F00618E36 /* CMeshBoundVariable.cpp in Sources */,
+				4063F85B246A053400DE870E /* CWindowingTools.cpp in Sources */,
 				E9C830832061E60E004417A9 /* fem_work_estimate_metis.cpp in Sources */,
-				E9F130CE1D513DA300EC8963 /* solver_direct_mean_inc.cpp in Sources */,
+				4063F83D246A03F800DE870E /* fvs.cpp in Sources */,
 				E9D6EE722317B88F00618E36 /* CDiscAdjMeshBoundVariable.cpp in Sources */,
 				E90B4FFB22DFDFE4000ED392 /* CAdjNSVariable.cpp in Sources */,
 				403426C7235F83B2005B5215 /* CMeshOutput.cpp in Sources */,


### PR DESCRIPTION
## Proposed Changes
1) Updated Xcode to include all the new files and not include deleted files. Compiles successfully for me.

2) I encountered one bug while doing this...

In adt_structure.cpp, I got many errors that looked like this:

```
In file included from /Users/jessie/Software/SU2-quickfix/Common/src/adt_structure.cpp:29:
/Users/jessie/Software/SU2-quickfix/Common/src/../include/adt_structure.hpp:161:34: error: implicit instantiation of undefined template 'std::__1::array<std::__1::vector<unsigned long, std::__1::allocator<unsigned long> >, 1>'
  array<vector<unsigned long>,1> FrontLeaves;
```

So I turned to Google / StackOverflow: https://stackoverflow.com/questions/12797051/implicit-instantiation-of-undefined-template-when-forward-declaring-template-c

And ``#include <array>`` worked for me. Didn't think too much of it, but I also don't have a PC or Linux readily available to test on another OS. I assumed it's a clang thing.
 
Tagging known Xcode users if any of you have a moment to review...
@economon @EduardoMolina @jayantmukho 


## Related Work
N/A



## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [ x] I am submitting my contribution to the develop branch.
- [ x] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [ n/a] My contribution is commented and consistent with SU2 style.
- [ n/a] I have added a test case that demonstrates my contribution, if necessary.
- [ n/a] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
