### PR TITLE
Fix for nDim initialization causing macos builds in develop

### DIFF
--- a/SU2_CFD/src/fluid/CNEMOGas.cpp
+++ b/SU2_CFD/src/fluid/CNEMOGas.cpp
@@ -229,7 +229,7 @@ void CNEMOGas::ComputedPdU(su2double *V, vector<su2double>& val_eves, su2double 
 void CNEMOGas::ComputedTdU(su2double *V, su2double *val_dTdU){
 
   su2double v2, ef, rhoCvtr;
-  su2double Vel[nDim] = {0.0};
+  su2double Vel[3] = {0.0};
 
   /*--- Necessary indexes to assess primitive variables ---*/
   unsigned long VEL_INDEX     = nSpecies+2;


### PR DESCRIPTION
The fixes a change made by #1111 
The changes passed regressions however during the macos builds in develop.
I spoke with @economon and this should fix the problem.

## Related Work
#1111 
