### PR TITLE
Fix spelling error in CSinglezoneDriver.cpp. Add missing comment for iteration_structure.hpp

### DIFF
--- a/SU2_CFD/include/drivers/CSinglezoneDriver.hpp
+++ b/SU2_CFD/include/drivers/CSinglezoneDriver.hpp
@@ -99,7 +99,7 @@ public:
   bool Monitor(unsigned long TimeIter) override;
 
   /*!
-     * \brief  Returns wheter all specified windowed-time-averaged ouputs have been converged
+     * \brief  Returns whether all specified windowed-time-averaged ouputs have been converged
      * \return Boolean indicating whether the problem is converged.
      */
   inline virtual bool GetTimeConvergence() const{

--- a/SU2_CFD/include/iteration_structure.hpp
+++ b/SU2_CFD/include/iteration_structure.hpp
@@ -101,7 +101,15 @@ public:
 
   /*!
    * \brief A virtual member.
-   * \param[in] ??? - Description here.
+   * \param[in] output - Pointer to the COutput class.
+   * \param[in] integration - Container vector with all the integration methods.
+   * \param[in] geometry - Geometrical definition of the problem.
+   * \param[in] solver - Container vector with all the solutions.
+   * \param[in] numerics - Description of the numerical method (the way in which the equations are solved).
+   * \param[in] config - Definition of the particular problem.
+   * \param[in] surface_movement - Surface movement classes of the problem.
+   * \param[in] grid_movement - Volume grid movement classes of the problem.
+   * \param[in] FFDBox - FFD FFDBoxes of the problem.
    */
   virtual void Preprocess(COutput *output,
                           CIntegration ****integration,


### PR DESCRIPTION
Preprocess in iteration_structure.hpp

## Proposed Changes
* Fix a minor comment spelling error in CSinglezoneDriver.cpp.  The preprocess method's comment section involving param in is missing, so I added in. 
 


## Related Work
*N/A



## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [x] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
