### PR TITLE
Small improvement to least squares gradients for non-periodic problems

### DIFF
--- a/Common/include/option_structure.hpp
+++ b/Common/include/option_structure.hpp
@@ -353,7 +353,7 @@ enum ENUM_INLET_SPANWISEINTERPOLATION {
   LINEAR_1D = 1,
   AKIMA_1D = 2,
 };
-static const map<string, ENUM_INLET_SPANWISEINTERPOLATION> Inlet_SpanwiseInterpolation_Map = {
+static const MapType<string, ENUM_INLET_SPANWISEINTERPOLATION> Inlet_SpanwiseInterpolation_Map = {
   MakePair("NONE", NO_INTERPOLATION)
   MakePair("LINEAR_1D",LINEAR_1D)
   MakePair("AKIMA_1D",AKIMA_1D)
@@ -366,7 +366,7 @@ enum ENUM_INLET_INTERPOLATIONTYPE {
   VR_VTHETA = 0,
   ALPHA_PHI = 1,
 };
-static const map<string, ENUM_INLET_INTERPOLATIONTYPE> Inlet_SpanwiseInterpolationType_Map = {
+static const MapType<string, ENUM_INLET_INTERPOLATIONTYPE> Inlet_SpanwiseInterpolationType_Map = {
   MakePair("VR_VTHETA",VR_VTHETA)
   MakePair("ALPHA_PHI",ALPHA_PHI)
 };

--- a/SU2_CFD/include/gradients/computeGradientsLeastSquares.hpp
+++ b/SU2_CFD/include/gradients/computeGradientsLeastSquares.hpp
@@ -27,6 +27,7 @@
  */
 
 #include "../../../Common/include/omp_structure.hpp"
+#include "../../../Common/include/toolboxes/geometry_toolbox.hpp"
 
 
 /*!
@@ -59,6 +60,7 @@ void computeGradientsLeastSquares(CSolver* solver,
                                   RMatrixType& Rmatrix)
 {
   constexpr size_t MAXNDIM = 3;
+  const bool periodic = (solver != nullptr) && (config.GetnMarker_Periodic() > 0);
 
   size_t nPointDomain = geometry.GetnPointDomain();
   size_t nDim = geometry.GetnDim();
@@ -105,20 +107,12 @@ void computeGradientsLeastSquares(CSolver* solver,
       /*--- Distance vector from iPoint to jPoint ---*/
 
       su2double dist_ij[MAXNDIM] = {0.0};
-
-      for (size_t iDim = 0; iDim < nDim; ++iDim)
-        dist_ij[iDim] = coord_j[iDim] - coord_i[iDim];
+      GeometryToolbox::Distance(nDim, coord_j, coord_i, dist_ij);
 
       /*--- Compute inverse weight, default 1 (unweighted). ---*/
 
       su2double weight = 1.0;
-
-      if (weighted)
-      {
-        weight = 0.0;
-        for (size_t iDim = 0; iDim < nDim; ++iDim)
-          weight += dist_ij[iDim] * dist_ij[iDim];
-      }
+      if(weighted) weight = GeometryToolbox::SquaredNorm(nDim, dist_ij);
 
       /*--- Sumations for entries of upper triangular matrix R. ---*/
 
@@ -152,145 +146,42 @@ void computeGradientsLeastSquares(CSolver* solver,
       }
     }
 
-    for (size_t iDim = 0; iDim < nDim; ++iDim)
-      for (size_t jDim = 0; jDim < nDim; ++jDim)
-        AD::SetPreaccOut(Rmatrix(iPoint, iDim, jDim));
+    if (periodic)
+    {
+      /*--- A second loop is required after periodic comms. ---*/
 
-    for (size_t iVar = varBegin; iVar < varEnd; ++iVar)
       for (size_t iDim = 0; iDim < nDim; ++iDim)
-        AD::SetPreaccOut(gradient(iPoint, iVar, iDim));
+        for (size_t jDim = 0; jDim < nDim; ++jDim)
+          AD::SetPreaccOut(Rmatrix(iPoint, iDim, jDim));
 
-    AD::EndPreacc();
+      for (size_t iVar = varBegin; iVar < varEnd; ++iVar)
+        for (size_t iDim = 0; iDim < nDim; ++iDim)
+          AD::SetPreaccOut(gradient(iPoint, iVar, iDim));
+
+      AD::EndPreacc();
+    }
+    else {
+      /*--- Periodic comms are not needed, solve the LS problem for iPoint. ---*/
+
+      solveLeastSquares(iPoint, false, nDim, varBegin, varEnd, gradient, Rmatrix);
+    }
   }
 
   /*--- Correct the gradient values across any periodic boundaries. ---*/
 
-  if (solver != nullptr)
+  if (periodic)
   {
     for (size_t iPeriodic = 1; iPeriodic <= config.GetnMarker_Periodic()/2; ++iPeriodic)
     {
       solver->InitiatePeriodicComms(&geometry, &config, iPeriodic, kindPeriodicComm);
       solver->CompletePeriodicComms(&geometry, &config, iPeriodic, kindPeriodicComm);
     }
-  }
 
-  /*--- Second loop over points of the grid to compute final gradient. ---*/
+    /*--- Second loop over points of the grid to compute final gradient. ---*/
 
-  SU2_OMP_FOR_DYN(chunkSize)
-  for (size_t iPoint = 0; iPoint < nPointDomain; ++iPoint)
-  {
-    /*--- Entries of upper triangular matrix R. ---*/
-
-    su2double r11 = Rmatrix(iPoint,0,0);
-    su2double r12 = Rmatrix(iPoint,0,1);
-    su2double r22 = Rmatrix(iPoint,1,1);
-    su2double r13 = 0.0, r23 = 0.0, r23_a = 0.0, r23_b = 0.0, r33 = 0.0;
-
-    AD::StartPreacc();
-    AD::SetPreaccIn(r11);
-    AD::SetPreaccIn(r12);
-    AD::SetPreaccIn(r22);
-
-    if (r11 >= 0.0) r11 = sqrt(r11);
-    if (r11 >= 0.0) r12 /= r11; else r12 = 0.0;
-    su2double tmp = r22-r12*r12;
-    if (tmp >= 0.0) r22 = sqrt(tmp); else r22 = 0.0;
-
-    if (nDim == 3) {
-      r13   = Rmatrix(iPoint,0,2);
-      r23_a = Rmatrix(iPoint,1,2);
-      r23_b = Rmatrix(iPoint,2,1);
-      r33   = Rmatrix(iPoint,2,2);
-
-      AD::SetPreaccIn(r13);
-      AD::SetPreaccIn(r23_a);
-      AD::SetPreaccIn(r23_b);
-      AD::SetPreaccIn(r33);
-
-      if (r11 >= 0.0) r13 /= r11; else r13 = 0.0;
-
-      if ((r22 >= 0.0) && (r11*r22 >= 0.0)) {
-        r23 = r23_a/r22 - r23_b*r12/(r11*r22);
-      } else {
-        r23 = 0.0;
-      }
-
-      tmp = r33 - r23*r23 - r13*r13;
-      if (tmp >= 0.0) r33 = sqrt(tmp); else r33 = 0.0;
-    }
-
-    /*--- Compute determinant ---*/
-
-    su2double detR2 = (r11*r22)*(r11*r22);
-    if (nDim == 3) detR2 *= r33*r33;
-
-    /*--- Detect singular matrices ---*/
-
-    bool singular = false;
-
-    if (detR2 <= EPS) {
-      detR2 = 1.0;
-      singular = true;
-    }
-
-    /*--- S matrix := inv(R)*traspose(inv(R)) ---*/
-
-    su2double Smatrix[MAXNDIM][MAXNDIM];
-
-    if (singular) {
-      for (size_t iDim = 0; iDim < nDim; ++iDim)
-        for (size_t jDim = 0; jDim < nDim; ++jDim)
-          Smatrix[iDim][jDim] = 0.0;
-    }
-    else {
-      if (nDim == 2) {
-        Smatrix[0][0] = (r12*r12+r22*r22)/detR2;
-        Smatrix[0][1] = -r11*r12/detR2;
-        Smatrix[1][0] = Smatrix[0][1];
-        Smatrix[1][1] = r11*r11/detR2;
-      }
-      else {
-        su2double z11 = r22*r33;
-        su2double z12 =-r12*r33;
-        su2double z13 = r12*r23-r13*r22;
-        su2double z22 = r11*r33;
-        su2double z23 =-r11*r23;
-        su2double z33 = r11*r22;
-
-        Smatrix[0][0] = (z11*z11+z12*z12+z13*z13)/detR2;
-        Smatrix[0][1] = (z12*z22+z13*z23)/detR2;
-        Smatrix[0][2] = (z13*z33)/detR2;
-        Smatrix[1][0] = Smatrix[0][1];
-        Smatrix[1][1] = (z22*z22+z23*z23)/detR2;
-        Smatrix[1][2] = (z23*z33)/detR2;
-        Smatrix[2][0] = Smatrix[0][2];
-        Smatrix[2][1] = Smatrix[1][2];
-        Smatrix[2][2] = (z33*z33)/detR2;
-      }
-    }
-
-    for (size_t iDim = 0; iDim < nDim; ++iDim)
-      for (size_t jDim = 0; jDim < nDim; ++jDim)
-        AD::SetPreaccOut(Smatrix[iDim][jDim]);
-
-    AD::EndPreacc();
-
-    /*--- Computation of the gradient: S*c ---*/
-
-    for (size_t iVar = varBegin; iVar < varEnd; ++iVar)
-    {
-      su2double Cvector[MAXNDIM];
-
-      for (size_t iDim = 0; iDim < nDim; ++iDim)
-      {
-        Cvector[iDim] = 0.0;
-        for (size_t jDim = 0; jDim < nDim; ++jDim)
-          Cvector[iDim] += Smatrix[iDim][jDim] * gradient(iPoint, iVar, jDim);
-      }
-
-      for (size_t iDim = 0; iDim < nDim; ++iDim)
-        gradient(iPoint, iVar, iDim) = Cvector[iDim];
-    }
+    SU2_OMP_FOR_DYN(chunkSize)
+    for (size_t iPoint = 0; iPoint < nPointDomain; ++iPoint)
+      solveLeastSquares(iPoint, true, nDim, varBegin, varEnd, gradient, Rmatrix);
   }
 
   /*--- If no solver was provided we do not communicate ---*/
@@ -303,4 +194,126 @@ void computeGradientsLeastSquares(CSolver* solver,
     solver->CompleteComms(&geometry, &config, kindMpiComm);
   }
 
+}
+
+template<class GradientType, class RMatrixType>
+FORCEINLINE void solveLeastSquares(size_t iPoint,
+                                   bool periodic,
+                                   size_t nDim,
+                                   size_t varBegin,
+                                   size_t varEnd,
+                                   GradientType& gradient,
+                                   RMatrixType& Rmatrix) {
+  constexpr size_t MAXNDIM = 3;
+
+  /*--- Entries of upper triangular matrix R. ---*/
+
+  su2double r11 = Rmatrix(iPoint,0,0);
+  su2double r12 = Rmatrix(iPoint,0,1);
+  su2double r22 = Rmatrix(iPoint,1,1);
+  su2double r13 = 0.0, r23 = 0.0, r23_a = 0.0, r23_b = 0.0, r33 = 0.0;
+
+  if (periodic)
+  {
+    AD::StartPreacc();
+    AD::SetPreaccIn(r11);
+    AD::SetPreaccIn(r12);
+    AD::SetPreaccIn(r22);
+  }
+
+  if (r11 >= 0.0) r11 = sqrt(r11);
+  if (r11 >= 0.0) r12 /= r11; else r12 = 0.0;
+  su2double tmp = r22-r12*r12;
+  if (tmp >= 0.0) r22 = sqrt(tmp); else r22 = 0.0;
+
+  if (nDim == 3) {
+    r13   = Rmatrix(iPoint,0,2);
+    r23_a = Rmatrix(iPoint,1,2);
+    r23_b = Rmatrix(iPoint,2,1);
+    r33   = Rmatrix(iPoint,2,2);
+
+    if (periodic)
+    {
+      AD::SetPreaccIn(r13);
+      AD::SetPreaccIn(r23_a);
+      AD::SetPreaccIn(r23_b);
+      AD::SetPreaccIn(r33);
+    }
+
+    if (r11 >= 0.0) r13 /= r11; else r13 = 0.0;
+
+    if ((r22 >= 0.0) && (r11*r22 >= 0.0)) {
+      r23 = r23_a/r22 - r23_b*r12/(r11*r22);
+    } else {
+      r23 = 0.0;
+    }
+
+    tmp = r33 - r23*r23 - r13*r13;
+    if (tmp >= 0.0) r33 = sqrt(tmp); else r33 = 0.0;
+  }
+
+  /*--- Compute determinant ---*/
+
+  su2double detR2 = (r11*r22)*(r11*r22);
+  if (nDim == 3) detR2 *= r33*r33;
+
+  /*--- Detect singular matrix ---*/
+
+  bool singular = (detR2 <= EPS);
+  if(singular) detR2 = 1.0;
+
+  /*--- S matrix := inv(R)*traspose(inv(R)) ---*/
+
+  su2double Smatrix[MAXNDIM][MAXNDIM];
+
+  if (singular) {
+    for (size_t iDim = 0; iDim < nDim; ++iDim)
+      for (size_t jDim = 0; jDim < nDim; ++jDim)
+        Smatrix[iDim][jDim] = 0.0;
+  }
+  else {
+    if (nDim == 2) {
+      Smatrix[0][0] = (r12*r12+r22*r22)/detR2;
+      Smatrix[0][1] = -r11*r12/detR2;
+      Smatrix[1][0] = Smatrix[0][1];
+      Smatrix[1][1] = r11*r11/detR2;
+    }
+    else {
+      su2double z11 = r22*r33;
+      su2double z12 =-r12*r33;
+      su2double z13 = r12*r23-r13*r22;
+      su2double z22 = r11*r33;
+      su2double z23 =-r11*r23;
+      su2double z33 = r11*r22;
+
+      Smatrix[0][0] = (z11*z11+z12*z12+z13*z13)/detR2;
+      Smatrix[0][1] = (z12*z22+z13*z23)/detR2;
+      Smatrix[0][2] = (z13*z33)/detR2;
+      Smatrix[1][0] = Smatrix[0][1];
+      Smatrix[1][1] = (z22*z22+z23*z23)/detR2;
+      Smatrix[1][2] = (z23*z33)/detR2;
+      Smatrix[2][0] = Smatrix[0][2];
+      Smatrix[2][1] = Smatrix[1][2];
+      Smatrix[2][2] = (z33*z33)/detR2;
+    }
+  }
+
+  /*--- Computation of the gradient: S*c ---*/
+
+  for (size_t iVar = varBegin; iVar < varEnd; ++iVar)
+  {
+    su2double Cvector[MAXNDIM] = {0.0};
+
+    for (size_t iDim = 0; iDim < nDim; ++iDim)
+      for (size_t jDim = 0; jDim < nDim; ++jDim)
+        Cvector[iDim] += Smatrix[iDim][jDim] * gradient(iPoint, iVar, jDim);
+
+    for (size_t iDim = 0; iDim < nDim; ++iDim)
+    {
+      gradient(iPoint, iVar, iDim) = Cvector[iDim];
+      AD::SetPreaccOut(gradient(iPoint, iVar, iDim));
+    }
+  }
+
+  AD::EndPreacc();
 }

--- a/SU2_CFD/include/gradients/computeGradientsLeastSquares.hpp
+++ b/SU2_CFD/include/gradients/computeGradientsLeastSquares.hpp
@@ -298,6 +298,14 @@ FORCEINLINE void solveLeastSquares(size_t iPoint,
     }
   }
 
+  if (periodic)
+  {
+    for (size_t iDim = 0; iDim < nDim; ++iDim)
+      for (size_t jDim = 0; jDim < nDim; ++jDim)
+        AD::SetPreaccOut(Smatrix[iDim][jDim]);
+    AD::EndPreacc();
+  }
+
   /*--- Computation of the gradient: S*c ---*/
 
   for (size_t iVar = varBegin; iVar < varEnd; ++iVar)
@@ -309,11 +317,14 @@ FORCEINLINE void solveLeastSquares(size_t iPoint,
         Cvector[iDim] += Smatrix[iDim][jDim] * gradient(iPoint, iVar, jDim);
 
     for (size_t iDim = 0; iDim < nDim; ++iDim)
-    {
       gradient(iPoint, iVar, iDim) = Cvector[iDim];
-      AD::SetPreaccOut(gradient(iPoint, iVar, iDim));
-    }
   }
 
-  AD::EndPreacc();
+  if (!periodic)
+  {
+    for (size_t iVar = varBegin; iVar < varEnd; ++iVar)
+      for (size_t iDim = 0; iDim < nDim; ++iDim)
+        AD::SetPreaccOut(gradient(iPoint, iVar, iDim));
+    AD::EndPreacc();
+  }
 }


### PR DESCRIPTION
## Proposed Changes
The computation was done in two loops to account for period comms in between.
When there are no periodic comms one loop is sufficient, better locality, more effective AD accumulation.
To do this the function was split in two, which is also good.

## Related Work
#594

## PR Checklist
- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [X] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
