### PR TITLE
Fix vtu output on Windows

### DIFF
--- a/SU2_CFD/src/output/filewriter/CParaviewXMLFileWriter.cpp
+++ b/SU2_CFD/src/output/filewriter/CParaviewXMLFileWriter.cpp
@@ -71,7 +71,7 @@ void CParaviewXMLFileWriter::Write_Data(){
   char str_buf[255];
 
   OpenMPIFile();
-  
+
   dataOffset = 0;
 
   /*--- Communicate the number of total points that will be
@@ -295,7 +295,7 @@ void CParaviewXMLFileWriter::Write_Data(){
         }
       }
 
-      WriteDataArray(dataBufferFloat.data(), VTKDatatype::FLOAT32, myPoint*NCOORDS, GlobalPoint*NCOORDS, 
+      WriteDataArray(dataBufferFloat.data(), VTKDatatype::FLOAT32, myPoint*NCOORDS, GlobalPoint*NCOORDS,
                      dataSorter->GetnPointCumulative(rank)*NCOORDS);
 
       VarCounter++;
@@ -336,23 +336,21 @@ void CParaviewXMLFileWriter::WriteDataArray(void* data, VTKDatatype type, unsign
 
   /*--- Compute the size of the data to write in bytes ---*/
 
-  int byteSize;
-  byteSize = arraySize*typeSize;
+  size_t byteSize = arraySize*typeSize;
 
   /*--- The total data size ---*/
-  unsigned long totalByteSize;
-  totalByteSize = globalSize*typeSize;
+  size_t totalByteSize = globalSize*typeSize;
 
   /*--- Only the master node writes the total size in bytes as unsigned long in front of the array data ---*/
-  
-  if (!WriteMPIBinaryData(&totalByteSize, sizeof(unsigned long), MASTER_NODE)){
+
+  if (!WriteMPIBinaryData(&totalByteSize, sizeof(size_t), MASTER_NODE)){
     SU2_MPI::Error("Writing array size failed", CURRENT_FUNCTION);
   }
-  
+
   /*--- Collectively write all the data ---*/
-  
+
   if (!WriteMPIBinaryDataAll(data, byteSize, totalByteSize, offset*typeSize)){
-    SU2_MPI::Error("Writing data array failed", CURRENT_FUNCTION);    
+    SU2_MPI::Error("Writing data array failed", CURRENT_FUNCTION);
   }
 }
 
@@ -373,13 +371,13 @@ void CParaviewXMLFileWriter::AddDataArray(VTKDatatype type, string name,
   string offsetStr = ss.str();
 
   std::string typeStr;
-  unsigned long typeSize = 0, totalByteSize;
+  unsigned long typeSize = 0;
 
   GetTypeInfo(type, typeStr, typeSize);
 
   /*--- Total data size ---*/
 
-  totalByteSize = globalSize*typeSize;
+  size_t totalByteSize = globalSize*typeSize;
 
   /*--- Write the ASCII XML header information for this array ---*/
 
@@ -389,6 +387,6 @@ void CParaviewXMLFileWriter::AddDataArray(VTKDatatype type, string name,
                  string(" offset=") + offsetStr +
                  string(" format=\"appended\"/>\n"), MASTER_NODE);
 
-  dataOffset += totalByteSize + sizeof(unsigned long);
+  dataOffset += totalByteSize + sizeof(size_t);
 
 }


### PR DESCRIPTION
## Proposed Changes
Some folks are having issues on Windows: https://www.cfd-online.com/Forums/su2/227916-problem-opening-vtu-file-paraview.html
@talbring and I think it might be the classic "unsigned long is 32bits on Windows" problem, maybe this fixes it, I do not have access to a Windows machine, if someone could test this it would be great.

## Related Work
#980

## PR Checklist
- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [X] My contribution is commented and consistent with SU2 style.