### PR TITLE
Fix rough wall model in SST turbulence model

### DIFF
--- a/SU2_CFD/include/solvers/CFVMFlowSolverBase.hpp
+++ b/SU2_CFD/include/solvers/CFVMFlowSolverBase.hpp
@@ -145,6 +145,7 @@ class CFVMFlowSolverBase : public CSolver {
   su2double** HeatFluxTarget = nullptr;    /*!< \brief Heat transfer coefficient for each boundary and vertex. */
   su2double*** CharacPrimVar = nullptr;    /*!< \brief Value of the characteristic variables at each boundary. */
   su2double*** CSkinFriction = nullptr;    /*!< \brief Skin friction coefficient for each boundary and vertex. */
+  su2double** WallShearStress = nullptr;   /*!< \brief Wall Shear Stress for each boundary and vertex. */
   su2double*** HeatConjugateVar = nullptr; /*!< \brief CHT variables for each boundary and vertex. */
   su2double** CPressure = nullptr;         /*!< \brief Pressure coefficient for each boundary and vertex. */
   su2double** CPressureTarget = nullptr;   /*!< \brief Target Pressure coefficient for each boundary and vertex. */
@@ -1551,6 +1552,16 @@ class CFVMFlowSolverBase : public CSolver {
   inline su2double GetCSkinFriction(unsigned short val_marker, unsigned long val_vertex,
                                     unsigned short val_dim) const final {
     return CSkinFriction[val_marker][val_dim][val_vertex];
+  }
+
+  /*!
+   * \brief Get the wall shear stress.
+   * \param[in] val_marker - Surface marker where the wall shear stress is computed.
+   * \param[in] val_vertex - Vertex of the marker <i>val_marker</i> where the wall shear stress is evaluated.
+   * \return Value of the wall shear stress.
+   */
+  inline su2double GetWallShearStress(unsigned short val_marker, unsigned long val_vertex) const final {
+    return WallShearStress[val_marker][val_vertex];
   }
 
   /*!

--- a/SU2_CFD/include/solvers/CFVMFlowSolverBase.inl
+++ b/SU2_CFD/include/solvers/CFVMFlowSolverBase.inl
@@ -208,6 +208,10 @@ void CFVMFlowSolverBase<V, R>::Allocate(const CConfig& config) {
     }
   }
 
+  /*--- Wall Shear Stress in all the markers ---*/
+
+  Alloc2D(nMarker, nVertex, WallShearStress);
+
   /*--- Store the values of the temperature and the heat flux density at the boundaries,
    used for coupling with a solid donor cell ---*/
   constexpr auto nHeatConjugateVar = 4u;
@@ -471,6 +475,13 @@ CFVMFlowSolverBase<V, R>::~CFVMFlowSolverBase() {
       delete[] CSkinFriction[iMarker];
     }
     delete[] CSkinFriction;
+  }
+
+  if (WallShearStress != nullptr) {
+    for (iMarker = 0; iMarker < nMarker; iMarker++) {
+      delete[] WallShearStress[iMarker];
+    }
+    delete[] WallShearStress;
   }
 
   if (HeatConjugateVar != nullptr) {

--- a/SU2_CFD/include/solvers/CFVMFlowSolverBase.inl
+++ b/SU2_CFD/include/solvers/CFVMFlowSolverBase.inl
@@ -2030,7 +2030,7 @@ void CFVMFlowSolverBase<V, FlowRegime>::Friction_Forces(const CGeometry* geometr
   unsigned long iVertex, iPoint, iPointNormal;
   unsigned short iMarker, iMarker_Monitoring, iDim, jDim;
   unsigned short T_INDEX = 0, TVE_INDEX = 0, VEL_INDEX = 0;
-  su2double Viscosity = 0.0, div_vel, WallDist[3] = {0.0}, Area, WallShearStress, TauNormal, RefTemp, RefVel2 = 0.0,
+  su2double Viscosity = 0.0, div_vel, WallDist[3] = {0.0}, Area, TauNormal, RefTemp, RefVel2 = 0.0,
             RefDensity = 0.0, GradTemperature, Density = 0.0, WallDistMod, FrictionVel, Mach2Vel, Mach_Motion,
             UnitNormal[3] = {0.0}, TauElem[3] = {0.0}, TauTangent[3] = {0.0}, Tau[3][3] = {{0.0}}, Cp,
             thermal_conductivity, thermal_conductivity_tr, thermal_conductivity_ve = 0.0,
@@ -2247,13 +2247,13 @@ void CFVMFlowSolverBase<V, FlowRegime>::Friction_Forces(const CGeometry* geometr
       TauNormal = 0.0;
       for (iDim = 0; iDim < nDim; iDim++) TauNormal += TauElem[iDim] * UnitNormal[iDim];
 
-      WallShearStress = 0.0;
+      WallShearStress[iMarker][iVertex] = 0.0;
       for (iDim = 0; iDim < nDim; iDim++) {
         TauTangent[iDim] = TauElem[iDim] - TauNormal * UnitNormal[iDim];
         CSkinFriction[iMarker][iDim][iVertex] = TauTangent[iDim] / (0.5 * RefDensity * RefVel2);
-        WallShearStress += TauTangent[iDim] * TauTangent[iDim];
+        WallShearStress[iMarker][iVertex] += TauTangent[iDim] * TauTangent[iDim];
       }
-      WallShearStress = sqrt(WallShearStress);
+      WallShearStress[iMarker][iVertex] = sqrt(WallShearStress[iMarker][iVertex]);
 
       for (iDim = 0; iDim < nDim; iDim++) WallDist[iDim] = (Coord[iDim] - Coord_Normal[iDim]);
       WallDistMod = 0.0;
@@ -2262,7 +2262,7 @@ void CFVMFlowSolverBase<V, FlowRegime>::Friction_Forces(const CGeometry* geometr
 
       /*--- Compute y+ and non-dimensional velocity ---*/
 
-      FrictionVel = sqrt(fabs(WallShearStress) / Density);
+      FrictionVel = sqrt(fabs(WallShearStress[iMarker][iVertex]) / Density);
       YPlus[iMarker][iVertex] = WallDistMod * FrictionVel / (Viscosity / Density);
 
       /*--- Compute total and maximum heat flux on the wall ---*/

--- a/SU2_CFD/include/solvers/CSolver.hpp
+++ b/SU2_CFD/include/solvers/CSolver.hpp
@@ -3117,6 +3117,15 @@ public:
 
   /*!
    * \brief A virtual member.
+   * \param[in] val_marker - Surface marker where the wall shear stress is computed.
+   * \param[in] val_vertex - Vertex of the marker <i>val_marker</i> where the wall shear stress is evaluated.
+   * \return Value of the wall shear stress.
+   */
+  inline virtual su2double GetWallShearStress(unsigned short val_marker,
+                                              unsigned long val_vertex) const { return 0; }
+
+  /*!
+   * \brief A virtual member.
    * \param[in] val_marker - Surface marker where the coefficient is computed.
    * \param[in] val_vertex - Vertex of the marker <i>val_marker</i> where the coefficient is evaluated.
    * \return Value of the heat transfer coefficient.

--- a/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
+++ b/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
@@ -411,12 +411,13 @@ void CTurbSSTSolver::BC_HeatFlux_Wall(CGeometry *geometry, CSolver **solver_cont
         /*--- Set wall values ---*/
         su2double density = solver_container[FLOW_SOL]->GetNodes()->GetDensity(iPoint);
         su2double laminar_viscosity = solver_container[FLOW_SOL]->GetNodes()->GetLaminarViscosity(iPoint);
-
-        su2double WallShearStress = 0.0;
+        const su2double *U = config->GetVelocity_FreeStream();
+	su2double WallShearStress;
+        su2double SkinFrictionMag = 0.0;
         for (auto iDim = 0; iDim < nDim; iDim++)
-          WallShearStress += pow(solver_container[FLOW_SOL]->GetCSkinFriction(val_marker, iVertex, iDim),2.0);
+          SkinFrictionMag += pow(solver_container[FLOW_SOL]->GetCSkinFriction(val_marker, iVertex, iDim),2.0);
 
-        WallShearStress = sqrt(WallShearStress);
+        WallShearStress = sqrt(SkinFrictionMag)*0.5*density*pow(U/config->GetVelocity_Ref(), 2);
         /*--- Compute non-dimensional velocity ---*/
         su2double FrictionVel = sqrt(fabs(WallShearStress)/density);
 

--- a/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
+++ b/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
@@ -412,7 +412,7 @@ void CTurbSSTSolver::BC_HeatFlux_Wall(CGeometry *geometry, CSolver **solver_cont
         su2double density = solver_container[FLOW_SOL]->GetNodes()->GetDensity(iPoint);
         su2double laminar_viscosity = solver_container[FLOW_SOL]->GetNodes()->GetLaminarViscosity(iPoint);
         const su2double *U = config->GetVelocity_FreeStream();
-	su2double WallShearStress;
+        su2double WallShearStress;
         su2double SkinFrictionMag = 0.0;
         for (auto iDim = 0; iDim < nDim; iDim++)
           SkinFrictionMag += pow(solver_container[FLOW_SOL]->GetCSkinFriction(val_marker, iVertex, iDim),2.0);

--- a/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
+++ b/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
@@ -417,7 +417,7 @@ void CTurbSSTSolver::BC_HeatFlux_Wall(CGeometry *geometry, CSolver **solver_cont
         for (auto iDim = 0; iDim < nDim; iDim++)
           SkinFrictionMag += pow(solver_container[FLOW_SOL]->GetCSkinFriction(val_marker, iVertex, iDim),2.0);
 
-        WallShearStress = sqrt(SkinFrictionMag)*0.5*density*pow(U/config->GetVelocity_Ref(), 2);
+        WallShearStress = sqrt(SkinFrictionMag)*0.5*density*pow(U[0]/config->GetVelocity_Ref(), 2);
         /*--- Compute non-dimensional velocity ---*/
         su2double FrictionVel = sqrt(fabs(WallShearStress)/density);
 

--- a/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
+++ b/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
@@ -411,7 +411,7 @@ void CTurbSSTSolver::BC_HeatFlux_Wall(CGeometry *geometry, CSolver **solver_cont
         /*--- Set wall values ---*/
         su2double density = solver_container[FLOW_SOL]->GetNodes()->GetDensity(iPoint);
         su2double laminar_viscosity = solver_container[FLOW_SOL]->GetNodes()->GetLaminarViscosity(iPoint);
-        su2double WallShearStress = GetWallShearStress(val_marker, iVertex);
+        su2double WallShearStress = solver_container[FLOW_SOL]->GetWallShearStress(val_marker, iVertex);
 
         /*--- Compute non-dimensional velocity ---*/
         su2double FrictionVel = sqrt(fabs(WallShearStress)/density);

--- a/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
+++ b/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
@@ -411,13 +411,8 @@ void CTurbSSTSolver::BC_HeatFlux_Wall(CGeometry *geometry, CSolver **solver_cont
         /*--- Set wall values ---*/
         su2double density = solver_container[FLOW_SOL]->GetNodes()->GetDensity(iPoint);
         su2double laminar_viscosity = solver_container[FLOW_SOL]->GetNodes()->GetLaminarViscosity(iPoint);
-        const su2double *U = config->GetVelocity_FreeStream();
-        su2double WallShearStress;
-        su2double SkinFrictionMag = 0.0;
-        for (auto iDim = 0; iDim < nDim; iDim++)
-          SkinFrictionMag += pow(solver_container[FLOW_SOL]->GetCSkinFriction(val_marker, iVertex, iDim),2.0);
+        su2double WallShearStress = GetWallShearStress(val_marker, iVertex);
 
-        WallShearStress = sqrt(SkinFrictionMag)*0.5*density*pow(U[0]/config->GetVelocity_Ref(), 2);
         /*--- Compute non-dimensional velocity ---*/
         su2double FrictionVel = sqrt(fabs(WallShearStress)/density);
 


### PR DESCRIPTION
## Proposed Changes
We found a possible mistake in the tau wall computation in the rough wall boundary condition for the SST model.
In particular, in the current version, the tau wall is considered to be equal to the skin friction coefficient.
We changed it considering that
![ImmaginiSU2-2](https://latex.codecogs.com/gif.latex?%5Ctau_w%3Dc_f%5Cfrac%7B1%7D%7B2%7D%5Crho%20V_%5Cinfty%5E2).
We found this possible problem while doing a run on a NACA0012 airfoil.
The problem found is that the skin friction coefficient along the airfoil is too high compared to the theory.
The grid has 257 nodes on the airfoil, and it has been downloaded from the NASA website (https://turbmodels.larc.nasa.gov/naca0012_grids.html).
The solved equations are the RANS with the SST turbulence model, in compressible regime. M=0.1, Re=1e6, TU=10%, mut/mu=0.001
The run is dimensional.
![ImmaginiSU2-1](https://user-images.githubusercontent.com/53580993/96976601-5688b700-151c-11eb-8a72-ed0e0ff340dc.png)
In this figure "Rough Wall 1" is the case of tau wall computed with the current version.
"Rough Wall 2" is the case of tau wall computed after this modification.
The chosen k+ is 4 because, considering the Wilcox paper "Formulation of the k-w Turbulence Model Revisited, AIAA Journal, Vol. 46, No. 11, November 2008", the smooth wall has k+ < 5.
Moreover, the order of magnitude of omega wall is O(1e9). In case of the  "Rough Wall 1" it is of O(1e6), while in case of "Rough Wall 2" it is of O(1e9).
We don't know if the problem is somewhere else, but changing the computation of the tau wall it seems to be fixed.
 We hope this could be useful.

Authors: TAARG (Theoretical and Applied Aerodynamic Research Group), University of Naples Federico II.
Ettore Saetta, Lorenzo Russo, Renato Tognaccini, Benedetto Mele.


## Related Work
#877 



## PR Checklist

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags).
- [x] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
