### PR TITLE
Fix underrelaxation

### DIFF
--- a/SU2_CFD/include/solvers/CFVMFlowSolverBase.inl
+++ b/SU2_CFD/include/solvers/CFVMFlowSolverBase.inl
@@ -604,13 +604,6 @@ void CFVMFlowSolverBase<V, R>::ComputeUnderRelaxationFactor(CSolver** solver_con
       }
     }
 
-    /* In case of turbulence, take the min of the under-relaxation factor
-     between the mean flow and the turb model. */
-
-    if (config->GetKind_Turb_Model() != NONE)
-      localUnderRelaxation =
-          min(localUnderRelaxation, solver_container[TURB_SOL]->GetNodes()->GetUnderRelaxation(iPoint));
-
     /* Threshold the relaxation factor in the event that there is
      a very small value. This helps avoid catastrophic crashes due
      to non-realizable states by canceling the update. */

--- a/SU2_CFD/include/solvers/CFVMFlowSolverBase.inl
+++ b/SU2_CFD/include/solvers/CFVMFlowSolverBase.inl
@@ -597,7 +597,7 @@ void CFVMFlowSolverBase<V, R>::ComputeUnderRelaxationFactor(CSolver** solver_con
 
       if ((iVar == 0) || (iVar == nVar - 1)) {
         const unsigned long index = iPoint * nVar + iVar;
-        su2double ratio = fabs(LinSysSol[index]) / (nodes->GetSolution(iPoint, iVar) + EPS);
+        su2double ratio = fabs(LinSysSol[index]) / (fabs(nodes->GetSolution(iPoint, iVar)) + EPS);
         if (ratio > allowableRatio) {
           localUnderRelaxation = min(allowableRatio / ratio, localUnderRelaxation);
         }

--- a/SU2_CFD/src/solvers/CTurbSolver.cpp
+++ b/SU2_CFD/src/solvers/CTurbSolver.cpp
@@ -674,7 +674,7 @@ void CTurbSolver::ComputeUnderRelaxationFactor(CSolver **solver_container, const
          turbulence variables can change over a nonlinear iteration. */
 
         const unsigned long index = iPoint * nVar + iVar;
-        su2double ratio = fabs(LinSysSol[index]) / (nodes->GetSolution(iPoint, iVar) + EPS);
+        su2double ratio = fabs(LinSysSol[index]) / (fabs(nodes->GetSolution(iPoint, iVar)) + EPS);
         if (ratio > allowableRatio) {
           localUnderRelaxation = min(allowableRatio / ratio, localUnderRelaxation);
         }

--- a/SU2_CFD/src/solvers/CTurbSolver.cpp
+++ b/SU2_CFD/src/solvers/CTurbSolver.cpp
@@ -682,6 +682,10 @@ void CTurbSolver::ComputeUnderRelaxationFactor(CSolver **solver_container, const
       }
     }
 
+    /* Choose the minimum factor between mean flow and turbulence. */
+
+    localUnderRelaxation = min(localUnderRelaxation, solver_container[FLOW_SOL]->GetNodes()->GetUnderRelaxation(iPoint));
+
     /* Threshold the relaxation factor in the event that there is
      a very small value. This helps avoid catastrophic crashes due
      to non-realizable states by canceling the update. */

--- a/TestCases/hybrid_regression.py
+++ b/TestCases/hybrid_regression.py
@@ -143,7 +143,7 @@ def main():
     rae2822_sa.cfg_dir   = "rans/rae2822"
     rae2822_sa.cfg_file  = "turb_SA_RAE2822.cfg"
     rae2822_sa.test_iter = 20
-    rae2822_sa.test_vals = [-2.021218, -5.268447, 0.807465, 0.060897]
+    rae2822_sa.test_vals = [-2.021224, -5.268445, 0.807582, 0.060731]
     test_list.append(rae2822_sa)
 
     # RAE2822 SST
@@ -175,7 +175,7 @@ def main():
     turb_oneram6.cfg_dir   = "rans/oneram6"
     turb_oneram6.cfg_file  = "turb_ONERAM6.cfg"
     turb_oneram6.test_iter = 10
-    turb_oneram6.test_vals = [-2.412446, -6.702976, 0.229866, 0.147638]
+    turb_oneram6.test_vals = [-2.388851, -6.689340, 0.230320, 0.157649]
     test_list.append(turb_oneram6)
 
     # NACA0012 (SA, FUN3D finest grid results: CL=1.0983, CD=0.01242)
@@ -215,7 +215,7 @@ def main():
     propeller_var_load.cfg_dir   = "rans/actuatordisk_variable_load"
     propeller_var_load.cfg_file  = "propeller_variable_load.cfg"
     propeller_var_load.test_iter = 20
-    propeller_var_load.test_vals = [-1.810684, -4.535582, 0.000252, 0.170455]
+    propeller_var_load.test_vals = [-1.808010, -4.535613, 0.000190, 0.172483]
     test_list.append(propeller_var_load)
 
     #################################
@@ -240,7 +240,7 @@ def main():
     turb_naca0012_1c.cfg_dir   = "rans_uq/naca0012"
     turb_naca0012_1c.cfg_file  = "turb_NACA0012_uq_1c.cfg"
     turb_naca0012_1c.test_iter = 10
-    turb_naca0012_1c.test_vals = [-4.979339, 1.140084, 1.217182, 0.220079]
+    turb_naca0012_1c.test_vals = [-4.979389, 1.140070, 1.211965, 0.194237]
     test_list.append(turb_naca0012_1c)
 
     # NACA0012 2c
@@ -248,7 +248,7 @@ def main():
     turb_naca0012_2c.cfg_dir   = "rans_uq/naca0012"
     turb_naca0012_2c.cfg_file  = "turb_NACA0012_uq_2c.cfg"
     turb_naca0012_2c.test_iter = 10
-    turb_naca0012_2c.test_vals = [-5.484195, 0.969780, 1.315926, 0.258346]
+    turb_naca0012_2c.test_vals = [-5.484195, 0.969789, 1.310525, 0.231240]
     test_list.append(turb_naca0012_2c)
 
     # NACA0012 3c
@@ -256,7 +256,7 @@ def main():
     turb_naca0012_3c.cfg_dir   = "rans_uq/naca0012"
     turb_naca0012_3c.cfg_file  = "turb_NACA0012_uq_3c.cfg"
     turb_naca0012_3c.test_iter = 10
-    turb_naca0012_3c.test_vals = [-5.586959, 0.932347, 1.540973, 0.345562]
+    turb_naca0012_3c.test_vals = [-5.586959, 0.932359, 1.535455, 0.315820]
     test_list.append(turb_naca0012_3c)
 
     # NACA0012 p1c1

--- a/TestCases/hybrid_regression.py
+++ b/TestCases/hybrid_regression.py
@@ -264,7 +264,7 @@ def main():
     turb_naca0012_p1c1.cfg_dir   = "rans_uq/naca0012"
     turb_naca0012_p1c1.cfg_file  = "turb_NACA0012_uq_p1c1.cfg"
     turb_naca0012_p1c1.test_iter = 10
-    turb_naca0012_p1c1.test_vals = [-5.132080, 1.076459, 1.183320, 0.207012]
+    turb_naca0012_p1c1.test_vals = [-5.132081, 1.076462, 1.178093, 0.181595]
     test_list.append(turb_naca0012_p1c1)
 
     # NACA0012 p1c2
@@ -272,7 +272,7 @@ def main():
     turb_naca0012_p1c2.cfg_dir   = "rans_uq/naca0012"
     turb_naca0012_p1c2.cfg_file  = "turb_NACA0012_uq_p1c2.cfg"
     turb_naca0012_p1c2.test_iter = 10
-    turb_naca0012_p1c2.test_vals = [-5.556645, 0.945121, 1.246337, 0.231311]
+    turb_naca0012_p1c2.test_vals = [-5.556648, 0.945129, 1.240986, 0.205071]
     test_list.append(turb_naca0012_p1c2)
 
     ######################################
@@ -293,7 +293,7 @@ def main():
     hb_rans_preconditioning.cfg_dir   = "harmonic_balance/hb_rans_preconditioning"
     hb_rans_preconditioning.cfg_file  = "davis.cfg"
     hb_rans_preconditioning.test_iter = 25
-    hb_rans_preconditioning.test_vals = [-1.909633, -5.954752, 0.007773, 0.131217]
+    hb_rans_preconditioning.test_vals = [-1.902391, -5.950120, 0.007786, 0.128110]
     hb_rans_preconditioning.new_output = False
     test_list.append(hb_rans_preconditioning)
 
@@ -386,7 +386,7 @@ def main():
     Jones_tc.cfg_dir   = "turbomachinery/APU_turbocharger"
     Jones_tc.cfg_file  = "Jones.cfg"
     Jones_tc.test_iter = 5
-    Jones_tc.test_vals = [-5.280316, 0.379651, 44.725470, 2.271540]
+    Jones_tc.test_vals = [-5.280316, 0.379651, 72.207590, 1.277638]
     Jones_tc.new_output = False
     test_list.append(Jones_tc)
 
@@ -395,7 +395,7 @@ def main():
     Jones_tc_rst.cfg_dir   = "turbomachinery/APU_turbocharger"
     Jones_tc_rst.cfg_file  = "Jones_rst.cfg"
     Jones_tc_rst.test_iter = 5
-    Jones_tc_rst.test_vals = [-4.626647, -1.570858, 34.014100, 10.190720]
+    Jones_tc_rst.test_vals = [-4.625330, -1.568896, 33.995140, 10.181610]
     Jones_tc_rst.new_output = False
     test_list.append(Jones_tc_rst)
 
@@ -404,7 +404,7 @@ def main():
     axial_stage2D.cfg_dir   = "turbomachinery/axial_stage_2D"
     axial_stage2D.cfg_file  = "Axial_stage2D.cfg"
     axial_stage2D.test_iter = 20
-    axial_stage2D.test_vals = [-1.933199, 5.381560, 73.357900, 1.780500]
+    axial_stage2D.test_vals = [-1.933200, 5.379973, 73.357900, 0.925878]
     axial_stage2D.new_output = False
     test_list.append(axial_stage2D)
 
@@ -413,7 +413,7 @@ def main():
     transonic_stator.cfg_dir   = "turbomachinery/transonic_stator_2D"
     transonic_stator.cfg_file  = "transonic_stator.cfg"
     transonic_stator.test_iter = 20
-    transonic_stator.test_vals = [-0.563540, 5.823232, 96.736080, 0.062426]
+    transonic_stator.test_vals = [-0.562430, 5.828446, 96.436050, 0.062506]
     transonic_stator.new_output = False
     test_list.append(transonic_stator)
 

--- a/TestCases/parallel_regression.py
+++ b/TestCases/parallel_regression.py
@@ -188,7 +188,7 @@ def main():
     rae2822_sa.cfg_dir   = "rans/rae2822"
     rae2822_sa.cfg_file  = "turb_SA_RAE2822.cfg"
     rae2822_sa.test_iter = 20
-    rae2822_sa.test_vals = [-2.013881, -5.271311, 0.814981, 0.061858] #last 4 columns
+    rae2822_sa.test_vals = [-2.014031, -5.271357, 0.815010, 0.061599] #last 4 columns
     rae2822_sa.su2_exec  = "parallel_computation.py -f"
     rae2822_sa.timeout   = 1600
     rae2822_sa.tol       = 0.00001
@@ -232,7 +232,7 @@ def main():
     turb_oneram6.cfg_dir   = "rans/oneram6"
     turb_oneram6.cfg_file  = "turb_ONERAM6.cfg"
     turb_oneram6.test_iter = 10
-    turb_oneram6.test_vals = [-2.412448, -6.702975, 0.229867, 0.147637] #last 4 columns
+    turb_oneram6.test_vals = [-2.388853, -6.689340, 0.230321, 0.157649] #last 4 columns
     turb_oneram6.su2_exec  = "parallel_computation.py -f"
     turb_oneram6.timeout   = 3200
     turb_oneram6.tol       = 0.00001
@@ -287,7 +287,7 @@ def main():
     propeller_var_load.cfg_dir   = "rans/actuatordisk_variable_load"
     propeller_var_load.cfg_file  = "propeller_variable_load.cfg"
     propeller_var_load.test_iter = 20
-    propeller_var_load.test_vals = [-1.839227, -4.535048, -0.000314, 0.169980] #last 4 columns
+    propeller_var_load.test_vals = [-1.839281, -4.535070, -0.000323, 0.171814] #last 4 columns
     propeller_var_load.su2_exec  = "parallel_computation.py -f"
     propeller_var_load.timeout   = 3200
     propeller_var_load.tol       = 0.00001
@@ -642,7 +642,7 @@ def main():
     turb_naca0012_1c.cfg_dir   = "rans_uq/naca0012"
     turb_naca0012_1c.cfg_file  = "turb_NACA0012_uq_1c.cfg"
     turb_naca0012_1c.test_iter = 10
-    turb_naca0012_1c.test_vals = [-4.973604, 1.141377, 0.870252, 0.041511] #last 4 columns
+    turb_naca0012_1c.test_vals = [-4.973604, 1.141376, 0.865859, 0.015106] #last 4 columns
     turb_naca0012_1c.su2_exec  = "parallel_computation.py -f"
     turb_naca0012_1c.timeout   = 1600
     turb_naca0012_1c.tol       = 0.00001
@@ -653,7 +653,7 @@ def main():
     turb_naca0012_2c.cfg_dir   = "rans_uq/naca0012"
     turb_naca0012_2c.cfg_file  = "turb_NACA0012_uq_2c.cfg"
     turb_naca0012_2c.test_iter = 10
-    turb_naca0012_2c.test_vals = [-5.484222, 0.967203, 0.909852, 0.056844] #last 4 columns
+    turb_naca0012_2c.test_vals = [-5.484222, 0.967199, 0.905520, 0.029991] #last 4 columns
     turb_naca0012_2c.su2_exec  = "parallel_computation.py -f"
     turb_naca0012_2c.timeout   = 1600
     turb_naca0012_2c.tol       = 0.00001
@@ -664,7 +664,7 @@ def main():
     turb_naca0012_3c.cfg_dir   = "rans_uq/naca0012"
     turb_naca0012_3c.cfg_file  = "turb_NACA0012_uq_3c.cfg"
     turb_naca0012_3c.test_iter = 10
-    turb_naca0012_3c.test_vals = [-5.587082, 0.929251, 1.008548, 0.094463] #last 4 columns
+    turb_naca0012_3c.test_vals = [-5.587082, 0.929246, 1.004417, 0.066538] #last 4 columns
     turb_naca0012_3c.su2_exec  = "parallel_computation.py -f"
     turb_naca0012_3c.timeout   = 1600
     turb_naca0012_3c.tol       = 0.00001
@@ -675,7 +675,7 @@ def main():
     turb_naca0012_p1c1.cfg_dir   = "rans_uq/naca0012"
     turb_naca0012_p1c1.cfg_file  = "turb_NACA0012_uq_p1c1.cfg"
     turb_naca0012_p1c1.test_iter = 10
-    turb_naca0012_p1c1.test_vals = [-5.128243, 1.076374, 0.959431, 0.067416] #last 4 columns
+    turb_naca0012_p1c1.test_vals = [-5.128243, 1.076375, 0.955242, 0.039885] #last 4 columns
     turb_naca0012_p1c1.su2_exec  = "parallel_computation.py -f"
     turb_naca0012_p1c1.timeout   = 1600
     turb_naca0012_p1c1.tol       = 0.00001
@@ -686,7 +686,7 @@ def main():
     turb_naca0012_p1c2.cfg_dir   = "rans_uq/naca0012"
     turb_naca0012_p1c2.cfg_file  = "turb_NACA0012_uq_p1c2.cfg"
     turb_naca0012_p1c2.test_iter = 10
-    turb_naca0012_p1c2.test_vals = [-5.556656, 0.941889, 0.956330, 0.069297] #last 4 columns
+    turb_naca0012_p1c2.test_vals = [-5.556656, 0.941887, 0.952078, 0.041824] #last 4 columns
     turb_naca0012_p1c2.su2_exec  = "parallel_computation.py -f"
     turb_naca0012_p1c2.timeout   = 1600
     turb_naca0012_p1c2.tol       = 0.00001
@@ -713,7 +713,7 @@ def main():
     hb_rans_preconditioning.cfg_dir   = "harmonic_balance/hb_rans_preconditioning"
     hb_rans_preconditioning.cfg_file  = "davis.cfg"
     hb_rans_preconditioning.test_iter = 25
-    hb_rans_preconditioning.test_vals = [-1.909596, -5.954720, 0.007773, 0.131219] #last 4 columns
+    hb_rans_preconditioning.test_vals = [-1.902361, -5.950093, 0.007786, 0.128110] #last 4 columns
     hb_rans_preconditioning.su2_exec  = "parallel_computation.py -f"
     hb_rans_preconditioning.timeout   = 1600
     hb_rans_preconditioning.tol       = 0.00001
@@ -856,7 +856,7 @@ def main():
     Jones_tc.cfg_dir   = "turbomachinery/APU_turbocharger"
     Jones_tc.cfg_file  = "Jones.cfg"
     Jones_tc.test_iter = 5
-    Jones_tc.test_vals = [-5.280323, 0.379654, 44.725390, 2.271597] #last 4 columns
+    Jones_tc.test_vals = [-5.280323, 0.379654, 72.206950, 1.277699] #last 4 columns
     Jones_tc.su2_exec  = "parallel_computation.py -f"
     Jones_tc.timeout   = 1600
     Jones_tc.new_output = False
@@ -868,7 +868,7 @@ def main():
     Jones_tc_rst.cfg_dir   = "turbomachinery/APU_turbocharger"
     Jones_tc_rst.cfg_file  = "Jones_rst.cfg"
     Jones_tc_rst.test_iter = 5
-    Jones_tc_rst.test_vals = [-4.626538, -1.570728, 34.013520, 10.190740] #last 4 columns
+    Jones_tc_rst.test_vals = [-4.625211, -1.568755, 33.994550, 10.181630] #last 4 columns
     Jones_tc_rst.su2_exec  = "parallel_computation.py -f"
     Jones_tc_rst.timeout   = 1600
     Jones_tc_rst.new_output = False
@@ -880,7 +880,7 @@ def main():
     axial_stage2D.cfg_dir   = "turbomachinery/axial_stage_2D"
     axial_stage2D.cfg_file  = "Axial_stage2D.cfg"
     axial_stage2D.test_iter = 20
-    axial_stage2D.test_vals = [-1.933205, 5.381311, 73.357930, 1.780467] #last 4 columns
+    axial_stage2D.test_vals = [-1.933206, 5.379711, 73.357930, 0.925874] #last 4 columns
     axial_stage2D.su2_exec  = "parallel_computation.py -f"
     axial_stage2D.timeout   = 1600
     axial_stage2D.new_output = False
@@ -892,7 +892,7 @@ def main():
     transonic_stator.cfg_dir   = "turbomachinery/transonic_stator_2D"
     transonic_stator.cfg_file  = "transonic_stator.cfg"
     transonic_stator.test_iter = 20
-    transonic_stator.test_vals = [-0.576128, 5.820136, 96.994800, 0.062868] #last 4 columns
+    transonic_stator.test_vals = [-0.575758, 5.826350, 96.764000, 0.062990] #last 4 columns
     transonic_stator.su2_exec  = "parallel_computation.py -f"
     transonic_stator.timeout   = 1600
     transonic_stator.new_output = False

--- a/TestCases/serial_regression.py
+++ b/TestCases/serial_regression.py
@@ -222,7 +222,7 @@ def main():
     rae2822_sa.cfg_dir   = "rans/rae2822"
     rae2822_sa.cfg_file  = "turb_SA_RAE2822.cfg"
     rae2822_sa.test_iter = 20
-    rae2822_sa.test_vals = [-2.021218, -5.268447, 0.807465, 0.060897] #last 4 columns
+    rae2822_sa.test_vals = [-2.021224, -5.268445, 0.807582, 0.060731] #last 4 columns
     rae2822_sa.su2_exec  = "SU2_CFD"
     rae2822_sa.timeout   = 1600
     rae2822_sa.new_output = True
@@ -269,7 +269,7 @@ def main():
     turb_oneram6.cfg_dir   = "rans/oneram6"
     turb_oneram6.cfg_file  = "turb_ONERAM6.cfg"
     turb_oneram6.test_iter = 10
-    turb_oneram6.test_vals = [-2.412449, -6.702976, 0.229867, 0.147638]#last 4 columns
+    turb_oneram6.test_vals = [-2.388855, -6.689341, 0.230322, 0.157649]#last 4 columns
     turb_oneram6.su2_exec  = "SU2_CFD"
     turb_oneram6.new_output = True
     turb_oneram6.timeout   = 3200
@@ -328,7 +328,7 @@ def main():
     propeller_var_load.cfg_dir    = "rans/actuatordisk_variable_load"
     propeller_var_load.cfg_file   = "propeller_variable_load.cfg"
     propeller_var_load.test_iter  = 20
-    propeller_var_load.test_vals  = [-1.826392, -4.535254, 0.000003, 0.170298] #last 4 columns
+    propeller_var_load.test_vals  = [-1.824944, -4.535272, -0.000008, 0.172071] #last 4 columns
     propeller_var_load.su2_exec   = "SU2_CFD"
     propeller_var_load.new_output = True
     propeller_var_load.timeout    = 3200
@@ -766,7 +766,7 @@ def main():
     turb_naca0012_1c.cfg_dir   = "rans_uq/naca0012"
     turb_naca0012_1c.cfg_file  = "turb_NACA0012_uq_1c.cfg"
     turb_naca0012_1c.test_iter = 10
-    turb_naca0012_1c.test_vals = [-4.978069, 1.139129, 0.812114, 0.091150] #last 4 columns
+    turb_naca0012_1c.test_vals = [-4.978069, 1.139128, 0.807062, 0.064726] #last 4 columns
     turb_naca0012_1c.su2_exec  = "SU2_CFD"
     turb_naca0012_1c.new_output = True
     turb_naca0012_1c.timeout   = 1600
@@ -778,7 +778,7 @@ def main():
     turb_naca0012_2c.cfg_dir   = "rans_uq/naca0012"
     turb_naca0012_2c.cfg_file  = "turb_NACA0012_uq_2c.cfg"
     turb_naca0012_2c.test_iter = 10
-    turb_naca0012_2c.test_vals = [-5.484279, 0.967028, 0.828345, 0.097404] #last 4 columns
+    turb_naca0012_2c.test_vals = [-5.484279, 0.967025, 0.823201, 0.070866] #last 4 columns
     turb_naca0012_2c.su2_exec  = "SU2_CFD"
     turb_naca0012_2c.new_output = True
     turb_naca0012_2c.timeout   = 1600
@@ -790,7 +790,7 @@ def main():
     turb_naca0012_3c.cfg_dir   = "rans_uq/naca0012"
     turb_naca0012_3c.cfg_file  = "turb_NACA0012_uq_3c.cfg"
     turb_naca0012_3c.test_iter = 10
-    turb_naca0012_3c.test_vals = [-5.587068, 0.929129, 0.882932, 0.118094] #last 4 columns
+    turb_naca0012_3c.test_vals = [-5.587068, 0.929125, 0.877611, 0.090894] #last 4 columns
     turb_naca0012_3c.su2_exec  = "SU2_CFD"
     turb_naca0012_3c.new_output = True
     turb_naca0012_3c.timeout   = 1600
@@ -802,7 +802,7 @@ def main():
     turb_naca0012_p1c1.cfg_dir   = "rans_uq/naca0012"
     turb_naca0012_p1c1.cfg_file  = "turb_NACA0012_uq_p1c1.cfg"
     turb_naca0012_p1c1.test_iter = 10
-    turb_naca0012_p1c1.test_vals = [-5.126795, 1.076579, 0.788111, 0.082021] #last 4 columns
+    turb_naca0012_p1c1.test_vals = [-5.126796, 1.076577, 0.783116, 0.055988] #last 4 columns
     turb_naca0012_p1c1.su2_exec  = "SU2_CFD"
     turb_naca0012_p1c1.new_output = True
     turb_naca0012_p1c1.timeout   = 1600
@@ -814,7 +814,7 @@ def main():
     turb_naca0012_p1c2.cfg_dir   = "rans_uq/naca0012"
     turb_naca0012_p1c2.cfg_file  = "turb_NACA0012_uq_p1c2.cfg"
     turb_naca0012_p1c2.test_iter = 10
-    turb_naca0012_p1c2.test_vals = [-5.556585, 0.941681, 0.801057, 0.086980] #last 4 columns
+    turb_naca0012_p1c2.test_vals = [-5.556585, 0.941677, 0.796006, 0.060817] #last 4 columns
     turb_naca0012_p1c2.su2_exec  = "SU2_CFD"
     turb_naca0012_p1c2.new_output = True
     turb_naca0012_p1c2.timeout   = 1600
@@ -842,7 +842,7 @@ def main():
     hb_rans_preconditioning.cfg_dir   = "harmonic_balance/hb_rans_preconditioning"
     hb_rans_preconditioning.cfg_file  = "davis.cfg"
     hb_rans_preconditioning.test_iter = 25
-    hb_rans_preconditioning.test_vals = [-1.909598, -5.954721, 0.007773, 0.131219] #last 4 columns
+    hb_rans_preconditioning.test_vals = [-1.902362, -5.950093, 0.007786, 0.128110] #last 4 columns
     hb_rans_preconditioning.su2_exec  = "SU2_CFD"
     hb_rans_preconditioning.new_output= False
     hb_rans_preconditioning.timeout   = 1600
@@ -977,7 +977,7 @@ def main():
     ls89_sa.cfg_dir   = "nicf/LS89"
     ls89_sa.cfg_file  = "turb_SA_PR.cfg"
     ls89_sa.test_iter = 20
-    ls89_sa.test_vals = [-5.060859, -13.398192, 0.174451, 0.429491] #last 4 columns
+    ls89_sa.test_vals = [-5.050483, -13.389547, 0.174939, 0.430757] #last 4 columns
     ls89_sa.su2_exec  = "SU2_CFD"
     ls89_sa.new_output= True
     ls89_sa.timeout   = 1600
@@ -1018,7 +1018,7 @@ def main():
     Jones_tc.cfg_dir   = "turbomachinery/APU_turbocharger"
     Jones_tc.cfg_file  = "Jones.cfg"
     Jones_tc.test_iter = 5
-    Jones_tc.test_vals = [-5.280323, 0.379653, 44.725410, 2.271564] #last 4 columns
+    Jones_tc.test_vals = [-5.280323, 0.379653, 72.207240, 1.277670] #last 4 columns
     Jones_tc.su2_exec  = "SU2_CFD"
     Jones_tc.new_output = False
     Jones_tc.timeout   = 1600
@@ -1030,7 +1030,7 @@ def main():
     Jones_tc_rst.cfg_dir   = "turbomachinery/APU_turbocharger"
     Jones_tc_rst.cfg_file  = "Jones_rst.cfg"
     Jones_tc_rst.test_iter = 5
-    Jones_tc_rst.test_vals = [-4.626583, -1.570788, 34.014120, 10.190730] #last 4 columns
+    Jones_tc_rst.test_vals = [-4.625264, -1.568823, 33.995150, 10.181610] #last 4 columns
     Jones_tc_rst.su2_exec  = "SU2_CFD"
     Jones_tc_rst.new_output = False
     Jones_tc_rst.timeout   = 1600
@@ -1042,7 +1042,7 @@ def main():
     axial_stage2D.cfg_dir   = "turbomachinery/axial_stage_2D"
     axial_stage2D.cfg_file  = "Axial_stage2D.cfg"
     axial_stage2D.test_iter = 20
-    axial_stage2D.test_vals = [-1.933218, 5.381198, 73.357940, 1.780408] #last 4 columns
+    axial_stage2D.test_vals = [-1.933219, 5.379598, 73.357940, 0.925875] #last 4 columns
     axial_stage2D.su2_exec  = "SU2_CFD"
     axial_stage2D.new_output  = False
     axial_stage2D.timeout   = 1600
@@ -1054,7 +1054,7 @@ def main():
     transonic_stator.cfg_dir   = "turbomachinery/transonic_stator_2D"
     transonic_stator.cfg_file  = "transonic_stator.cfg"
     transonic_stator.test_iter = 20
-    transonic_stator.test_vals = [-0.562939, 5.828438, 96.597350, 0.062502] #last 4 columns
+    transonic_stator.test_vals = [-0.563318, 5.833490, 96.257510, 0.062597] #last 4 columns
     transonic_stator.su2_exec  = "SU2_CFD"
     transonic_stator.new_output  = False
     transonic_stator.timeout   = 1600

--- a/TestCases/tutorials.py
+++ b/TestCases/tutorials.py
@@ -144,7 +144,7 @@ def main():
     tutorial_nicfd_nozzle.cfg_dir   = "../Tutorials/compressible_flow/NICFD_nozzle"
     tutorial_nicfd_nozzle.cfg_file  = "NICFD_nozzle.cfg"
     tutorial_nicfd_nozzle.test_iter = 20
-    tutorial_nicfd_nozzle.test_vals = [-1.909272, -6.407306, 4.284191, 0.000000, 0.000000]
+    tutorial_nicfd_nozzle.test_vals = [-2.340879, -6.750977, 4.258430, 0.000000, 0.000000]
     tutorial_nicfd_nozzle.su2_exec  = "mpirun -np 2 SU2_CFD"
     tutorial_nicfd_nozzle.timeout   = 1600
     tutorial_nicfd_nozzle.tol       = 0.00001


### PR DESCRIPTION
## Proposed Changes
There was a bug in the CTurbSolver::ComputeUnderRelaxation() that would return a negative UR if the change in solution was too negative (less than the allowable decrease), which could cause the solution to head in the wrong direction.  I'm not really sure why the turbulent solver version of this function was written differently than the flow solver (maybe the intention was to have a different allowable increase and decrease but they ended up being the same in the end?), but I changed it to make it consistent with the flow solver version.

Also, as I mentioned in #1036, the UR parameters for the flow solver and turbulent solver both took the min of each other and were never reset for steady, meaning it was non-increasing.

While on the topic of UR, I was wondering what the community's thoughts are on changing the SST models to use UR instead of solution clipping. The limits seem somewhat arbitrary to me (is there a ref?), and the tests I've done on my mesh adaptation cases have performed well where I've replaced clipping with UR. I realize this is a very limited dataset so if anyone has any strong opinions of why we should be clipping, let me know.

## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [X] My contribution is commented and consistent with SU2 style.
- [X] I have added a test case that demonstrates my contribution, if necessary.
- [X] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
