### PR TITLE
Mesh Quality metrics output

### DIFF
--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -2038,8 +2038,6 @@ void CConfig::SetConfig_Options() {
   addBoolOption("WRT_PERFORMANCE", Wrt_Performance, false);
   /* DESCRIPTION: Output the tape statistics (discrete adjoint)  \ingroup Config*/
   addBoolOption("WRT_AD_STATISTICS", Wrt_AD_Statistics, false);
-  /* DESCRIPTION: Write the mesh quality metrics to the visualization files.  \ingroup Config*/
-  addBoolOption("WRT_MESH_QUALITY", Wrt_MeshQuality, false);
     /* DESCRIPTION: Output a 1D slice of a 2D cartesian solution \ingroup Config*/
   addBoolOption("WRT_SLICE", Wrt_Slice, false);
   /*!\brief MARKER_ANALYZE_AVERAGE
@@ -3215,6 +3213,13 @@ void CConfig::SetPostprocessing(unsigned short val_software, unsigned short val_
     }
   }
 
+  /*--- Check if MESH_QUALITY is requested in VOLUME_OUTPUT and set the config boolean accordingly. ---*/
+  Wrt_MeshQuality = false;
+  for (unsigned short iField = 0; iField < nVolumeOutput; iField++) {
+    if(VolumeOutput[iField].find("MESH_QUALITY") != string::npos) {
+      Wrt_MeshQuality = true;
+    }
+  }
 
   if (Kind_Solver == NAVIER_STOKES && Kind_Turb_Model != NONE){
     SU2_MPI::Error("KIND_TURB_MODEL must be NONE if SOLVER= NAVIER_STOKES", CURRENT_FUNCTION);

--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -2893,9 +2893,12 @@ void CConfig::SetConfig_Parsing(istream& config_buffer){
           newString.append("\n");
           if (!option_name.compare("RELAXATION_FACTOR_ADJFLOW"))
             newString.append("Option RELAXATION_FACTOR_ADJFLOW is now RELAXATION_FACTOR_ADJOINT, "
-                             "and it also applies to discrete adjoint problems\n.");
+                             "and it also applies to discrete adjoint problems.\n\n");
+          if (!option_name.compare("WRT_MESH_QUALITY"))
+            newString.append("WRT_MESH_QUALITY is deprecated. Use VOLUME_OUTPUT= (MESH_QUALITY, ...) instead.\n\n");
           errorString.append(newString);
           err_count++;
+          line_count++;
         continue;
       }
 
@@ -2908,6 +2911,7 @@ void CConfig::SetConfig_Parsing(istream& config_buffer){
         newString.append("\n");
         errorString.append(newString);
         err_count++;
+        line_count++;
         continue;
       }
 

--- a/SU2_CFD/src/output/CFlowCompOutput.cpp
+++ b/SU2_CFD/src/output/CFlowCompOutput.cpp
@@ -414,6 +414,12 @@ void CFlowCompOutput::SetVolumeOutputFields(CConfig *config){
     AddVolumeOutput("Q_CRITERION", "Q_Criterion", "VORTEX_IDENTIFICATION", "Value of the Q-Criterion");
   }
 
+  // Mesh quality metrics, computed in CPhysicalGeometry::ComputeMeshQualityStatistics.
+  // WRT_MESH_QUALITY= YES has to be set, otherwise the memory holding the data is freed.
+  AddVolumeOutput("ORTHOGONALITY", "Orthogonality", "MESH_QUALITY", "Orthogonality, additionally set \"WRT_MESH_QUALITY= YES\"");
+  AddVolumeOutput("ASPECT_RATIO", "Aspect_Ratio", "MESH_QUALITY", "Aspect ratio, additionally set \"WRT_MESH_QUALITY= YES\"");
+  AddVolumeOutput("VOLUME_RATIO", "Volume_Ratio", "MESH_QUALITY", "Volume Ratio, additionally set \"WRT_MESH_QUALITY= YES\"");
+
   if (config->GetTime_Domain()){
     SetTimeAveragedFields();
   }
@@ -552,6 +558,13 @@ void CFlowCompOutput::LoadVolumeData(CConfig *config, CGeometry *geometry, CSolv
       SetVolumeOutputValue("VORTICITY", iPoint, Node_Flow->GetVorticity(iPoint)[2]);
     }
     SetVolumeOutputValue("Q_CRITERION", iPoint, GetQ_Criterion(&(Node_Flow->GetGradient_Primitive(iPoint)[1])));
+  }
+
+  // Mesh quality metrics
+  if (config->GetWrt_MeshQuality()) {
+    SetVolumeOutputValue("ORTHOGONALITY", iPoint, geometry->Orthogonality[iPoint]);
+    SetVolumeOutputValue("ASPECT_RATIO", iPoint, geometry->Aspect_Ratio[iPoint]);
+    SetVolumeOutputValue("VOLUME_RATIO", iPoint, geometry->Volume_Ratio[iPoint]);
   }
 
   if (config->GetTime_Domain()){

--- a/SU2_CFD/src/output/CFlowCompOutput.cpp
+++ b/SU2_CFD/src/output/CFlowCompOutput.cpp
@@ -415,10 +415,9 @@ void CFlowCompOutput::SetVolumeOutputFields(CConfig *config){
   }
 
   // Mesh quality metrics, computed in CPhysicalGeometry::ComputeMeshQualityStatistics.
-  // WRT_MESH_QUALITY= YES has to be set, otherwise the memory holding the data is freed.
-  AddVolumeOutput("ORTHOGONALITY", "Orthogonality", "MESH_QUALITY", "Orthogonality, additionally set \"WRT_MESH_QUALITY= YES\"");
-  AddVolumeOutput("ASPECT_RATIO", "Aspect_Ratio", "MESH_QUALITY", "Aspect ratio, additionally set \"WRT_MESH_QUALITY= YES\"");
-  AddVolumeOutput("VOLUME_RATIO", "Volume_Ratio", "MESH_QUALITY", "Volume Ratio, additionally set \"WRT_MESH_QUALITY= YES\"");
+  AddVolumeOutput("ORTHOGONALITY", "Orthogonality", "MESH_QUALITY", "Orthogonality Angle (deg.)");
+  AddVolumeOutput("ASPECT_RATIO",  "Aspect_Ratio",  "MESH_QUALITY", "CV Face Area Aspect Ratio");
+  AddVolumeOutput("VOLUME_RATIO",  "Volume_Ratio",  "MESH_QUALITY", "CV Sub-Volume Ratio");
 
   if (config->GetTime_Domain()){
     SetTimeAveragedFields();
@@ -563,8 +562,8 @@ void CFlowCompOutput::LoadVolumeData(CConfig *config, CGeometry *geometry, CSolv
   // Mesh quality metrics
   if (config->GetWrt_MeshQuality()) {
     SetVolumeOutputValue("ORTHOGONALITY", iPoint, geometry->Orthogonality[iPoint]);
-    SetVolumeOutputValue("ASPECT_RATIO", iPoint, geometry->Aspect_Ratio[iPoint]);
-    SetVolumeOutputValue("VOLUME_RATIO", iPoint, geometry->Volume_Ratio[iPoint]);
+    SetVolumeOutputValue("ASPECT_RATIO",  iPoint, geometry->Aspect_Ratio[iPoint]);
+    SetVolumeOutputValue("VOLUME_RATIO",  iPoint, geometry->Volume_Ratio[iPoint]);
   }
 
   if (config->GetTime_Domain()){

--- a/SU2_CFD/src/output/CFlowIncOutput.cpp
+++ b/SU2_CFD/src/output/CFlowIncOutput.cpp
@@ -480,10 +480,9 @@ void CFlowIncOutput::SetVolumeOutputFields(CConfig *config){
   }
 
   // Mesh quality metrics, computed in CPhysicalGeometry::ComputeMeshQualityStatistics.
-  // WRT_MESH_QUALITY= YES has to be set, otherwise the memory holding the data is freed.
-  AddVolumeOutput("ORTHOGONALITY", "Orthogonality", "MESH_QUALITY", "Orthogonality, additionally set \"WRT_MESH_QUALITY= YES\"");
-  AddVolumeOutput("ASPECT_RATIO", "Aspect_Ratio", "MESH_QUALITY", "Aspect ratio, additionally set \"WRT_MESH_QUALITY= YES\"");
-  AddVolumeOutput("VOLUME_RATIO", "Volume_Ratio", "MESH_QUALITY", "Volume Ratio, additionally set \"WRT_MESH_QUALITY= YES\"");
+  AddVolumeOutput("ORTHOGONALITY", "Orthogonality", "MESH_QUALITY", "Orthogonality Angle (deg.)");
+  AddVolumeOutput("ASPECT_RATIO",  "Aspect_Ratio",  "MESH_QUALITY", "CV Face Area Aspect Ratio");
+  AddVolumeOutput("VOLUME_RATIO",  "Volume_Ratio",  "MESH_QUALITY", "CV Sub-Volume Ratio");
 
 }
 
@@ -652,8 +651,8 @@ void CFlowIncOutput::LoadSurfaceData(CConfig *config, CGeometry *geometry, CSolv
   // Mesh quality metrics
   if (config->GetWrt_MeshQuality()) {
     SetVolumeOutputValue("ORTHOGONALITY", iPoint, geometry->Orthogonality[iPoint]);
-    SetVolumeOutputValue("ASPECT_RATIO", iPoint, geometry->Aspect_Ratio[iPoint]);
-    SetVolumeOutputValue("VOLUME_RATIO", iPoint, geometry->Volume_Ratio[iPoint]);
+    SetVolumeOutputValue("ASPECT_RATIO",  iPoint, geometry->Aspect_Ratio[iPoint]);
+    SetVolumeOutputValue("VOLUME_RATIO",  iPoint, geometry->Volume_Ratio[iPoint]);
   }
 
 }

--- a/SU2_CFD/src/output/CFlowIncOutput.cpp
+++ b/SU2_CFD/src/output/CFlowIncOutput.cpp
@@ -478,6 +478,13 @@ void CFlowIncOutput::SetVolumeOutputFields(CConfig *config){
     }
     AddVolumeOutput("Q_CRITERION", "Q_Criterion", "VORTEX_IDENTIFICATION", "Value of the Q-Criterion");
   }
+
+  // Mesh quality metrics, computed in CPhysicalGeometry::ComputeMeshQualityStatistics.
+  // WRT_MESH_QUALITY= YES has to be set, otherwise the memory holding the data is freed.
+  AddVolumeOutput("ORTHOGONALITY", "Orthogonality", "MESH_QUALITY", "Orthogonality, additionally set \"WRT_MESH_QUALITY= YES\"");
+  AddVolumeOutput("ASPECT_RATIO", "Aspect_Ratio", "MESH_QUALITY", "Aspect ratio, additionally set \"WRT_MESH_QUALITY= YES\"");
+  AddVolumeOutput("VOLUME_RATIO", "Volume_Ratio", "MESH_QUALITY", "Volume Ratio, additionally set \"WRT_MESH_QUALITY= YES\"");
+
 }
 
 void CFlowIncOutput::LoadVolumeData(CConfig *config, CGeometry *geometry, CSolver **solver, unsigned long iPoint){
@@ -641,6 +648,14 @@ void CFlowIncOutput::LoadSurfaceData(CConfig *config, CGeometry *geometry, CSolv
     }
     SetVolumeOutputValue("Y_PLUS", iPoint, solver[FLOW_SOL]->GetYPlus(iMarker, iVertex));
   }
+
+  // Mesh quality metrics
+  if (config->GetWrt_MeshQuality()) {
+    SetVolumeOutputValue("ORTHOGONALITY", iPoint, geometry->Orthogonality[iPoint]);
+    SetVolumeOutputValue("ASPECT_RATIO", iPoint, geometry->Aspect_Ratio[iPoint]);
+    SetVolumeOutputValue("VOLUME_RATIO", iPoint, geometry->Volume_Ratio[iPoint]);
+  }
+
 }
 
 bool CFlowIncOutput::SetInit_Residuals(CConfig *config){

--- a/SU2_CFD/src/output/CHeatOutput.cpp
+++ b/SU2_CFD/src/output/CHeatOutput.cpp
@@ -131,6 +131,12 @@ void CHeatOutput::SetVolumeOutputFields(CConfig *config){
   // Residuals
   AddVolumeOutput("RES_TEMPERATURE", "Residual_Temperature", "RESIDUAL", "Residual of the temperature");
 
+  // Mesh quality metrics, computed in CPhysicalGeometry::ComputeMeshQualityStatistics.
+  // WRT_MESH_QUALITY= YES has to be set, otherwise the memory holding the data is freed.
+  AddVolumeOutput("ORTHOGONALITY", "Orthogonality", "MESH_QUALITY", "Orthogonality, additionally set \"WRT_MESH_QUALITY= YES\"");
+  AddVolumeOutput("ASPECT_RATIO", "Aspect_Ratio", "MESH_QUALITY", "Aspect ratio, additionally set \"WRT_MESH_QUALITY= YES\"");
+  AddVolumeOutput("VOLUME_RATIO", "Volume_Ratio", "MESH_QUALITY", "Volume Ratio, additionally set \"WRT_MESH_QUALITY= YES\"");
+
 }
 
 
@@ -150,6 +156,13 @@ void CHeatOutput::LoadVolumeData(CConfig *config, CGeometry *geometry, CSolver *
 
   // Residuals
   SetVolumeOutputValue("RES_TEMPERATURE", iPoint, solver[HEAT_SOL]->LinSysRes(iPoint, 0));
+
+  // Mesh quality metrics
+  if (config->GetWrt_MeshQuality()) {
+    SetVolumeOutputValue("ORTHOGONALITY", iPoint, geometry->Orthogonality[iPoint]);
+    SetVolumeOutputValue("ASPECT_RATIO", iPoint, geometry->Aspect_Ratio[iPoint]);
+    SetVolumeOutputValue("VOLUME_RATIO", iPoint, geometry->Volume_Ratio[iPoint]);
+  }
 
 }
 

--- a/SU2_CFD/src/output/CHeatOutput.cpp
+++ b/SU2_CFD/src/output/CHeatOutput.cpp
@@ -132,10 +132,9 @@ void CHeatOutput::SetVolumeOutputFields(CConfig *config){
   AddVolumeOutput("RES_TEMPERATURE", "Residual_Temperature", "RESIDUAL", "Residual of the temperature");
 
   // Mesh quality metrics, computed in CPhysicalGeometry::ComputeMeshQualityStatistics.
-  // WRT_MESH_QUALITY= YES has to be set, otherwise the memory holding the data is freed.
-  AddVolumeOutput("ORTHOGONALITY", "Orthogonality", "MESH_QUALITY", "Orthogonality, additionally set \"WRT_MESH_QUALITY= YES\"");
-  AddVolumeOutput("ASPECT_RATIO", "Aspect_Ratio", "MESH_QUALITY", "Aspect ratio, additionally set \"WRT_MESH_QUALITY= YES\"");
-  AddVolumeOutput("VOLUME_RATIO", "Volume_Ratio", "MESH_QUALITY", "Volume Ratio, additionally set \"WRT_MESH_QUALITY= YES\"");
+  AddVolumeOutput("ORTHOGONALITY", "Orthogonality", "MESH_QUALITY", "Orthogonality Angle (deg.)");
+  AddVolumeOutput("ASPECT_RATIO",  "Aspect_Ratio",  "MESH_QUALITY", "CV Face Area Aspect Ratio");
+  AddVolumeOutput("VOLUME_RATIO",  "Volume_Ratio",  "MESH_QUALITY", "CV Sub-Volume Ratio");
 
 }
 
@@ -160,8 +159,8 @@ void CHeatOutput::LoadVolumeData(CConfig *config, CGeometry *geometry, CSolver *
   // Mesh quality metrics
   if (config->GetWrt_MeshQuality()) {
     SetVolumeOutputValue("ORTHOGONALITY", iPoint, geometry->Orthogonality[iPoint]);
-    SetVolumeOutputValue("ASPECT_RATIO", iPoint, geometry->Aspect_Ratio[iPoint]);
-    SetVolumeOutputValue("VOLUME_RATIO", iPoint, geometry->Volume_Ratio[iPoint]);
+    SetVolumeOutputValue("ASPECT_RATIO",  iPoint, geometry->Aspect_Ratio[iPoint]);
+    SetVolumeOutputValue("VOLUME_RATIO",  iPoint, geometry->Volume_Ratio[iPoint]);
   }
 
 }

--- a/SU2_CFD/src/output/CMeshOutput.cpp
+++ b/SU2_CFD/src/output/CMeshOutput.cpp
@@ -56,6 +56,11 @@ void CMeshOutput::SetVolumeOutputFields(CConfig *config){
   if (nDim == 3)
     AddVolumeOutput("COORD-Z", "z", "COORDINATES", "z-component of the coordinate vector");
 
+  // Mesh quality metrics, computed in CPhysicalGeometry::ComputeMeshQualityStatistics.
+  // WRT_MESH_QUALITY= YES has to be set, otherwise the memory holding the data is freed.
+  AddVolumeOutput("ORTHOGONALITY", "Orthogonality", "MESH_QUALITY", "Orthogonality, additionally set \"WRT_MESH_QUALITY= YES\"");
+  AddVolumeOutput("ASPECT_RATIO", "Aspect_Ratio", "MESH_QUALITY", "Aspect ratio, additionally set \"WRT_MESH_QUALITY= YES\"");
+  AddVolumeOutput("VOLUME_RATIO", "Volume_Ratio", "MESH_QUALITY", "Volume Ratio, additionally set \"WRT_MESH_QUALITY= YES\"");
 
 }
 
@@ -67,5 +72,12 @@ void CMeshOutput::LoadVolumeData(CConfig *config, CGeometry *geometry, CSolver *
   SetVolumeOutputValue("COORD-Y", iPoint,  Node_Geo->GetCoord(iPoint, 1));
   if (nDim == 3)
     SetVolumeOutputValue("COORD-Z", iPoint, Node_Geo->GetCoord(iPoint, 2));
+
+  // Mesh quality metrics
+  if (config->GetWrt_MeshQuality()) {
+    SetVolumeOutputValue("ORTHOGONALITY", iPoint, geometry->Orthogonality[iPoint]);
+    SetVolumeOutputValue("ASPECT_RATIO", iPoint, geometry->Aspect_Ratio[iPoint]);
+    SetVolumeOutputValue("VOLUME_RATIO", iPoint, geometry->Volume_Ratio[iPoint]);
+  }
 
 }

--- a/SU2_CFD/src/output/CMeshOutput.cpp
+++ b/SU2_CFD/src/output/CMeshOutput.cpp
@@ -57,10 +57,9 @@ void CMeshOutput::SetVolumeOutputFields(CConfig *config){
     AddVolumeOutput("COORD-Z", "z", "COORDINATES", "z-component of the coordinate vector");
 
   // Mesh quality metrics, computed in CPhysicalGeometry::ComputeMeshQualityStatistics.
-  // WRT_MESH_QUALITY= YES has to be set, otherwise the memory holding the data is freed.
-  AddVolumeOutput("ORTHOGONALITY", "Orthogonality", "MESH_QUALITY", "Orthogonality, additionally set \"WRT_MESH_QUALITY= YES\"");
-  AddVolumeOutput("ASPECT_RATIO", "Aspect_Ratio", "MESH_QUALITY", "Aspect ratio, additionally set \"WRT_MESH_QUALITY= YES\"");
-  AddVolumeOutput("VOLUME_RATIO", "Volume_Ratio", "MESH_QUALITY", "Volume Ratio, additionally set \"WRT_MESH_QUALITY= YES\"");
+  AddVolumeOutput("ORTHOGONALITY", "Orthogonality", "MESH_QUALITY", "Orthogonality Angle (deg.)");
+  AddVolumeOutput("ASPECT_RATIO",  "Aspect_Ratio",  "MESH_QUALITY", "CV Face Area Aspect Ratio");
+  AddVolumeOutput("VOLUME_RATIO",  "Volume_Ratio",  "MESH_QUALITY", "CV Sub-Volume Ratio");
 
 }
 
@@ -76,8 +75,8 @@ void CMeshOutput::LoadVolumeData(CConfig *config, CGeometry *geometry, CSolver *
   // Mesh quality metrics
   if (config->GetWrt_MeshQuality()) {
     SetVolumeOutputValue("ORTHOGONALITY", iPoint, geometry->Orthogonality[iPoint]);
-    SetVolumeOutputValue("ASPECT_RATIO", iPoint, geometry->Aspect_Ratio[iPoint]);
-    SetVolumeOutputValue("VOLUME_RATIO", iPoint, geometry->Volume_Ratio[iPoint]);
+    SetVolumeOutputValue("ASPECT_RATIO",  iPoint, geometry->Aspect_Ratio[iPoint]);
+    SetVolumeOutputValue("VOLUME_RATIO",  iPoint, geometry->Volume_Ratio[iPoint]);
   }
 
 }

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -1422,6 +1422,9 @@ HISTORY_OUTPUT= (ITER, RMS_RES)
 % Volume output fields/groups (use 'SU2_CFD -d <config_file>' to view list of available fields)
 VOLUME_OUTPUT= (COORDINATES, SOLUTION, PRIMITIVE)
 %
+% Write volume data for mesh quality metrics. Additionally set VOLUME_OUTPUT= (MESH_QUALITY, ...)
+WRT_MESH_QUALITY= NO
+%
 % Writing frequency for screen output
 SCREEN_WRT_FREQ_INNER= 1
 %

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -1422,9 +1422,6 @@ HISTORY_OUTPUT= (ITER, RMS_RES)
 % Volume output fields/groups (use 'SU2_CFD -d <config_file>' to view list of available fields)
 VOLUME_OUTPUT= (COORDINATES, SOLUTION, PRIMITIVE)
 %
-% Write volume data for mesh quality metrics. Additionally set VOLUME_OUTPUT= (MESH_QUALITY, ...)
-WRT_MESH_QUALITY= NO
-%
 % Writing frequency for screen output
 SCREEN_WRT_FREQ_INNER= 1
 %


### PR DESCRIPTION
## Proposed Changes
Hi, I noticed that the mesh quality metrics are not available in the current output structure, so here they are. 
I removed WRT_MESH_QUALITY and just check&set in the configs postprocessing routine.
Compressible, Incompressible, Heat and Mesh Output are added here as the FEM solvers dont have the dual grid as stated in the original PR. 

**Bonus issue:** I noticed that Coordinates are not written in the Volume Output for the cases I tested (also the Quickstart) but haven't really figured out why yet. Doesn't matter whether VOLUME_OUTPUT is set with COORDINATES or not at all. I will look into this again but if you have a hint that would be appreciated💐 **Edit:** of course they are written implicitly otherwise on couldn't open a visu file but what do we have the volume output field COORDINATES for then? Maybe I am just blind, but this is not really part of this PR anyway.

Cheers, Tobi

## Related Work
Initial implementation #778 

## PR Checklist

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags, or simply --warnlevel=2 when using meson).
- [x] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
