### PR TITLE
Bsend -> Isend on ActDisk and Nearfield methods

### DIFF
--- a/Common/include/option_structure.hpp
+++ b/Common/include/option_structure.hpp
@@ -74,7 +74,6 @@ enum SU2_COMPONENT {
 
 const unsigned int EXIT_DIVERGENCE = 2;   /*!< \brief Exit code (divergence). */
 
-const unsigned int BUFSIZE = 3000000;         /*!< \brief MPI buffer. */
 const unsigned int MAX_PARAMETERS = 10;       /*!< \brief Maximum number of parameters for a design variable definition. */
 const unsigned int MAX_NUMBER_PERIODIC = 10;  /*!< \brief Maximum number of periodic boundary conditions. */
 const unsigned int MAX_STRING_SIZE = 200;     /*!< \brief Maximum number of domains. */

--- a/Common/include/parallelization/mpi_structure.hpp
+++ b/Common/include/parallelization/mpi_structure.hpp
@@ -144,10 +144,6 @@ class CBaseMPIWrapper {
     winMinRankErrorInUse = true;
   }
 
-  static inline void Buffer_attach(void* buffer, int size) { MPI_Buffer_attach(buffer, size); }
-
-  static inline void Buffer_detach(void* buffer, int* size) { MPI_Buffer_detach(buffer, size); }
-
   static inline void Comm_rank(Comm comm, int* rank) { MPI_Comm_rank(comm, rank); }
 
   static inline void Comm_size(Comm comm, int* size) { MPI_Comm_size(comm, size); }
@@ -176,6 +172,8 @@ class CBaseMPIWrapper {
 
   static inline void Wait(Request* request, Status* status) { MPI_Wait(request, status); }
 
+  static inline int Request_free(Request *request) { return MPI_Request_free(request); }
+
   static inline void Testall(int count, Request* array_of_requests, int* flag, Status* array_of_statuses) {
     MPI_Testall(count, array_of_requests, flag, array_of_statuses);
   }
@@ -196,10 +194,6 @@ class CBaseMPIWrapper {
 
   static inline void Bcast(void* buf, int count, Datatype datatype, int root, Comm comm) {
     MPI_Bcast(buf, count, datatype, root, comm);
-  }
-
-  static inline void Bsend(const void* buf, int count, Datatype datatype, int dest, int tag, Comm comm) {
-    MPI_Bsend(buf, count, datatype, dest, tag, comm);
   }
 
   static inline void Reduce(const void* sendbuf, void* recvbuf, int count, Datatype datatype, Op op, int root,
@@ -351,10 +345,6 @@ class CMediMPIWrapper : public CBaseMPIWrapper {
     }
   }
 
-  static inline void Buffer_attach(void* buffer, int size) { AMPI_Buffer_attach(buffer, size); }
-
-  static inline void Buffer_detach(void* buffer, int* size) { AMPI_Buffer_detach(buffer, size); }
-
   static inline void Comm_rank(Comm comm, int* rank) { AMPI_Comm_rank(convertComm(comm), rank); }
 
   static inline void Comm_size(Comm comm, int* size) { AMPI_Comm_size(convertComm(comm), size); }
@@ -385,6 +375,8 @@ class CMediMPIWrapper : public CBaseMPIWrapper {
 
   static inline void Wait(SU2_MPI::Request* request, Status* status) { AMPI_Wait(request, status); }
 
+  static inline int Request_free(Request *request) { return AMPI_Request_free(request); }
+
   static inline void Testall(int count, Request* array_of_requests, int* flag, Status* array_of_statuses) {
     AMPI_Testall(count, array_of_requests, flag, array_of_statuses);
   }
@@ -407,10 +399,6 @@ class CMediMPIWrapper : public CBaseMPIWrapper {
 
   static inline void Bcast(void* buf, int count, Datatype datatype, int root, Comm comm) {
     AMPI_Bcast(buf, count, convertDatatype(datatype), root, convertComm(comm));
-  }
-
-  static inline void Bsend(const void* buf, int count, Datatype datatype, int dest, int tag, Comm comm) {
-    AMPI_Bsend(buf, count, convertDatatype(datatype), dest, tag, convertComm(comm));
   }
 
   static inline void Reduce(const void* sendbuf, void* recvbuf, int count, Datatype datatype, Op op, int root,
@@ -574,10 +562,6 @@ class CBaseMPIWrapper {
 
   static inline void Init_thread(int* argc, char*** argv, int required, int* provided) { *provided = required; }
 
-  static inline void Buffer_attach(void* buffer, int size) {}
-
-  static inline void Buffer_detach(void* buffer, int* size) {}
-
   static inline void Barrier(Comm comm) {}
 
   static inline void Abort(Comm comm, int error) { exit(EXIT_FAILURE); }
@@ -595,6 +579,8 @@ class CBaseMPIWrapper {
 
   static inline void Wait(Request* request, Status* status) {}
 
+  static inline int Request_free(Request *request) { return 0; }
+
   static inline void Waitall(int nrequests, Request* request, Status* status) {}
 
   static inline void Waitany(int nrequests, Request* request, int* index, Status* status) {}
@@ -604,8 +590,6 @@ class CBaseMPIWrapper {
   static inline void Recv(void* buf, int count, Datatype datatype, int dest, int tag, Comm comm, Status* status) {}
 
   static inline void Bcast(void* buf, int count, Datatype datatype, int root, Comm comm) {}
-
-  static inline void Bsend(const void* buf, int count, Datatype datatype, int dest, int tag, Comm comm) {}
 
   static inline void Reduce(const void* sendbuf, void* recvbuf, int count, Datatype datatype, Op op, int root,
                             Comm comm) {

--- a/SU2_CFD/src/SU2_CFD.cpp
+++ b/SU2_CFD/src/SU2_CFD.cpp
@@ -61,8 +61,6 @@ int main(int argc, char *argv[]) {
   /*--- MPI initialization, and buffer setting ---*/
 
 #ifdef HAVE_MPI
-  int  buffsize;
-  char *buffptr;
 #ifdef HAVE_OMP
   int required = use_thread_mult? MPI_THREAD_MULTIPLE : MPI_THREAD_FUNNELED;
   int provided;
@@ -70,7 +68,6 @@ int main(int argc, char *argv[]) {
 #else
   SU2_MPI::Init(&argc, &argv);
 #endif
-  SU2_MPI::Buffer_attach( malloc(BUFSIZE), BUFSIZE );
   SU2_Comm MPICommunicator(MPI_COMM_WORLD);
 #else
   SU2_Comm MPICommunicator(0);
@@ -178,11 +175,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   /*--- Finalize MPI parallelization. ---*/
-#ifdef HAVE_MPI
-  SU2_MPI::Buffer_detach(&buffptr, &buffsize);
-  free(buffptr);
   SU2_MPI::Finalize();
-#endif
 
   return EXIT_SUCCESS;
 

--- a/SU2_CFD/src/solvers/CAdjEulerSolver.cpp
+++ b/SU2_CFD/src/solvers/CAdjEulerSolver.cpp
@@ -403,14 +403,10 @@ void CAdjEulerSolver::Set_MPI_ActDisk(CSolver **solver_container, CGeometry *geo
   unsigned short iVar, iMarker, jMarker;
   long nDomain = 0, iDomain, jDomain;
 
-#ifdef HAVE_MPI
-
   /*--- MPI status and request arrays for non-blocking communications ---*/
 
-  SU2_MPI::Status status, status_;
-
-
-#endif
+  SU2_MPI::Status status;
+  SU2_MPI::Request req;
 
   /*--- Define buffer vector interior domain ---*/
 
@@ -480,13 +476,10 @@ void CAdjEulerSolver::Set_MPI_ActDisk(CSolver **solver_container, CGeometry *geo
 
     if (rank != iDomain) {
 
-#ifdef HAVE_MPI
-
       /*--- Communicate the counts to iDomain with non-blocking sends ---*/
 
-      SU2_MPI::Bsend(&nPointTotal_s[iDomain], 1, MPI_UNSIGNED_LONG, iDomain, iDomain, MPI_COMM_WORLD);
-
-#endif
+      SU2_MPI::Isend(&nPointTotal_s[iDomain], 1, MPI_UNSIGNED_LONG, iDomain, iDomain, MPI_COMM_WORLD, &req);
+      SU2_MPI::Request_free(&req);
 
     } else {
 
@@ -508,14 +501,10 @@ void CAdjEulerSolver::Set_MPI_ActDisk(CSolver **solver_container, CGeometry *geo
 
         if (rank != jDomain) {
 
-#ifdef HAVE_MPI
-
           /*--- Recv the data by probing for the current sender, jDomain,
            first and then receiving the values from it. ---*/
 
           SU2_MPI::Recv(&nPointTotal_r[jDomain], 1, MPI_UNSIGNED_LONG, jDomain, rank, MPI_COMM_WORLD, &status);
-
-#endif
 
         }
       }
@@ -525,11 +514,7 @@ void CAdjEulerSolver::Set_MPI_ActDisk(CSolver **solver_container, CGeometry *geo
 
   /*--- Wait for the non-blocking sends to complete. ---*/
 
-#ifdef HAVE_MPI
-
   SU2_MPI::Barrier(MPI_COMM_WORLD);
-
-#endif
 
   /*--- Initialize the counters for the larger send buffers (by domain) ---*/
 
@@ -578,17 +563,13 @@ void CAdjEulerSolver::Set_MPI_ActDisk(CSolver **solver_container, CGeometry *geo
 
     if (iDomain != rank) {
 
-#ifdef HAVE_MPI
-
       /*--- Communicate the coordinates, global index, colors, and element
        date to iDomain with non-blocking sends. ---*/
 
-      SU2_MPI::Bsend(&Buffer_Send_AdjVar[PointTotal_Counter*(nVar+3)],
+      SU2_MPI::Isend(&Buffer_Send_AdjVar[PointTotal_Counter*(nVar+3)],
                      nPointTotal_s[iDomain]*(nVar+3), MPI_DOUBLE, iDomain,
-                     iDomain,  MPI_COMM_WORLD);
-
-#endif
-
+                     iDomain,  MPI_COMM_WORLD, &req);
+      SU2_MPI::Request_free(&req);
     }
 
     else {
@@ -631,11 +612,7 @@ void CAdjEulerSolver::Set_MPI_ActDisk(CSolver **solver_container, CGeometry *geo
 
   /*--- Wait for the non-blocking sends to complete. ---*/
 
-#ifdef HAVE_MPI
-
   SU2_MPI::Barrier(MPI_COMM_WORLD);
-
-#endif
 
   /*--- The next section begins the recv of all data for the interior
    points/elements in the mesh. First, create the domain structures for
@@ -655,7 +632,7 @@ void CAdjEulerSolver::Set_MPI_ActDisk(CSolver **solver_container, CGeometry *geo
       /*--- Receive the buffers with the coords, global index, and colors ---*/
 
       SU2_MPI::Recv(Buffer_Receive_AdjVar, nPointTotal_r[iDomain]*(nVar+3) , MPI_DOUBLE,
-                    iDomain, rank, MPI_COMM_WORLD, &status_);
+                    iDomain, rank, MPI_COMM_WORLD, &status);
 
       /*--- Loop over all of the points that we have recv'd and store the
        coords, global index vertex and markers ---*/
@@ -687,11 +664,7 @@ void CAdjEulerSolver::Set_MPI_ActDisk(CSolver **solver_container, CGeometry *geo
 
   /*--- Wait for the non-blocking sends to complete. ---*/
 
-#ifdef HAVE_MPI
-
   SU2_MPI::Barrier(MPI_COMM_WORLD);
-
-#endif
 
   /*--- Free all of the memory used for communicating points and elements ---*/
 
@@ -712,14 +685,10 @@ void CAdjEulerSolver::Set_MPI_Nearfield(CGeometry *geometry, CConfig *config) {
   unsigned short iVar, iMarker, jMarker;
   long nDomain = 0, iDomain, jDomain;
 
-#ifdef HAVE_MPI
-
   /*--- MPI status and request arrays for non-blocking communications ---*/
 
-  SU2_MPI::Status status, status_;
-
-
-#endif
+  SU2_MPI::Status status;
+  SU2_MPI::Request req;
 
   /*--- Define buffer vector interior domain ---*/
 
@@ -742,11 +711,7 @@ void CAdjEulerSolver::Set_MPI_Nearfield(CGeometry *geometry, CConfig *config) {
 
   nDomain = size;
 
-#ifdef HAVE_MPI
-
   SU2_MPI::Barrier(MPI_COMM_WORLD);
-
-#endif
 
   /*--- This loop gets the array sizes of points for each
    rank to send to each other rank. ---*/
@@ -796,13 +761,10 @@ void CAdjEulerSolver::Set_MPI_Nearfield(CGeometry *geometry, CConfig *config) {
 
     if (rank != iDomain) {
 
-#ifdef HAVE_MPI
-
       /*--- Communicate the counts to iDomain with non-blocking sends ---*/
 
-      SU2_MPI::Bsend(&nPointTotal_s[iDomain], 1, MPI_UNSIGNED_LONG, iDomain, iDomain, MPI_COMM_WORLD);
-
-#endif
+      SU2_MPI::Isend(&nPointTotal_s[iDomain], 1, MPI_UNSIGNED_LONG, iDomain, iDomain, MPI_COMM_WORLD, &req);
+      SU2_MPI::Request_free(&req);
 
     } else {
 
@@ -824,14 +786,10 @@ void CAdjEulerSolver::Set_MPI_Nearfield(CGeometry *geometry, CConfig *config) {
 
         if (rank != jDomain) {
 
-#ifdef HAVE_MPI
-
           /*--- Recv the data by probing for the current sender, jDomain,
            first and then receiving the values from it. ---*/
 
           SU2_MPI::Recv(&nPointTotal_r[jDomain], 1, MPI_UNSIGNED_LONG, jDomain, rank, MPI_COMM_WORLD, &status);
-
-#endif
 
         }
       }
@@ -841,11 +799,7 @@ void CAdjEulerSolver::Set_MPI_Nearfield(CGeometry *geometry, CConfig *config) {
 
   /*--- Wait for the non-blocking sends to complete. ---*/
 
-#ifdef HAVE_MPI
-
   SU2_MPI::Barrier(MPI_COMM_WORLD);
-
-#endif
 
   /*--- Initialize the counters for the larger send buffers (by domain) ---*/
 
@@ -893,17 +847,13 @@ void CAdjEulerSolver::Set_MPI_Nearfield(CGeometry *geometry, CConfig *config) {
 
     if (iDomain != rank) {
 
-#ifdef HAVE_MPI
-
       /*--- Communicate the coordinates, global index, colors, and element
        date to iDomain with non-blocking sends. ---*/
 
-      SU2_MPI::Bsend(&Buffer_Send_AdjVar[PointTotal_Counter*(nVar+3)],
+      SU2_MPI::Isend(&Buffer_Send_AdjVar[PointTotal_Counter*(nVar+3)],
                      nPointTotal_s[iDomain]*(nVar+3), MPI_DOUBLE, iDomain,
-                     iDomain,  MPI_COMM_WORLD);
-
-#endif
-
+                     iDomain,  MPI_COMM_WORLD, &req);
+      SU2_MPI::Request_free(&req);
     }
 
     else {
@@ -946,11 +896,7 @@ void CAdjEulerSolver::Set_MPI_Nearfield(CGeometry *geometry, CConfig *config) {
 
   /*--- Wait for the non-blocking sends to complete. ---*/
 
-#ifdef HAVE_MPI
-
   SU2_MPI::Barrier(MPI_COMM_WORLD);
-
-#endif
 
   /*--- The next section begins the recv of all data for the interior
    points/elements in the mesh. First, create the domain structures for
@@ -970,7 +916,7 @@ void CAdjEulerSolver::Set_MPI_Nearfield(CGeometry *geometry, CConfig *config) {
       /*--- Receive the buffers with the coords, global index, and colors ---*/
 
       SU2_MPI::Recv(Buffer_Receive_AdjVar, nPointTotal_r[iDomain]*(nVar+3) , MPI_DOUBLE,
-                    iDomain, rank, MPI_COMM_WORLD, &status_);
+                    iDomain, rank, MPI_COMM_WORLD, &status);
 
 
       /*--- Loop over all of the points that we have recv'd and store the
@@ -1003,11 +949,7 @@ void CAdjEulerSolver::Set_MPI_Nearfield(CGeometry *geometry, CConfig *config) {
 
   /*--- Wait for the non-blocking sends to complete. ---*/
 
-#ifdef HAVE_MPI
-
   SU2_MPI::Barrier(MPI_COMM_WORLD);
-
-#endif
 
   /*--- Free all of the memory used for communicating points and elements ---*/
 

--- a/SU2_CFD/src/solvers/CEulerSolver.cpp
+++ b/SU2_CFD/src/solvers/CEulerSolver.cpp
@@ -833,13 +833,10 @@ void CEulerSolver::Set_MPI_ActDisk(CSolver **solver_container, CGeometry *geomet
   unsigned short nPrimVar_ = nPrimVar;
   if (rans) nPrimVar_ += 2; // Add two extra variables for the turbulence.
 
-#ifdef HAVE_MPI
-
   /*--- MPI status and request arrays for non-blocking communications ---*/
 
   SU2_MPI::Status status;
-
-#endif
+  SU2_MPI::Request req;
 
   /*--- Define buffer vector interior domain ---*/
 
@@ -917,13 +914,10 @@ void CEulerSolver::Set_MPI_ActDisk(CSolver **solver_container, CGeometry *geomet
 
     if (rank != iDomain) {
 
-#ifdef HAVE_MPI
-
       /*--- Communicate the counts to iDomain with non-blocking sends ---*/
 
-      SU2_MPI::Bsend(&nPointTotal_s[iDomain], 1, MPI_UNSIGNED_LONG, iDomain, iDomain, MPI_COMM_WORLD);
-
-#endif
+      SU2_MPI::Isend(&nPointTotal_s[iDomain], 1, MPI_UNSIGNED_LONG, iDomain, iDomain, MPI_COMM_WORLD, &req);
+      SU2_MPI::Request_free(&req);
 
     } else {
 
@@ -945,14 +939,10 @@ void CEulerSolver::Set_MPI_ActDisk(CSolver **solver_container, CGeometry *geomet
 
         if (rank != jDomain) {
 
-#ifdef HAVE_MPI
-
           /*--- Recv the data by probing for the current sender, jDomain,
            first and then receiving the values from it. ---*/
 
           SU2_MPI::Recv(&nPointTotal_r[jDomain], 1, MPI_UNSIGNED_LONG, jDomain, rank, MPI_COMM_WORLD, &status);
-
-#endif
 
         }
       }
@@ -962,11 +952,7 @@ void CEulerSolver::Set_MPI_ActDisk(CSolver **solver_container, CGeometry *geomet
 
   /*--- Wait for the non-blocking sends to complete. ---*/
 
-#ifdef HAVE_MPI
-
   SU2_MPI::Barrier(MPI_COMM_WORLD);
-
-#endif
 
   /*--- Initialize the counters for the larger send buffers (by domain) ---*/
 
@@ -1023,21 +1009,18 @@ void CEulerSolver::Set_MPI_ActDisk(CSolver **solver_container, CGeometry *geomet
 
     if (iDomain != rank) {
 
-#ifdef HAVE_MPI
-
       /*--- Communicate the coordinates, global index, colors, and element
        date to iDomain with non-blocking sends. ---*/
 
-      SU2_MPI::Bsend(&Buffer_Send_PrimVar[PointTotal_Counter*(nPrimVar_)],
+      SU2_MPI::Isend(&Buffer_Send_PrimVar[PointTotal_Counter*(nPrimVar_)],
                      nPointTotal_s[iDomain]*(nPrimVar_), MPI_DOUBLE, iDomain,
-                     iDomain,  MPI_COMM_WORLD);
+                     iDomain,  MPI_COMM_WORLD, &req);
+      SU2_MPI::Request_free(&req);
 
-      SU2_MPI::Bsend(&Buffer_Send_Data[PointTotal_Counter*(3)],
+      SU2_MPI::Isend(&Buffer_Send_Data[PointTotal_Counter*(3)],
                      nPointTotal_s[iDomain]*(3), MPI_LONG, iDomain,
-                     iDomain+nDomain,  MPI_COMM_WORLD);
-
-#endif
-
+                     iDomain+nDomain,  MPI_COMM_WORLD, &req);
+      SU2_MPI::Request_free(&req);
     }
 
     else {
@@ -1087,11 +1070,7 @@ void CEulerSolver::Set_MPI_ActDisk(CSolver **solver_container, CGeometry *geomet
 
   /*--- Wait for the non-blocking sends to complete. ---*/
 
-#ifdef HAVE_MPI
-
   SU2_MPI::Barrier(MPI_COMM_WORLD);
-
-#endif
 
   /*--- The next section begins the recv of all data for the interior
    points/elements in the mesh. First, create the domain structures for
@@ -1150,11 +1129,7 @@ void CEulerSolver::Set_MPI_ActDisk(CSolver **solver_container, CGeometry *geomet
 
   /*--- Wait for the non-blocking sends to complete. ---*/
 
-#ifdef HAVE_MPI
-
   SU2_MPI::Barrier(MPI_COMM_WORLD);
-
-#endif
 
   /*--- Free all of the memory used for communicating points and elements ---*/
 
@@ -1177,14 +1152,10 @@ void CEulerSolver::Set_MPI_Nearfield(CGeometry *geometry, CConfig *config) {
   unsigned short iVar, iMarker, jMarker;
   long nDomain = 0, iDomain, jDomain;
 
-#ifdef HAVE_MPI
-
   /*--- MPI status and request arrays for non-blocking communications ---*/
 
-  SU2_MPI::Status status, status_;
-
-
-#endif
+  SU2_MPI::Status status;
+  SU2_MPI::Request req;
 
   /*--- Define buffer vector interior domain ---*/
 
@@ -1253,13 +1224,10 @@ void CEulerSolver::Set_MPI_Nearfield(CGeometry *geometry, CConfig *config) {
 
     if (rank != iDomain) {
 
-#ifdef HAVE_MPI
-
       /*--- Communicate the counts to iDomain with non-blocking sends ---*/
 
-      SU2_MPI::Bsend(&nPointTotal_s[iDomain], 1, MPI_UNSIGNED_LONG, iDomain, iDomain, MPI_COMM_WORLD);
-
-#endif
+      SU2_MPI::Isend(&nPointTotal_s[iDomain], 1, MPI_UNSIGNED_LONG, iDomain, iDomain, MPI_COMM_WORLD, &req);
+      SU2_MPI::Request_free(&req);
 
     } else {
 
@@ -1281,14 +1249,10 @@ void CEulerSolver::Set_MPI_Nearfield(CGeometry *geometry, CConfig *config) {
 
         if (rank != jDomain) {
 
-#ifdef HAVE_MPI
-
           /*--- Recv the data by probing for the current sender, jDomain,
            first and then receiving the values from it. ---*/
 
           SU2_MPI::Recv(&nPointTotal_r[jDomain], 1, MPI_UNSIGNED_LONG, jDomain, rank, MPI_COMM_WORLD, &status);
-
-#endif
 
         }
       }
@@ -1298,11 +1262,7 @@ void CEulerSolver::Set_MPI_Nearfield(CGeometry *geometry, CConfig *config) {
 
   /*--- Wait for the non-blocking sends to complete. ---*/
 
-#ifdef HAVE_MPI
-
   SU2_MPI::Barrier(MPI_COMM_WORLD);
-
-#endif
 
   /*--- Initialize the counters for the larger send buffers (by domain) ---*/
 
@@ -1348,17 +1308,13 @@ void CEulerSolver::Set_MPI_Nearfield(CGeometry *geometry, CConfig *config) {
 
     if (iDomain != rank) {
 
-#ifdef HAVE_MPI
-
       /*--- Communicate the coordinates, global index, colors, and element
        date to iDomain with non-blocking sends. ---*/
 
-      SU2_MPI::Bsend(&Buffer_Send_PrimVar[PointTotal_Counter*(nPrimVar+3)],
+      SU2_MPI::Isend(&Buffer_Send_PrimVar[PointTotal_Counter*(nPrimVar+3)],
                      nPointTotal_s[iDomain]*(nPrimVar+3), MPI_DOUBLE, iDomain,
-                     iDomain,  MPI_COMM_WORLD);
-
-#endif
-
+                     iDomain,  MPI_COMM_WORLD, &req);
+      SU2_MPI::Request_free(&req);
     }
 
     else {
@@ -1407,11 +1363,7 @@ void CEulerSolver::Set_MPI_Nearfield(CGeometry *geometry, CConfig *config) {
 
   /*--- Wait for the non-blocking sends to complete. ---*/
 
-#ifdef HAVE_MPI
-
   SU2_MPI::Barrier(MPI_COMM_WORLD);
-
-#endif
 
   /*--- The next section begins the recv of all data for the interior
    points/elements in the mesh. First, create the domain structures for
@@ -1431,7 +1383,7 @@ void CEulerSolver::Set_MPI_Nearfield(CGeometry *geometry, CConfig *config) {
       /*--- Receive the buffers with the coords, global index, and colors ---*/
 
       SU2_MPI::Recv(Buffer_Receive_PrimVar, nPointTotal_r[iDomain]*(nPrimVar+3) , MPI_DOUBLE,
-                    iDomain, rank, MPI_COMM_WORLD, &status_);
+                    iDomain, rank, MPI_COMM_WORLD, &status);
 
       /*--- Loop over all of the points that we have recv'd and store the
        coords, global index vertex and markers ---*/
@@ -1469,11 +1421,7 @@ void CEulerSolver::Set_MPI_Nearfield(CGeometry *geometry, CConfig *config) {
 
   /*--- Wait for the non-blocking sends to complete. ---*/
 
-#ifdef HAVE_MPI
-
   SU2_MPI::Barrier(MPI_COMM_WORLD);
-
-#endif
 
   /*--- Free all of the memory used for communicating points and elements ---*/
 

--- a/UnitTests/test_driver.cpp
+++ b/UnitTests/test_driver.cpp
@@ -38,15 +38,12 @@ int main(int argc, char *argv[]) {
 
   /*--- Startup MPI, if supported ---*/
 #ifdef HAVE_MPI
-  int  buffsize;
-  char *buffptr;
 #ifdef HAVE_OMP
   int provided;
   SU2_MPI::Init_thread(&argc, &argv, MPI_THREAD_FUNNELED, &provided);
 #else
   SU2_MPI::Init(&argc, &argv);
 #endif
-  SU2_MPI::Buffer_attach( malloc(BUFSIZE), BUFSIZE );
   SU2_Comm MPICommunicator(MPI_COMM_WORLD);
 #else
   SU2_Comm MPICommunicator(0);
@@ -56,11 +53,7 @@ int main(int argc, char *argv[]) {
   int result = Catch::Session().run(argc, argv);
 
   /*--- Finalize MPI parallelization ---*/
-#ifdef HAVE_MPI
-  SU2_MPI::Buffer_detach(&buffptr, &buffsize);
-  free(buffptr);
   SU2_MPI::Finalize();
-#endif
 
   return result;
 }


### PR DESCRIPTION
## Proposed Changes
Use Isend instead of Bsend (to avoid having to attach / resize buffers).
Disclaimer: No idea if this is the right way, like a good programmer I got the solution from stackoverflow.

## Related Work
Should fix #1150

## PR Checklist
- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags, or simply --warnlevel=2 when using meson).
- [X] My contribution is commented and consistent with SU2 style.
- [X] I have added a test case that demonstrates my contribution, if necessary.
- [X] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
