### PR TITLE
Remove mapping of global<->local marker IDs

### DIFF
--- a/Common/include/geometry/CGeometry.hpp
+++ b/Common/include/geometry/CGeometry.hpp
@@ -1073,13 +1073,6 @@ public:
   inline virtual long GetGlobal_to_Local_Point(unsigned long val_ipoint) const { return 0; }
 
   /*!
-   * \brief A virtual member.
-   * \param[in] val_ipoint - Global marker.
-   * \return Local marker that correspond with the global index.
-   */
-  inline virtual unsigned short GetGlobal_to_Local_Marker(unsigned short val_imarker) const { return 0; }
-
-  /*!
    * \brief Retrieve total number of elements in a simulation across all processors.
    * \return Total number of elements in a simulation across all processors.
    */

--- a/Common/include/geometry/CPhysicalGeometry.hpp
+++ b/Common/include/geometry/CPhysicalGeometry.hpp
@@ -42,8 +42,6 @@ class CPhysicalGeometry final : public CGeometry {
   unordered_map<unsigned long, unsigned long>
   Global_to_Local_Point;                           /*!< \brief Global-local indexation for the points. */
   long *Local_to_Global_Point{nullptr};            /*!< \brief Local-global indexation for the points. */
-  unsigned short *Local_to_Global_Marker{nullptr}; /*!< \brief Local to Global marker. */
-  unsigned short *Global_to_Local_Marker{nullptr}; /*!< \brief Global to Local marker. */
   unsigned long *adj_counter{nullptr};             /*!< \brief Adjacency counter. */
   unsigned long **adjacent_elem{nullptr};          /*!< \brief Adjacency element list. */
   su2activematrix Sensitivity;                     /*!< \brief Matrix holding the sensitivities at each point. */
@@ -301,15 +299,6 @@ public:
     if (it != Global_to_Local_Point.cend())
       return it->second;
     return -1;
-  }
-
-  /*!
-   * \brief Get the local marker that correspond with the global marker.
-   * \param[in] val_ipoint - Global marker.
-   * \return Local marker that correspond with the global index.
-   */
-  inline unsigned short GetGlobal_to_Local_Marker(unsigned short val_imarker) const override {
-    return Global_to_Local_Marker[val_imarker];
   }
 
   /*!

--- a/Common/src/geometry/CPhysicalGeometry.cpp
+++ b/Common/src/geometry/CPhysicalGeometry.cpp
@@ -317,8 +317,6 @@ CPhysicalGeometry::CPhysicalGeometry(CGeometry *geometry,
 CPhysicalGeometry::~CPhysicalGeometry(void) {
 
   delete [] Local_to_Global_Point;
-  delete [] Global_to_Local_Marker;
-  delete [] Local_to_Global_Marker;
 
   /*--- Free up memory from turbomachinery performance computation  ---*/
 


### PR DESCRIPTION
## Proposed Changes
 Remove unused `CPhysicalGeometry::Local_to_Global_Marker`, `Global_to_Local_Marker`
 


## Related Work
#1110



## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [ X] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags, or simply --warnlevel=2 when using meson).
- [ X] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
