### PR TITLE
Fix memory issues

### DIFF
--- a/Common/include/CConfig.hpp
+++ b/Common/include/CConfig.hpp
@@ -1077,6 +1077,8 @@ private:
   default_jst_adj_coeff[2],      /*!< \brief Default artificial dissipation (adjoint) array for the COption class. */
   default_ad_coeff_heat[2],      /*!< \brief Default artificial dissipation (heat) array for the COption class. */
   default_obj_coeff[5],          /*!< \brief Default objective array for the COption class. */
+  default_mesh_box_length[3],    /*!< \brief Default length of the RECTANGLE or BOX grid in the x,y,z directions. */
+  default_mesh_box_offset[3],    /*!< \brief Default offset from 0.0 of the RECTANGLE or BOX grid in the x,y,z directions. */
   default_geo_loc[2],            /*!< \brief Default SU2_GEO section locations array for the COption class. */
   default_distortion[2],         /*!< \brief Default SU2_GEO section locations array for the COption class. */
   default_ea_lim[3],             /*!< \brief Default equivalent area limit array for the COption class. */

--- a/Common/include/CConfig.hpp
+++ b/Common/include/CConfig.hpp
@@ -1077,8 +1077,8 @@ private:
   default_jst_adj_coeff[2],      /*!< \brief Default artificial dissipation (adjoint) array for the COption class. */
   default_ad_coeff_heat[2],      /*!< \brief Default artificial dissipation (heat) array for the COption class. */
   default_obj_coeff[5],          /*!< \brief Default objective array for the COption class. */
-  default_mesh_box_length[3],    /*!< \brief Default length of the RECTANGLE or BOX grid in the x,y,z directions. */
-  default_mesh_box_offset[3],    /*!< \brief Default offset from 0.0 of the RECTANGLE or BOX grid in the x,y,z directions. */
+  default_mesh_box_length[3],    /*!< \brief Default mesh box length for the COption class. */
+  default_mesh_box_offset[3],    /*!< \brief Default mesh box offset for the COption class. */
   default_geo_loc[2],            /*!< \brief Default SU2_GEO section locations array for the COption class. */
   default_distortion[2],         /*!< \brief Default SU2_GEO section locations array for the COption class. */
   default_ea_lim[3],             /*!< \brief Default equivalent area limit array for the COption class. */

--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -1944,12 +1944,12 @@ void CConfig::SetConfig_Options() {
   addShortListOption("MESH_BOX_SIZE", nMesh_Box_Size, Mesh_Box_Size);
 
   /* DESCRIPTION: List of the length of the RECTANGLE or BOX grid in the x,y,z directions. (default: (1.0,1.0,1.0) ).  */
-  array<su2double, 3> default_mesh_box_length = {{1.0, 1.0, 1.0}};
-  addDoubleArrayOption("MESH_BOX_LENGTH", 3, Mesh_Box_Length, default_mesh_box_length.data());
+  default_mesh_box_length[0] = 1.0; default_mesh_box_length[1] = 1.0; default_mesh_box_length[2] = 1.0;
+  addDoubleArrayOption("MESH_BOX_LENGTH", 3, Mesh_Box_Length, default_mesh_box_length);
 
   /* DESCRIPTION: List of the offset from 0.0 of the RECTANGLE or BOX grid in the x,y,z directions. (default: (0.0,0.0,0.0) ). */
-  array<su2double, 3> default_mesh_box_offset = {{0.0, 0.0, 0.0}};
-  addDoubleArrayOption("MESH_BOX_OFFSET", 3, Mesh_Box_Offset, default_mesh_box_offset.data());
+  default_mesh_box_offset[0] = 0.0; default_mesh_box_offset[1] = 0.0; default_mesh_box_offset[2] = 0.0;
+  addDoubleArrayOption("MESH_BOX_OFFSET", 3, Mesh_Box_Offset, default_mesh_box_offset);
 
   /* DESCRIPTION: Determine if the mesh file supports multizone. \n DEFAULT: true (temporarily) */
   addBoolOption("MULTIZONE_MESH", Multizone_Mesh, true);

--- a/SU2_CFD/src/output/filewriter/CParallelDataSorter.cpp
+++ b/SU2_CFD/src/output/filewriter/CParallelDataSorter.cpp
@@ -324,7 +324,7 @@ void CParallelDataSorter::PrepareSendBuffers(std::vector<unsigned long>& globalI
   /*--- Allocate the data buffer to hold the sorted data. We have to make it large enough
    * to hold passivedoubles and su2doubles ---*/
   unsigned short maxSize = max(sizeof(passivedouble), sizeof(su2double));
-  dataBuffer = new char[VARS_PER_POINT*nPoint_Recv[size]*maxSize];
+  dataBuffer = new char[VARS_PER_POINT*nPoint_Recv[size]*maxSize] {};
 
   /*--- doubleBuffer and passiveDouble buffer use the same memory allocated above using the dataBuffer. ---*/
 


### PR DESCRIPTION
## Proposed Changes
This PR contains fixes for two memory issues.

- The first issue regards AD builds. The reinterpret cast of the dynamically allocated char array to an `su2double` array prevents `su2double` default constructor calls. In that case, the memory must be zero initialized in order for the AD index management to work correctly.
- Regarding the second issue, invalid reads occur when the pointers to the local arrays are used later in `CConfig::SetDefaults()` when the arrays are already out of scope.

## PR Checklist

- [X] I am submitting my contribution to the develop branch.
- [ ] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [ ] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
