### PR TITLE
Fix compilation with gcc 4.8

### DIFF
--- a/Common/include/linear_algebra/CSysVector.hpp
+++ b/Common/include/linear_algebra/CSysVector.hpp
@@ -101,7 +101,7 @@ class CSysVector : public VecExpr::CVecExpr<CSysVector<ScalarType>, ScalarType> 
   /*!
    * \brief Default constructor of the class.
    */
-  CSysVector() = default;
+  CSysVector() {}
 
   /*!
    * \brief Destructor

--- a/Common/include/parallelization/vectorization.hpp
+++ b/Common/include/parallelization/vectorization.hpp
@@ -78,7 +78,7 @@ public:
   static constexpr bool StoreAsRef = true;
 
 private:
-  alignas(Align) Scalar x_[N];
+  alignas(Size*sizeof(Scalar)) Scalar x_[N];
 
 public:
 #define ARRAY_BOILERPLATE                                                     \

--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -4381,6 +4381,10 @@ void CConfig::SetPostprocessing(unsigned short val_software, unsigned short val_
     SU2_MPI::Error("BC transition model currently only available in combination with SA turbulence model!", CURRENT_FUNCTION);
   }
 
+  if (Kind_Trans_Model == LM) {
+    SU2_MPI::Error("The LM transition model is under maintenance.", CURRENT_FUNCTION);
+  }
+
   /*--- Check for constant lift mode. Initialize the update flag for
    the AoA with each iteration to false  ---*/
 
@@ -5539,6 +5543,7 @@ void CConfig::SetOutput(unsigned short val_software, unsigned short val_izone) {
           case SST_SUST:  cout << "Menter's SST with sustaining terms" << endl; break;
         }
         if (QCR) cout << "Using Quadratic Constitutive Relation, 2000 version (QCR2000)" << endl;
+        if (Kind_Trans_Model == BC) cout << "Using the revised BC transition model (2020)" << endl;
         cout << "Hybrid RANS/LES: ";
         switch (Kind_HybridRANSLES){
           case NO_HYBRIDRANSLES: cout <<  "No Hybrid RANS/LES" << endl; break;

--- a/SU2_CFD/src/numerics/turbulent/turb_sources.cpp
+++ b/SU2_CFD/src/numerics/turbulent/turb_sources.cpp
@@ -76,10 +76,6 @@ CNumerics::ResidualType<> CSourcePieceWise_TurbSA::ComputeResidual(const CConfig
 //  AD::SetPreaccIn(TurbVar_Grad_i[0], nDim);
 //  AD::SetPreaccIn(Volume); AD::SetPreaccIn(dist_i);
 
-//  BC Transition Model variables
-  su2double vmag, rey, re_theta, re_theta_t, re_v;
-  su2double tu, nu_t, chi_1, chi_2, term1, term2, term_exponential;
-
   // Set the boolean here depending on whether the point is closest to a rough wall or not.
   roughwall = (roughness_i > 0.0);
 
@@ -99,16 +95,6 @@ CNumerics::ResidualType<> CSourcePieceWise_TurbSA::ComputeResidual(const CConfig
   Jacobian_i[0]   = 0.0;
 
   gamma_BC = 0.0;
-  vmag = 0.0;
-  tu   = config->GetTurbulenceIntensity_FreeStream();
-  rey  = config->GetReynolds();
-
-  if (nDim==2) {
-    vmag = sqrt(V_i[1]*V_i[1]+V_i[2]*V_i[2]);
-  }
-  else {
-    vmag = sqrt(V_i[1]*V_i[1]+V_i[2]*V_i[2]+V_i[3]*V_i[3]);
-  }
 
   /*--- Evaluate Omega ---*/
 
@@ -151,23 +137,23 @@ CNumerics::ResidualType<> CSourcePieceWise_TurbSA::ComputeResidual(const CConfig
 
     if (transition) {
 
-//    BC model constants
-      chi_1 = 0.002;
-      chi_2 = 50.0;
+      /*--- BC model constants (2020 revision). ---*/
+      const su2double chi_1 = 0.002;
+      const su2double chi_2 = 50.0;
 
-      nu_t = (TurbVar_i[0]*fv1); //S-A variable
-      //nu_cr = chi_2/rey;
-      //nu_BC = (nu_t)/(vmag*dist_i);
+      su2double tu = config->GetTurbulenceIntensity_FreeStream();
 
-      re_v   = ((Density_i*pow(dist_i,2.))/(Laminar_Viscosity_i))*Omega;
-      re_theta = re_v/2.193;
-      re_theta_t = (803.73 * pow((tu + 0.6067),-1.027)); //MENTER correlation
+      su2double nu_t = (TurbVar_i[0]*fv1); //S-A variable
+
+      su2double re_v = ((Density_i*pow(dist_i,2.))/(Laminar_Viscosity_i))*Omega;
+      su2double re_theta = re_v/2.193;
+      su2double re_theta_t = (803.73 * pow((tu + 0.6067),-1.027)); //MENTER correlation
       //re_theta_t = 163.0 + exp(6.91-tu); //ABU-GHANNAM & SHAW correlation
 
-      term1 = sqrt(max(re_theta-re_theta_t,0.)/(chi_1*re_theta_t));
-      term2 = sqrt(max((nu_t*chi_2)/nu,0.));
-      term_exponential = (term1 + term2);
-      gamma_BC = 1.0 - exp(-term_exponential);
+      su2double term1 = sqrt(max(re_theta-re_theta_t,0.)/(chi_1*re_theta_t));
+      su2double term2 = sqrt(max((nu_t*chi_2)/nu,0.));
+      su2double term_exponential = (term1 + term2);
+      su2double gamma_BC = 1.0 - exp(-term_exponential);
 
       Production = gamma_BC*cb1*Shat*TurbVar_i[0]*Volume;
     }

--- a/TestCases/parallel_regression.py
+++ b/TestCases/parallel_regression.py
@@ -546,7 +546,7 @@ def main():
     schubauer_klebanoff_transition.cfg_dir      = "transition/Schubauer_Klebanoff"
     schubauer_klebanoff_transition.cfg_file     = "transitional_BC_model_ConfigFile.cfg"
     schubauer_klebanoff_transition.test_iter    = 10
-    schubauer_klebanoff_transition.test_vals    = [-7.994740, -14.268433, 0.000046, 0.007987]
+    schubauer_klebanoff_transition.test_vals    = [-7.994740, -14.268326, 0.000046, 0.007987]
     schubauer_klebanoff_transition.su2_exec     = "parallel_computation.py -f"
     schubauer_klebanoff_transition.timeout      = 1600
     schubauer_klebanoff_transition.tol          = 0.00001

--- a/TestCases/parallel_regression.py
+++ b/TestCases/parallel_regression.py
@@ -546,7 +546,7 @@ def main():
     schubauer_klebanoff_transition.cfg_dir      = "transition/Schubauer_Klebanoff"
     schubauer_klebanoff_transition.cfg_file     = "transitional_BC_model_ConfigFile.cfg"
     schubauer_klebanoff_transition.test_iter    = 10
-    schubauer_klebanoff_transition.test_vals    = [-7.994740, -14.268367, 0.000046, 0.007987]
+    schubauer_klebanoff_transition.test_vals    = [-7.994740, -14.268433, 0.000046, 0.007987]
     schubauer_klebanoff_transition.su2_exec     = "parallel_computation.py -f"
     schubauer_klebanoff_transition.timeout      = 1600
     schubauer_klebanoff_transition.tol          = 0.00001

--- a/TestCases/serial_regression.py
+++ b/TestCases/serial_regression.py
@@ -643,7 +643,7 @@ def main():
     schubauer_klebanoff_transition.cfg_file     = "transitional_BC_model_ConfigFile.cfg"
     schubauer_klebanoff_transition.test_iter    = 10
     schubauer_klebanoff_transition.new_output   = True
-    schubauer_klebanoff_transition.test_vals    = [-8.029786, -14.268417, 0.000053, 0.007986] #last 4 columns
+    schubauer_klebanoff_transition.test_vals    = [-8.029786, -14.268310, 0.000053, 0.007986] #last 4 columns
     schubauer_klebanoff_transition.su2_exec     = "SU2_CFD"
     schubauer_klebanoff_transition.timeout      = 1600
     schubauer_klebanoff_transition.tol          = 0.00001

--- a/TestCases/serial_regression.py
+++ b/TestCases/serial_regression.py
@@ -643,7 +643,7 @@ def main():
     schubauer_klebanoff_transition.cfg_file     = "transitional_BC_model_ConfigFile.cfg"
     schubauer_klebanoff_transition.test_iter    = 10
     schubauer_klebanoff_transition.new_output   = True
-    schubauer_klebanoff_transition.test_vals    = [-8.029786, -14.268351, 0.000053, 0.007986] #last 4 columns
+    schubauer_klebanoff_transition.test_vals    = [-8.029786, -14.268417, 0.000053, 0.007986] #last 4 columns
     schubauer_klebanoff_transition.su2_exec     = "SU2_CFD"
     schubauer_klebanoff_transition.timeout      = 1600
     schubauer_klebanoff_transition.tol          = 0.00001

--- a/TestCases/tutorials.py
+++ b/TestCases/tutorials.py
@@ -121,7 +121,7 @@ def main():
     tutorial_trans_flatplate.cfg_dir    = "../Tutorials/compressible_flow/Transitional_Flat_Plate"
     tutorial_trans_flatplate.cfg_file   = "transitional_BC_model_ConfigFile.cfg"
     tutorial_trans_flatplate.test_iter  = 0
-    tutorial_trans_flatplate.test_vals  = [-22.021786, -15.330906, 0.000000, 0.023952] #last 4 columns
+    tutorial_trans_flatplate.test_vals  = [-22.021786, -15.330766, 0.000000, 0.023952] #last 4 columns
     tutorial_trans_flatplate.su2_exec   = "mpirun -np 2 SU2_CFD"
     tutorial_trans_flatplate.timeout    = 1600
     tutorial_trans_flatplate.tol        = 0.00001

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -21,6 +21,9 @@ SOLVER= EULER
 % Specify turbulence model (NONE, SA, SA_NEG, SST, SA_E, SA_COMP, SA_E_COMP, SST_SUST)
 KIND_TURB_MODEL= NONE
 %
+% Transition model (NONE, BC)
+KIND_TRANS_MODEL= NONE
+%
 % Specify subgrid scale model(NONE, IMPLICIT_LES, SMAGORINSKY, WALE, VREMAN)
 KIND_SGS_MODEL= NONE
 %


### PR DESCRIPTION
## Proposed Changes
Throw error for LM, print message that BC is the 2020 version.

## Related Work
#1132
#1130

## PR Checklist
- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags, or simply --warnlevel=2 when using meson).
- [X] My contribution is commented and consistent with SU2 style.
- [X] I have added a test case that demonstrates my contribution, if necessary.
- [X] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
