### PR TITLE
Fixed a bug for the interpolation weights of a tet

### DIFF
--- a/Common/src/adt_structure.cpp
+++ b/Common/src/adt_structure.cpp
@@ -1304,10 +1304,10 @@ bool CADTElemClass::CoorInTetrahedron(const unsigned long elemID,
      ((parCoor[0]+parCoor[1]+parCoor[2]) <= paramLowerBound)) {
     coorIsInside = true;
 
-    parCoor[0] = -0.5*(parCoor[0] + parCoor[1] + parCoor[2] + 1.0);
-    parCoor[1] =  0.5*(parCoor[0] + 1.0);
-    parCoor[2] =  0.5*(parCoor[1] + 1.0);
-    parCoor[3] =  0.5*(parCoor[2] + 1.0);
+    weightsInterpol[0] = -0.5*(parCoor[0] + parCoor[1] + parCoor[2] + 1.0);
+    weightsInterpol[1] =  0.5*(parCoor[0] + 1.0);
+    weightsInterpol[2] =  0.5*(parCoor[1] + 1.0);
+    weightsInterpol[3] =  0.5*(parCoor[2] + 1.0);
   }
 
   /* Return the value of coorIsInside. */

--- a/SU2_CFD/src/output/filewriter/CParaviewXMLFileWriter.cpp
+++ b/SU2_CFD/src/output/filewriter/CParaviewXMLFileWriter.cpp
@@ -343,7 +343,7 @@ void CParaviewXMLFileWriter::WriteDataArray(void* data, VTKDatatype type, unsign
   unsigned long totalByteSize;
   totalByteSize = globalSize*typeSize;
 
-  /*--- Only the master node writes the total size in bytes as int32 in front of the array data ---*/
+  /*--- Only the master node writes the total size in bytes as unsigned long in front of the array data ---*/
   
   if (!WriteMPIBinaryData(&totalByteSize, sizeof(unsigned long), MASTER_NODE)){
     SU2_MPI::Error("Writing array size failed", CURRENT_FUNCTION);


### PR DESCRIPTION
## Proposed Changes
This small PR fixes the interpolation weights of the function CADTElemClass::CoorInTetrahedron. Thanks @monika1387 for bringing that to our attention.
 


## Related Work
None



## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [ X] I am submitting my contribution to the develop branch.
- [ X] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [ X] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
