### PR TITLE
Fix normal computation

### DIFF
--- a/Common/include/geometry/dual_grid/CEdge.hpp
+++ b/Common/include/geometry/dual_grid/CEdge.hpp
@@ -130,25 +130,27 @@ public:
    * \param[in] coord_Edge_CG - Coordinates of the centre of gravity of the edge.
    * \param[in] coord_FaceElem_CG - Coordinates of the centre of gravity of the face of an element.
    * \param[in] coord_Elem_CG - Coordinates of the centre of gravity of the element.
-   * \param[in] config - Definition of the particular problem.
+   * \param[in] vec_ij - Vector between nodes i and j, to check normal direction.
    * \return Compute the normal (dimensional) to the face that makes the control volume boundaries.
    */
   void SetNodes_Coord(unsigned long iEdge,
                       const su2double* coord_Edge_CG,
                       const su2double* coord_FaceElem_CG,
-                      const su2double* coord_Elem_CG);
+                      const su2double* coord_Elem_CG,
+                      const su2double* vec_ij);
 
   /*!
    * \brief Set the face that corresponds to an edge (2D version).
    * \param[in] iEdge - Edge index.
    * \param[in] coord_Edge_CG - Coordinates of the centre of gravity of the edge.
    * \param[in] coord_Elem_CG - Coordinates of the centre of gravity of the element.
-   * \param[in] config - Definition of the particular problem.
+   * \param[in] vec_ij - Vector between nodes i and j, to check normal direction.
    * \return Compute the normal (dimensional) to the face that makes the contorl volume boundaries.
    */
   void SetNodes_Coord(unsigned long iEdge,
                       const su2double* coord_Edge_CG,
-                      const su2double* coord_Elem_CG);
+                      const su2double* coord_Elem_CG,
+                      const su2double* vec_ij);
 
   /*!
    * \brief Copy the the normal vector of a face.

--- a/Common/src/geometry/CPhysicalGeometry.cpp
+++ b/Common/src/geometry/CPhysicalGeometry.cpp
@@ -7789,7 +7789,7 @@ void CPhysicalGeometry::SetControlVolume(CConfig *config, unsigned short action)
           Coord_Edge_CG[iDim] = edges->GetCG(iEdge,iDim);
           Coord_Elem_CG[iDim] = elem[iElem]->GetCG(iDim);
           Coord_FaceElem_CG[iDim] = elem[iElem]->GetFaceCG(iFace, iDim);
-          Vec_ij[iDim] = dir*(Coord_FacejPoint[iDim] - Coord_FacejPoint[iDim]);
+          Vec_ij[iDim] = dir*(Coord_FacejPoint[iDim] - Coord_FaceiPoint[iDim]);
         }
 
         su2double Volume_i, Volume_j;

--- a/Common/src/geometry/dual_grid/CEdge.cpp
+++ b/Common/src/geometry/dual_grid/CEdge.cpp
@@ -97,7 +97,8 @@ su2double CEdge::GetVolume(const su2double *coord_Edge_CG,
 void CEdge::SetNodes_Coord(unsigned long iEdge,
                            const su2double *coord_Edge_CG,
                            const su2double *coord_FaceElem_CG,
-                           const su2double *coord_Elem_CG) {
+                           const su2double *coord_Elem_CG, 
+                           const su2double *vec_ij) {
 
   constexpr unsigned long nDim = 3;
 
@@ -114,8 +115,12 @@ void CEdge::SetNodes_Coord(unsigned long iEdge,
 
   CrossProduct(vec_a, vec_b, Dim_Normal);
 
+  const su2double sign = ((Dim_Normal[0] * vec_ij[0] 
+                         + Dim_Normal[1] * vec_ij[1] 
+                         + Dim_Normal[2] * vec_ij[2]) > 0) ? 1.0 : -1.0;
+
   for (auto iDim = 0ul; iDim < nDim; ++iDim)
-    Normal(iEdge,iDim) += 0.5 * Dim_Normal[iDim];
+    Normal(iEdge,iDim) += sign * 0.5 * Dim_Normal[iDim];
 
   AD::SetPreaccOut(Normal[iEdge], nDim);
   AD::EndPreacc();
@@ -123,7 +128,8 @@ void CEdge::SetNodes_Coord(unsigned long iEdge,
 
 void CEdge::SetNodes_Coord(unsigned long iEdge,
                            const su2double *coord_Edge_CG,
-                           const su2double *coord_Elem_CG) {
+                           const su2double *coord_Elem_CG,
+                           const su2double *vec_ij) {
 
   constexpr unsigned long nDim = 2;
 
@@ -132,8 +138,12 @@ void CEdge::SetNodes_Coord(unsigned long iEdge,
   AD::SetPreaccIn(coord_Edge_CG, nDim);
   AD::SetPreaccIn(Normal[iEdge], nDim);
 
-  Normal(iEdge,0) += coord_Elem_CG[1] - coord_Edge_CG[1];
-  Normal(iEdge,1) -= coord_Elem_CG[0] - coord_Edge_CG[0];
+  const su2double nx = coord_Elem_CG[1] - coord_Edge_CG[1];
+  const su2double ny = -(coord_Elem_CG[0] - coord_Edge_CG[0])
+  const su2double sign = ((nx * vec_ij[0] + ny * vec_ij[1]) > 0) ? 1.0 : -1.0;
+
+  Normal(iEdge,0) += sign*nx; 
+  Normal(iEdge,1) += sign*ny;
 
   AD::SetPreaccOut(Normal[iEdge], nDim);
   AD::EndPreacc();

--- a/Common/src/geometry/dual_grid/CEdge.cpp
+++ b/Common/src/geometry/dual_grid/CEdge.cpp
@@ -139,7 +139,7 @@ void CEdge::SetNodes_Coord(unsigned long iEdge,
   AD::SetPreaccIn(Normal[iEdge], nDim);
 
   const su2double nx = coord_Elem_CG[1] - coord_Edge_CG[1];
-  const su2double ny = -(coord_Elem_CG[0] - coord_Edge_CG[0])
+  const su2double ny = -(coord_Elem_CG[0] - coord_Edge_CG[0]);
   const su2double sign = ((nx * vec_ij[0] + ny * vec_ij[1]) > 0) ? 1.0 : -1.0;
 
   Normal(iEdge,0) += sign*nx; 


### PR DESCRIPTION
## Proposed Changes
This is a slight modification to the computation of face normals. Previously, the inputs to SetCoord_CG were swapped depending on whether iPoint < jPoint, but this can result in an inconsistent direction for the normals of each sub-face associated with edge i/j (i.e. for each element connected to edge i/j).

This logic is replaced by dotting the sub-face normals with the edge vector from i to j (or j to i if iPoint > jPoint), and flipping the normal if the product is negative.

This fix might be needed for the surface elements too, but I was less sure of what's going on in SetBoundControlVolume().

## PR Checklist

- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [X] My contribution is commented and consistent with SU2 style.
- [X] I have added a test case that demonstrates my contribution, if necessary.
- [X] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
