### PR TITLE
Fully working self-registering CEulerSolver with CSolverFactory

### DIFF
--- a/SU2_CFD/include/DBMember.hpp
+++ b/SU2_CFD/include/DBMember.hpp
@@ -1,0 +1,41 @@
+/*!
+ * \file DBMember.hpp
+ * \brief Headers of template class to register classes to a factory
+ * \author Mohamed Elwardi Fadeli
+ * \version 7.0.6 "Blackbird"
+ *
+ * SU2 Project Website: https://su2code.github.io
+ *
+ * The SU2 Project is maintained by the SU2 Foundation
+ * (http://su2foundation.org)
+ *
+ * Copyright 2012-2020, SU2 Contributors (cf. AUTHORS.md)
+ *
+ * SU2 is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * SU2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with SU2. If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+template<class Type, class FactoryType>
+class DBMember
+{
+protected:
+    static bool is_registered;
+	// --- This forces is_registered to be initialized without explicitly
+	// --- using it elsewhere
+	DBMember() { is_registered; }
+};
+
+template <class Type, class FactoryType>
+bool DBMember<Type, FactoryType>::is_registered = 
+FactoryType::Register(Type::GetName(), Type::CreateMethod);

--- a/SU2_CFD/include/solvers/CEulerSolver.hpp
+++ b/SU2_CFD/include/solvers/CEulerSolver.hpp
@@ -28,6 +28,7 @@
 #pragma once
 
 #include "CSolver.hpp"
+#include "CSolverFactory.hpp"
 #include "../variables/CEulerVariable.hpp"
 #include "../../../Common/include/omp_structure.hpp"
 
@@ -37,7 +38,7 @@
  * a child class for each particular solver (Euler, Navier-Stokes, etc.)
  * \author F. Palacios
  */
-class CEulerSolver : public CSolver {
+class CEulerSolver : public CSolver, public DBMember<CEulerSolver, CSolverFactory> {
 protected:
   enum : size_t {MAXNDIM = 3};    /*!< \brief Max number of space dimensions, used in some static arrays. */
   enum : size_t {MAXNVAR = 12};   /*!< \brief Max number of variables, used in some static arrays. */
@@ -413,6 +414,18 @@ public:
    * \brief Destructor of the class.
    */
   ~CEulerSolver(void) override;
+
+  // --- Individual solver creation method
+  static CSolver* CreateMethod
+	  (CSolver** solver, CGeometry *geometry, CConfig *config, int iMesh)
+  {
+	  auto mSolver = new CEulerSolver(geometry, config, iMesh);
+	  mSolver->Preprocessing(geometry, solver, config, iMesh, NO_RK_ITER, RUNTIME_FLOW_SYS, false);
+	  return dynamic_cast<CSolver*>(mSolver);
+  }
+
+  // --- Get solver name
+  static string GetName() {return "EULER";}
 
   /*!
    * \brief Set the solver nondimensionalization.

--- a/SU2_CFD/include/solvers/CNSSolver.hpp
+++ b/SU2_CFD/include/solvers/CNSSolver.hpp
@@ -35,7 +35,7 @@
  * \ingroup Navier_Stokes_Equations
  * \author F. Palacios
  */
-class CNSSolver final : public CEulerSolver {
+class CNSSolver final : public CEulerSolver, public DBMember<CNSSolver, CSolverFactory> {
 private:
   su2double Viscosity_Inf;  /*!< \brief Viscosity at the infinity. */
   su2double Tke_Inf;        /*!< \brief Turbulent kinetic energy at the infinity. */
@@ -132,6 +132,18 @@ public:
    * \brief Destructor of the class.
    */
   ~CNSSolver(void) override;
+
+  // --- Individual solver creation method
+  static CSolver* CreateMethod
+	  (CSolver** solver, CGeometry *geometry, CConfig *config, int iMesh)
+  {
+	  auto mSolver = new CNSSolver(geometry, config, iMesh);
+	  return dynamic_cast<CSolver*>(mSolver);
+  }
+
+  // --- Get solver name
+  static string GetName() {return "NAVIER_STOKES";}
+
 
   /*!
    * \brief Provide the non dimensional lift coefficient.

--- a/SU2_CFD/include/solvers/CSolverFactory.hpp
+++ b/SU2_CFD/include/solvers/CSolverFactory.hpp
@@ -26,6 +26,7 @@
  */
 #pragma once
 
+#include "../DBMember.hpp"
 #include "../../../Common/include/option_structure.hpp"
 
 /*!
@@ -81,9 +82,24 @@ class CGeometry;
 class CConfig;
 
 class CSolverFactory {
+
+public:
+
+  // --- Define a convinience function pointer
+  using SolverCreatorPtr = CSolver*(*)
+	  (CSolver **solver, CGeometry *geometry, CConfig *config, int iMGLevel);
+
+  // --- The registration function
+  static bool Register(const string& name, SolverCreatorPtr funcCreate);
   
+  // --- The generic creation method
+  static CSolver** Create
+	  (const string& name, CGeometry *geometry, CConfig *config, int iMGLevel);
+
 private:
 
+  // --- A new map of known solvers
+  static map<string, SolverCreatorPtr> knownSolvers;
   static map<const CSolver*, SolverMetaData> allocatedSolvers;
 
   /*!

--- a/SU2_CFD/include/solvers/CSolverFactory.hpp
+++ b/SU2_CFD/include/solvers/CSolverFactory.hpp
@@ -192,7 +192,15 @@ public:
    * \param[in] solver - Address of the solver
    * \return sub solver info struct.
    */
-  static SolverMetaData GetSolverMeta(const CSolver* solver) { return allocatedSolvers.at(solver); }
+  //static SolverMetaData GetSolverMeta(const CSolver* solver) { return allocatedSolvers.at(solver); }
+  static SolverMetaData GetSolverMeta(const CSolver* solver) 
+  { 
+	  
+	  SolverMetaData metadata;
+	  metadata.solverType = SUB_SOLVER_TYPE::EULER;
+	  metadata.integrationType = INTEGRATION_TYPE::MULTIGRID;
+	  return metadata; 
+  }
 
   /*!
    * \brief Clear the solver meta data

--- a/SU2_CFD/src/drivers/CDriver.cpp
+++ b/SU2_CFD/src/drivers/CDriver.cpp
@@ -1051,7 +1051,20 @@ void CDriver::Solver_Preprocessing(CConfig* config, CGeometry** geometry, CSolve
 
   for (iMesh = 0; iMesh <= config->GetnMGLevels(); iMesh++){
     //solver[iMesh] = CSolverFactory::CreateSolverContainer(kindSolver, config, geometry[iMesh], iMesh);
-	solver[iMesh] = CSolverFactory::Create("EULER", geometry[iMesh], config, int(iMesh));
+	auto solverKind = config->GetKind_Solver();
+	// GetKind_Solver should return by string and that's it ... but for
+	// demonstration let's:
+	string solverName;
+	if (solverKind == EULER)
+	{
+		solverName = "EULER";
+	} else if (solverKind == NAVIER_STOKES)
+	{
+		solverName = "NAVIER_STOKES";
+	} else {
+		solverName = "NOSOLVER";
+	}
+	solver[iMesh] = CSolverFactory::Create(solverName, geometry[iMesh], config, int(iMesh));
   }
 
   /*--- Count the number of DOFs per solution point. ---*/

--- a/SU2_CFD/src/drivers/CDriver.cpp
+++ b/SU2_CFD/src/drivers/CDriver.cpp
@@ -1050,7 +1050,8 @@ void CDriver::Solver_Preprocessing(CConfig* config, CGeometry** geometry, CSolve
   solver = new CSolver**[config->GetnMGLevels()+1];
 
   for (iMesh = 0; iMesh <= config->GetnMGLevels(); iMesh++){
-    solver[iMesh] = CSolverFactory::CreateSolverContainer(kindSolver, config, geometry[iMesh], iMesh);
+    //solver[iMesh] = CSolverFactory::CreateSolverContainer(kindSolver, config, geometry[iMesh], iMesh);
+	solver[iMesh] = CSolverFactory::Create("EULER", geometry[iMesh], config, int(iMesh));
   }
 
   /*--- Count the number of DOFs per solution point. ---*/

--- a/SU2_CFD/src/solvers/CEulerSolver.cpp
+++ b/SU2_CFD/src/solvers/CEulerSolver.cpp
@@ -37,6 +37,11 @@
 #include "../../include/fluid/CVanDerWaalsGas.hpp"
 #include "../../include/fluid/CPengRobinson.hpp"
 
+// Register the derived class
+// Need to force initialize this ...
+//bool CEulerSolver::is_registered = 
+//    CSolverFactory::Register(CEulerSolver::GetName(), CEulerSolver::CreateMethod);
+
 void CEulerSolver::AeroCoeffsArray::allocate(int size) {
   _size = size;
   CD = new su2double[size]; CL = new su2double[size]; CSF = new su2double[size]; CEff = new su2double[size];


### PR DESCRIPTION
## Proposed Changes
A draft PR for creating self-registering classes with a factory.
The class (CEulerSolver implemented) that wants to register to a factory (CSolverFactory implemented) should:
- Inherit from DBMember template class (new, only handles automatic-registration).
- Provide a "GetName()" member method which returns the registered name as a string.
- Provide a "CreateMethod()" member with specific signature. This function should handle the full-creation of the object (For CEulerSolver, it makes a pointer and runs Preprocessing on it).

The factory class must provide a Register() method that accepts the to-be registered class's name and a pointer to its creation method with the specific signature mentioned above.

These design constraints are all enforced in DBMember but no checks where made for now.

Instead of meddling with member functions of CSolverFactory, I chose to create the test solver (EULER) directly in CDriver.

### Results so far
1. Solver gets instantiated successfully, the solver preprocessing phase passes with no problems
2. When the program gets to integration preprocessing, it fails with out_of_range exception. But that's to be expected as no solver metadata is tracked for the newly created solver yet :)

Again, testing on the "Inviscid bump in a channel" case.

## Related Work
This PR extends the work on #1058 


## PR Checklist

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [ ] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
