### PR TITLE
Restructure source residual computation to fix axisymmetric chemsitry/vib source computation

### DIFF
--- a/SU2_CFD/src/numerics/NEMO/NEMO_sources.cpp
+++ b/SU2_CFD/src/numerics/NEMO/NEMO_sources.cpp
@@ -372,12 +372,12 @@ CNumerics::ResidualType<> CSource_NEMO::ComputeAxisymmetric(const CConfig *confi
                                                                     -TWO3*AuxVar_Grad_i[0][0]);
     residual[nSpecies+1] -= Volume*(yinv*total_viscosity_i*2*(PrimVar_Grad_i[nSpecies+3][1]-v*yinv)
                                                                     -TWO3*AuxVar_Grad_i[0][1]);
-    residual[nSpecies+2] -= Volume*(yinv*(- sumJhs_y + total_viscosity_i*(u*(PrimVar_Grad_i[nSpecies+3][0]+PrimVar_Grad_i[nSpecies+2][1])
+    residual[nSpecies+2] -= Volume*(yinv*(sumJhs_y + total_viscosity_i*(u*(PrimVar_Grad_i[nSpecies+3][0]+PrimVar_Grad_i[nSpecies+2][1])
                                                      +v*TWO3*(2*PrimVar_Grad_i[nSpecies+2][1]-PrimVar_Grad_i[nSpecies+2][0]
                                                      -v*yinv+rho*turb_ke_i))
                                                      -total_conductivity_i*PrimVar_Grad_i[nSpecies][1])
                                                      -TWO3*(AuxVar_Grad_i[1][1]+AuxVar_Grad_i[2][1]));
-    residual[nSpecies+3] -= Volume*(yinv*(-sumJeve_y -qy_ve));
+    residual[nSpecies+3] -= Volume*(yinv*(sumJeve_y -qy_ve));
   }
 
 //  if (implicit) {


### PR DESCRIPTION
## Proposed Changes

- This PR addresses an issue I found in my previous implementation where the chemistry source residual was being computed incorrectly when the axisymmetric source residual was called. 
- This implementation fixes that issue, caused by using outer and inner loops. 
- This PR eliminates redundant set functions, and restructures the code blocks to minimize the number of loops. 


## Related Work

- Fixes bug found in PR #1162 


## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags, or simply --warnlevel=2 when using meson).
- [x] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
