### PR TITLE
Fix some screen output and frozen limiter logic

### DIFF
--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -7236,21 +7236,18 @@ unsigned short CConfig::GetMarker_ZoneInterface(string val_marker) const {
   return Marker_CfgFile_ZoneInterface[iMarker_CfgFile];
 }
 
-bool CConfig::GetSolid_Wall(unsigned short iMarker) const {
-
-  return (Marker_All_KindBC[iMarker] == HEAT_FLUX  ||
-          Marker_All_KindBC[iMarker] == ISOTHERMAL ||
-          Marker_All_KindBC[iMarker] == SMOLUCHOWSKI_MAXWELL ||
-          Marker_All_KindBC[iMarker] == CHT_WALL_INTERFACE ||
-          Marker_All_KindBC[iMarker] == EULER_WALL);
-}
-
 bool CConfig::GetViscous_Wall(unsigned short iMarker) const {
 
   return (Marker_All_KindBC[iMarker] == HEAT_FLUX  ||
           Marker_All_KindBC[iMarker] == ISOTHERMAL ||
           Marker_All_KindBC[iMarker] == SMOLUCHOWSKI_MAXWELL ||
           Marker_All_KindBC[iMarker] == CHT_WALL_INTERFACE);
+}
+
+bool CConfig::GetSolid_Wall(unsigned short iMarker) const {
+
+  return GetViscous_Wall(iMarker) ||
+         Marker_All_KindBC[iMarker] == EULER_WALL;
 }
 
 void CConfig::SetSurface_Movement(unsigned short iMarker, unsigned short kind_movement) {

--- a/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
+++ b/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
@@ -51,7 +51,7 @@ protected:
   su2double cw1;
   su2double cr1;
 
-  su2double gamma_BC;
+  su2double Gamma_BC = 0.0;
   su2double intermittency;
   su2double Production, Destruction, CrossProduction;
 
@@ -105,7 +105,7 @@ public:
    * \brief  Get the intermittency for the BC trans. model.
    * \return Value of the intermittency.
    */
-  inline su2double GetGammaBC(void) const final { return gamma_BC; }
+  inline su2double GetGammaBC(void) const final { return Gamma_BC; }
 
   /*!
    * \brief  ______________.

--- a/SU2_CFD/src/numerics/turbulent/turb_sources.cpp
+++ b/SU2_CFD/src/numerics/turbulent/turb_sources.cpp
@@ -94,8 +94,6 @@ CNumerics::ResidualType<> CSourcePieceWise_TurbSA::ComputeResidual(const CConfig
   CrossProduction = 0.0;
   Jacobian_i[0]   = 0.0;
 
-  gamma_BC = 0.0;
-
   /*--- Evaluate Omega ---*/
 
   Omega = sqrt(Vorticity_i[0]*Vorticity_i[0] + Vorticity_i[1]*Vorticity_i[1] + Vorticity_i[2]*Vorticity_i[2]);
@@ -153,9 +151,10 @@ CNumerics::ResidualType<> CSourcePieceWise_TurbSA::ComputeResidual(const CConfig
       su2double term1 = sqrt(max(re_theta-re_theta_t,0.)/(chi_1*re_theta_t));
       su2double term2 = sqrt(max((nu_t*chi_2)/nu,0.));
       su2double term_exponential = (term1 + term2);
-      su2double gamma_BC = 1.0 - exp(-term_exponential);
 
-      Production = gamma_BC*cb1*Shat*TurbVar_i[0]*Volume;
+      Gamma_BC = 1.0 - exp(-term_exponential);
+
+      Production = Gamma_BC*cb1*Shat*TurbVar_i[0]*Volume;
     }
     else {
       Production = cb1*Shat*TurbVar_i[0]*Volume;
@@ -192,7 +191,7 @@ CNumerics::ResidualType<> CSourcePieceWise_TurbSA::ComputeResidual(const CConfig
     else dShat = (fv2+TurbVar_i[0]*dfv2)*inv_k2_d2;
 
     if (transition) {
-      Jacobian_i[0] += gamma_BC*cb1*(TurbVar_i[0]*dShat+Shat)*Volume;
+      Jacobian_i[0] += Gamma_BC*cb1*(TurbVar_i[0]*dShat+Shat)*Volume;
     }
     else {
       Jacobian_i[0] += cb1*(TurbVar_i[0]*dShat+Shat)*Volume;

--- a/SU2_CFD/src/output/CFlowCompOutput.cpp
+++ b/SU2_CFD/src/output/CFlowCompOutput.cpp
@@ -370,29 +370,31 @@ void CFlowCompOutput::SetVolumeOutputFields(CConfig *config){
     break;
   }
 
-  // Limiter values
-  AddVolumeOutput("LIMITER_VELOCITY-X", "Limiter_Velocity_x", "LIMITER", "Limiter value of the x-velocity");
-  AddVolumeOutput("LIMITER_VELOCITY-Y", "Limiter_Velocity_y", "LIMITER", "Limiter value of the y-velocity");
-  if (nDim == 3) {
-    AddVolumeOutput("LIMITER_VELOCITY-Z", "Limiter_Velocity_z", "LIMITER", "Limiter value of the z-velocity");
-  }
-  AddVolumeOutput("LIMITER_PRESSURE", "Limiter_Pressure", "LIMITER", "Limiter value of the pressure");
-  AddVolumeOutput("LIMITER_DENSITY", "Limiter_Density", "LIMITER", "Limiter value of the density");
-  AddVolumeOutput("LIMITER_ENTHALPY", "Limiter_Enthalpy", "LIMITER", "Limiter value of the enthalpy");
-
-  switch(config->GetKind_Turb_Model()){
-  case SST: case SST_SUST:
-    AddVolumeOutput("LIMITER_TKE", "Limiter_TKE", "LIMITER", "Limiter value of turb. kinetic energy");
-    AddVolumeOutput("LIMITER_DISSIPATION", "Limiter_Omega", "LIMITER", "Limiter value of dissipation rate");
-    break;
-  case SA: case SA_COMP: case SA_E:
-  case SA_E_COMP: case SA_NEG:
-    AddVolumeOutput("LIMITER_NU_TILDE", "Limiter_Nu_Tilde", "LIMITER", "Limiter value of the Spalart-Allmaras variable");
-    break;
-  case NONE:
-    break;
+  if (config->GetKind_SlopeLimit_Flow() != NO_LIMITER && config->GetKind_SlopeLimit_Flow() != VAN_ALBADA_EDGE) {
+    AddVolumeOutput("LIMITER_VELOCITY-X", "Limiter_Velocity_x", "LIMITER", "Limiter value of the x-velocity");
+    AddVolumeOutput("LIMITER_VELOCITY-Y", "Limiter_Velocity_y", "LIMITER", "Limiter value of the y-velocity");
+    if (nDim == 3) {
+      AddVolumeOutput("LIMITER_VELOCITY-Z", "Limiter_Velocity_z", "LIMITER", "Limiter value of the z-velocity");
+    }
+    AddVolumeOutput("LIMITER_PRESSURE", "Limiter_Pressure", "LIMITER", "Limiter value of the pressure");
+    AddVolumeOutput("LIMITER_DENSITY", "Limiter_Density", "LIMITER", "Limiter value of the density");
+    AddVolumeOutput("LIMITER_ENTHALPY", "Limiter_Enthalpy", "LIMITER", "Limiter value of the enthalpy");
   }
 
+  if (config->GetKind_SlopeLimit_Turb() != NO_LIMITER) {
+    switch(config->GetKind_Turb_Model()){
+    case SST: case SST_SUST:
+      AddVolumeOutput("LIMITER_TKE", "Limiter_TKE", "LIMITER", "Limiter value of turb. kinetic energy");
+      AddVolumeOutput("LIMITER_DISSIPATION", "Limiter_Omega", "LIMITER", "Limiter value of dissipation rate");
+      break;
+    case SA: case SA_COMP: case SA_E:
+    case SA_E_COMP: case SA_NEG:
+      AddVolumeOutput("LIMITER_NU_TILDE", "Limiter_Nu_Tilde", "LIMITER", "Limiter value of the Spalart-Allmaras variable");
+      break;
+    case NONE:
+      break;
+    }
+  }
 
   // Hybrid RANS-LES
   if (config->GetKind_HybridRANSLES() != NO_HYBRIDRANSLES){
@@ -522,26 +524,30 @@ void CFlowCompOutput::LoadVolumeData(CConfig *config, CGeometry *geometry, CSolv
     break;
   }
 
-  SetVolumeOutputValue("LIMITER_VELOCITY-X", iPoint, Node_Flow->GetLimiter_Primitive(iPoint, 1));
-  SetVolumeOutputValue("LIMITER_VELOCITY-Y", iPoint, Node_Flow->GetLimiter_Primitive(iPoint, 2));
-  if (nDim == 3){
-    SetVolumeOutputValue("LIMITER_VELOCITY-Z", iPoint, Node_Flow->GetLimiter_Primitive(iPoint, 3));
+  if (config->GetKind_SlopeLimit_Flow() != NO_LIMITER && config->GetKind_SlopeLimit_Flow() != VAN_ALBADA_EDGE) {
+    SetVolumeOutputValue("LIMITER_VELOCITY-X", iPoint, Node_Flow->GetLimiter_Primitive(iPoint, 1));
+    SetVolumeOutputValue("LIMITER_VELOCITY-Y", iPoint, Node_Flow->GetLimiter_Primitive(iPoint, 2));
+    if (nDim == 3){
+      SetVolumeOutputValue("LIMITER_VELOCITY-Z", iPoint, Node_Flow->GetLimiter_Primitive(iPoint, 3));
+    }
+    SetVolumeOutputValue("LIMITER_PRESSURE", iPoint, Node_Flow->GetLimiter_Primitive(iPoint, nDim+1));
+    SetVolumeOutputValue("LIMITER_DENSITY", iPoint, Node_Flow->GetLimiter_Primitive(iPoint, nDim+2));
+    SetVolumeOutputValue("LIMITER_ENTHALPY", iPoint, Node_Flow->GetLimiter_Primitive(iPoint, nDim+3));
   }
-  SetVolumeOutputValue("LIMITER_PRESSURE", iPoint, Node_Flow->GetLimiter_Primitive(iPoint, nDim+1));
-  SetVolumeOutputValue("LIMITER_DENSITY", iPoint, Node_Flow->GetLimiter_Primitive(iPoint, nDim+2));
-  SetVolumeOutputValue("LIMITER_ENTHALPY", iPoint, Node_Flow->GetLimiter_Primitive(iPoint, nDim+3));
 
-  switch(config->GetKind_Turb_Model()){
-  case SST: case SST_SUST:
-    SetVolumeOutputValue("LIMITER_TKE",         iPoint, Node_Turb->GetLimiter_Primitive(iPoint, 0));
-    SetVolumeOutputValue("LIMITER_DISSIPATION", iPoint, Node_Turb->GetLimiter_Primitive(iPoint, 1));
-    break;
-  case SA: case SA_COMP: case SA_E:
-  case SA_E_COMP: case SA_NEG:
-    SetVolumeOutputValue("LIMITER_NU_TILDE", iPoint, Node_Turb->GetLimiter_Primitive(iPoint, 0));
-    break;
-  case NONE:
-    break;
+  if (config->GetKind_SlopeLimit_Turb() != NO_LIMITER) {
+    switch(config->GetKind_Turb_Model()){
+    case SST: case SST_SUST:
+      SetVolumeOutputValue("LIMITER_TKE",         iPoint, Node_Turb->GetLimiter(iPoint, 0));
+      SetVolumeOutputValue("LIMITER_DISSIPATION", iPoint, Node_Turb->GetLimiter(iPoint, 1));
+      break;
+    case SA: case SA_COMP: case SA_E:
+    case SA_E_COMP: case SA_NEG:
+      SetVolumeOutputValue("LIMITER_NU_TILDE", iPoint, Node_Turb->GetLimiter(iPoint, 0));
+      break;
+    case NONE:
+      break;
+    }
   }
 
   if (config->GetKind_HybridRANSLES() != NO_HYBRIDRANSLES){

--- a/SU2_CFD/src/output/CFlowIncOutput.cpp
+++ b/SU2_CFD/src/output/CFlowIncOutput.cpp
@@ -436,25 +436,28 @@ void CFlowIncOutput::SetVolumeOutputFields(CConfig *config){
     break;
   }
 
-  // Limiter values
-  AddVolumeOutput("LIMITER_PRESSURE", "Limiter_Pressure", "LIMITER", "Limiter value of the pressure");
-  AddVolumeOutput("LIMITER_VELOCITY-X", "Limiter_Velocity_x", "LIMITER", "Limiter value of the x-velocity");
-  AddVolumeOutput("LIMITER_VELOCITY-Y", "Limiter_Velocity_y", "LIMITER", "Limiter value of the y-velocity");
-  if (nDim == 3)
-    AddVolumeOutput("LIMITER_VELOCITY-Z", "Limiter_Velocity_z", "LIMITER", "Limiter value of the z-velocity");
-  AddVolumeOutput("LIMITER_TEMPERATURE", "Limiter_Temperature", "LIMITER", "Limiter value of the temperature");
+  if (config->GetKind_SlopeLimit_Flow() != NO_LIMITER && config->GetKind_SlopeLimit_Flow() != VAN_ALBADA_EDGE) {
+    AddVolumeOutput("LIMITER_PRESSURE", "Limiter_Pressure", "LIMITER", "Limiter value of the pressure");
+    AddVolumeOutput("LIMITER_VELOCITY-X", "Limiter_Velocity_x", "LIMITER", "Limiter value of the x-velocity");
+    AddVolumeOutput("LIMITER_VELOCITY-Y", "Limiter_Velocity_y", "LIMITER", "Limiter value of the y-velocity");
+    if (nDim == 3)
+      AddVolumeOutput("LIMITER_VELOCITY-Z", "Limiter_Velocity_z", "LIMITER", "Limiter value of the z-velocity");
+    AddVolumeOutput("LIMITER_TEMPERATURE", "Limiter_Temperature", "LIMITER", "Limiter value of the temperature");
+  }
 
-  switch(config->GetKind_Turb_Model()){
-  case SST: case SST_SUST:
-    AddVolumeOutput("LIMITER_TKE", "Limiter_TKE", "LIMITER", "Limiter value of turb. kinetic energy.");
-    AddVolumeOutput("LIMITER_DISSIPATION", "Limiter_Omega", "LIMITER", "Limiter value of dissipation rate.");
-    break;
-  case SA: case SA_COMP: case SA_E:
-  case SA_E_COMP: case SA_NEG:
-    AddVolumeOutput("LIMITER_NU_TILDE", "Limiter_Nu_Tilde", "LIMITER", "Limiter value of Spalart–Allmaras variable.");
-    break;
-  case NONE:
-    break;
+  if (config->GetKind_SlopeLimit_Turb() != NO_LIMITER) {
+    switch(config->GetKind_Turb_Model()){
+    case SST: case SST_SUST:
+      AddVolumeOutput("LIMITER_TKE", "Limiter_TKE", "LIMITER", "Limiter value of turb. kinetic energy.");
+      AddVolumeOutput("LIMITER_DISSIPATION", "Limiter_Omega", "LIMITER", "Limiter value of dissipation rate.");
+      break;
+    case SA: case SA_COMP: case SA_E:
+    case SA_E_COMP: case SA_NEG:
+      AddVolumeOutput("LIMITER_NU_TILDE", "Limiter_Nu_Tilde", "LIMITER", "Limiter value of Spalart–Allmaras variable.");
+      break;
+    case NONE:
+      break;
+    }
   }
 
   // Hybrid RANS-LES
@@ -587,27 +590,31 @@ void CFlowIncOutput::LoadVolumeData(CConfig *config, CGeometry *geometry, CSolve
     break;
   }
 
-  SetVolumeOutputValue("LIMITER_PRESSURE", iPoint, Node_Flow->GetLimiter_Primitive(iPoint, 0));
-  SetVolumeOutputValue("LIMITER_VELOCITY-X", iPoint, Node_Flow->GetLimiter_Primitive(iPoint, 1));
-  SetVolumeOutputValue("LIMITER_VELOCITY-Y", iPoint, Node_Flow->GetLimiter_Primitive(iPoint, 2));
-  if (nDim == 3){
-    SetVolumeOutputValue("LIMITER_VELOCITY-Z", iPoint, Node_Flow->GetLimiter_Primitive(iPoint, 3));
-    SetVolumeOutputValue("LIMITER_TEMPERATURE", iPoint, Node_Flow->GetLimiter_Primitive(iPoint, 4));
-  } else {
-    SetVolumeOutputValue("LIMITER_TEMPERATURE", iPoint, Node_Flow->GetLimiter_Primitive(iPoint, 3));
+  if (config->GetKind_SlopeLimit_Flow() != NO_LIMITER && config->GetKind_SlopeLimit_Flow() != VAN_ALBADA_EDGE) {
+    SetVolumeOutputValue("LIMITER_PRESSURE", iPoint, Node_Flow->GetLimiter_Primitive(iPoint, 0));
+    SetVolumeOutputValue("LIMITER_VELOCITY-X", iPoint, Node_Flow->GetLimiter_Primitive(iPoint, 1));
+    SetVolumeOutputValue("LIMITER_VELOCITY-Y", iPoint, Node_Flow->GetLimiter_Primitive(iPoint, 2));
+    if (nDim == 3){
+      SetVolumeOutputValue("LIMITER_VELOCITY-Z", iPoint, Node_Flow->GetLimiter_Primitive(iPoint, 3));
+      SetVolumeOutputValue("LIMITER_TEMPERATURE", iPoint, Node_Flow->GetLimiter_Primitive(iPoint, 4));
+    } else {
+      SetVolumeOutputValue("LIMITER_TEMPERATURE", iPoint, Node_Flow->GetLimiter_Primitive(iPoint, 3));
+    }
   }
 
-  switch(config->GetKind_Turb_Model()){
-  case SST: case SST_SUST:
-    SetVolumeOutputValue("LIMITER_TKE", iPoint, Node_Turb->GetLimiter_Primitive(iPoint, 0));
-    SetVolumeOutputValue("LIMITER_DISSIPATION", iPoint, Node_Turb->GetLimiter_Primitive(iPoint, 1));
-    break;
-  case SA: case SA_COMP: case SA_E:
-  case SA_E_COMP: case SA_NEG:
-    SetVolumeOutputValue("LIMITER_NU_TILDE", iPoint, Node_Turb->GetLimiter_Primitive(iPoint, 0));
-    break;
-  case NONE:
-    break;
+  if (config->GetKind_SlopeLimit_Turb() != NO_LIMITER) {
+    switch(config->GetKind_Turb_Model()){
+    case SST: case SST_SUST:
+      SetVolumeOutputValue("LIMITER_TKE", iPoint, Node_Turb->GetLimiter(iPoint, 0));
+      SetVolumeOutputValue("LIMITER_DISSIPATION", iPoint, Node_Turb->GetLimiter(iPoint, 1));
+      break;
+    case SA: case SA_COMP: case SA_E:
+    case SA_E_COMP: case SA_NEG:
+      SetVolumeOutputValue("LIMITER_NU_TILDE", iPoint, Node_Turb->GetLimiter(iPoint, 0));
+      break;
+    case NONE:
+      break;
+    }
   }
 
   if (config->GetKind_HybridRANSLES() != NO_HYBRIDRANSLES){

--- a/SU2_CFD/src/output/CFlowOutput.cpp
+++ b/SU2_CFD/src/output/CFlowOutput.cpp
@@ -380,41 +380,23 @@ void CFlowOutput::SetAnalyzeSurface(CSolver *solver, CGeometry *geometry, CConfi
 
   }
 
-#ifdef HAVE_MPI
+  auto Allreduce = [nMarker_Analyze](const su2double* src, su2double* dst) {
+    SU2_MPI::Allreduce(src, dst, nMarker_Analyze, MPI_DOUBLE, MPI_SUM, SU2_MPI::GetComm());
+  };
 
-  SU2_MPI::Allreduce(Surface_MassFlow_Local, Surface_MassFlow_Total, nMarker_Analyze, MPI_DOUBLE, MPI_SUM, SU2_MPI::GetComm());
-  SU2_MPI::Allreduce(Surface_Mach_Local, Surface_Mach_Total, nMarker_Analyze, MPI_DOUBLE, MPI_SUM, SU2_MPI::GetComm());
-  SU2_MPI::Allreduce(Surface_Temperature_Local, Surface_Temperature_Total, nMarker_Analyze, MPI_DOUBLE, MPI_SUM, SU2_MPI::GetComm());
-  SU2_MPI::Allreduce(Surface_Density_Local, Surface_Density_Total, nMarker_Analyze, MPI_DOUBLE, MPI_SUM, SU2_MPI::GetComm());
-  SU2_MPI::Allreduce(Surface_Enthalpy_Local, Surface_Enthalpy_Total, nMarker_Analyze, MPI_DOUBLE, MPI_SUM, SU2_MPI::GetComm());
-  SU2_MPI::Allreduce(Surface_NormalVelocity_Local, Surface_NormalVelocity_Total, nMarker_Analyze, MPI_DOUBLE, MPI_SUM, SU2_MPI::GetComm());
-  SU2_MPI::Allreduce(Surface_StreamVelocity2_Local, Surface_StreamVelocity2_Total, nMarker_Analyze, MPI_DOUBLE, MPI_SUM, SU2_MPI::GetComm());
-  SU2_MPI::Allreduce(Surface_TransvVelocity2_Local, Surface_TransvVelocity2_Total, nMarker_Analyze, MPI_DOUBLE, MPI_SUM, SU2_MPI::GetComm());
-  SU2_MPI::Allreduce(Surface_Pressure_Local, Surface_Pressure_Total, nMarker_Analyze, MPI_DOUBLE, MPI_SUM, SU2_MPI::GetComm());
-  SU2_MPI::Allreduce(Surface_TotalTemperature_Local, Surface_TotalTemperature_Total, nMarker_Analyze, MPI_DOUBLE, MPI_SUM, SU2_MPI::GetComm());
-  SU2_MPI::Allreduce(Surface_TotalPressure_Local, Surface_TotalPressure_Total, nMarker_Analyze, MPI_DOUBLE, MPI_SUM, SU2_MPI::GetComm());
-  SU2_MPI::Allreduce(Surface_Area_Local, Surface_Area_Total, nMarker_Analyze, MPI_DOUBLE, MPI_SUM, SU2_MPI::GetComm());
-  SU2_MPI::Allreduce(Surface_MassFlow_Abs_Local, Surface_MassFlow_Abs_Total, nMarker_Analyze, MPI_DOUBLE, MPI_SUM, SU2_MPI::GetComm());
-
-#else
-
-  for (iMarker_Analyze = 0; iMarker_Analyze < nMarker_Analyze; iMarker_Analyze++) {
-    Surface_MassFlow_Total[iMarker_Analyze]          = Surface_MassFlow_Local[iMarker_Analyze];
-    Surface_Mach_Total[iMarker_Analyze]              = Surface_Mach_Local[iMarker_Analyze];
-    Surface_Temperature_Total[iMarker_Analyze]       = Surface_Temperature_Local[iMarker_Analyze];
-    Surface_Density_Total[iMarker_Analyze]           = Surface_Density_Local[iMarker_Analyze];
-    Surface_Enthalpy_Total[iMarker_Analyze]          = Surface_Enthalpy_Local[iMarker_Analyze];
-    Surface_NormalVelocity_Total[iMarker_Analyze]    = Surface_NormalVelocity_Local[iMarker_Analyze];
-    Surface_StreamVelocity2_Total[iMarker_Analyze]   = Surface_StreamVelocity2_Local[iMarker_Analyze];
-    Surface_TransvVelocity2_Total[iMarker_Analyze]   = Surface_TransvVelocity2_Local[iMarker_Analyze];
-    Surface_Pressure_Total[iMarker_Analyze]          = Surface_Pressure_Local[iMarker_Analyze];
-    Surface_TotalTemperature_Total[iMarker_Analyze]  = Surface_TotalTemperature_Local[iMarker_Analyze];
-    Surface_TotalPressure_Total[iMarker_Analyze]     = Surface_TotalPressure_Local[iMarker_Analyze];
-    Surface_Area_Total[iMarker_Analyze]              = Surface_Area_Local[iMarker_Analyze];
-    Surface_MassFlow_Abs_Total[iMarker_Analyze]      = Surface_MassFlow_Abs_Local[iMarker_Analyze];
-  }
-
-#endif
+  Allreduce(Surface_MassFlow_Local, Surface_MassFlow_Total);
+  Allreduce(Surface_Mach_Local, Surface_Mach_Total);
+  Allreduce(Surface_Temperature_Local, Surface_Temperature_Total);
+  Allreduce(Surface_Density_Local, Surface_Density_Total);
+  Allreduce(Surface_Enthalpy_Local, Surface_Enthalpy_Total);
+  Allreduce(Surface_NormalVelocity_Local, Surface_NormalVelocity_Total);
+  Allreduce(Surface_StreamVelocity2_Local, Surface_StreamVelocity2_Total);
+  Allreduce(Surface_TransvVelocity2_Local, Surface_TransvVelocity2_Total);
+  Allreduce(Surface_Pressure_Local, Surface_Pressure_Total);
+  Allreduce(Surface_TotalTemperature_Local, Surface_TotalTemperature_Total);
+  Allreduce(Surface_TotalPressure_Local, Surface_TotalPressure_Total);
+  Allreduce(Surface_Area_Local, Surface_Area_Total);
+  Allreduce(Surface_MassFlow_Abs_Local, Surface_MassFlow_Abs_Total);
 
   /*--- Compute the value of Surface_Area_Total, and Surface_Pressure_Total, and
    set the value in the config structure for future use ---*/
@@ -918,11 +900,8 @@ void CFlowOutput::Set_CpInverseDesign(CSolver *solver, CGeometry *geometry, CCon
       }
     }
 
-#ifdef HAVE_MPI
     su2double MyPressDiff = PressDiff;
     SU2_MPI::Allreduce(&MyPressDiff, &PressDiff, 1, MPI_DOUBLE, MPI_SUM, SU2_MPI::GetComm());
-#endif
-
   }
 
   /*--- Update the total Cp difference coeffient ---*/

--- a/SU2_CFD/src/output/CFlowOutput.cpp
+++ b/SU2_CFD/src/output/CFlowOutput.cpp
@@ -114,38 +114,36 @@ void CFlowOutput::SetAnalyzeSurface(CSolver *solver, CGeometry *geometry, CConfi
   unsigned short iDim, iMarker, iMarker_Analyze;
   unsigned long iVertex, iPoint;
   su2double Mach = 0.0, Pressure, Temperature = 0.0, TotalPressure = 0.0, TotalTemperature = 0.0,
-  Enthalpy, Velocity[3] = {}, TangVel[3], Velocity2, MassFlow, Density, Area,
+  Enthalpy, Velocity[3] = {0.0}, TangVel[3], Vector[3], Velocity2, MassFlow, Density, Area,
   AxiFactor = 1.0, SoundSpeed, Vn, Vn2, Vtang2, Weight = 1.0;
 
-  su2double Gas_Constant      = config->GetGas_ConstantND();
-  su2double Gamma             = config->GetGamma();
-  unsigned short nMarker      = config->GetnMarker_All();
-  unsigned short nDim         = geometry->GetnDim();
-  unsigned short Kind_Average = config->GetKind_Average();
+  const su2double Gas_Constant      = config->GetGas_ConstantND();
+  const su2double Gamma             = config->GetGamma();
+  const unsigned short nMarker      = config->GetnMarker_All();
+  const unsigned short nDim         = geometry->GetnDim();
+  const unsigned short Kind_Average = config->GetKind_Average();
 
-  bool compressible   = config->GetKind_Regime() == COMPRESSIBLE;
-  bool incompressible = config->GetKind_Regime() == INCOMPRESSIBLE;
-  bool energy         = config->GetEnergy_Equation();
+  const bool compressible   = config->GetKind_Regime() == COMPRESSIBLE;
+  const bool incompressible = config->GetKind_Regime() == INCOMPRESSIBLE;
+  const bool energy         = config->GetEnergy_Equation();
 
+  const bool axisymmetric               = config->GetAxisymmetric();
+  const unsigned short nMarker_Analyze  = config->GetnMarker_Analyze();
 
-  bool axisymmetric               = config->GetAxisymmetric();
-  unsigned short nMarker_Analyze  = config->GetnMarker_Analyze();
-
-  su2double  *Vector                    = new su2double[nDim];
-  su2double  *Surface_MassFlow          = new su2double[nMarker];
-  su2double  *Surface_Mach              = new su2double[nMarker];
-  su2double  *Surface_Temperature       = new su2double[nMarker];
-  su2double  *Surface_Density           = new su2double[nMarker];
-  su2double  *Surface_Enthalpy          = new su2double[nMarker];
-  su2double  *Surface_NormalVelocity    = new su2double[nMarker];
-  su2double  *Surface_StreamVelocity2   = new su2double[nMarker];
-  su2double  *Surface_TransvVelocity2   = new su2double[nMarker];
-  su2double  *Surface_Pressure          = new su2double[nMarker];
-  su2double  *Surface_TotalTemperature  = new su2double[nMarker];
-  su2double  *Surface_TotalPressure     = new su2double[nMarker];
-  su2double  *Surface_VelocityIdeal     = new su2double[nMarker];
-  su2double  *Surface_Area              = new su2double[nMarker];
-  su2double  *Surface_MassFlow_Abs      = new su2double[nMarker];
+  vector<su2double> Surface_MassFlow          (nMarker,0.0);
+  vector<su2double> Surface_Mach              (nMarker,0.0);
+  vector<su2double> Surface_Temperature       (nMarker,0.0);
+  vector<su2double> Surface_Density           (nMarker,0.0);
+  vector<su2double> Surface_Enthalpy          (nMarker,0.0);
+  vector<su2double> Surface_NormalVelocity    (nMarker,0.0);
+  vector<su2double> Surface_StreamVelocity2   (nMarker,0.0);
+  vector<su2double> Surface_TransvVelocity2   (nMarker,0.0);
+  vector<su2double> Surface_Pressure          (nMarker,0.0);
+  vector<su2double> Surface_TotalTemperature  (nMarker,0.0);
+  vector<su2double> Surface_TotalPressure     (nMarker,0.0);
+  vector<su2double> Surface_VelocityIdeal     (nMarker,0.0);
+  vector<su2double> Surface_Area              (nMarker,0.0);
+  vector<su2double> Surface_MassFlow_Abs      (nMarker,0.0);
 
   su2double  Tot_Surface_MassFlow          = 0.0;
   su2double  Tot_Surface_Mach              = 0.0;
@@ -165,21 +163,6 @@ void CFlowOutput::SetAnalyzeSurface(CSolver *solver, CGeometry *geometry, CConfi
   /*--- Compute the numerical fan face Mach number, and the total area of the inflow ---*/
 
   for (iMarker = 0; iMarker < nMarker; iMarker++) {
-
-    Surface_MassFlow[iMarker]          = 0.0;
-    Surface_Mach[iMarker]              = 0.0;
-    Surface_Temperature[iMarker]       = 0.0;
-    Surface_Density[iMarker]           = 0.0;
-    Surface_Enthalpy[iMarker]          = 0.0;
-    Surface_NormalVelocity[iMarker]    = 0.0;
-    Surface_StreamVelocity2[iMarker]   = 0.0;
-    Surface_TransvVelocity2[iMarker]   = 0.0;
-    Surface_Pressure[iMarker]          = 0.0;
-    Surface_TotalTemperature[iMarker]  = 0.0;
-    Surface_TotalPressure[iMarker]     = 0.0;
-    Surface_VelocityIdeal[iMarker]     = 0.0;
-    Surface_Area[iMarker]              = 0.0;
-    Surface_MassFlow_Abs[iMarker]      = 0.0;
 
     if (config->GetMarker_All_Analyze(iMarker) == YES) {
 
@@ -285,68 +268,35 @@ void CFlowOutput::SetAnalyzeSurface(CSolver *solver, CGeometry *geometry, CConfi
 
   /*--- Copy to the appropriate structure ---*/
 
-  su2double *Surface_MassFlow_Local          = new su2double [nMarker_Analyze];
-  su2double *Surface_Mach_Local              = new su2double [nMarker_Analyze];
-  su2double *Surface_Temperature_Local       = new su2double [nMarker_Analyze];
-  su2double *Surface_Density_Local           = new su2double [nMarker_Analyze];
-  su2double *Surface_Enthalpy_Local          = new su2double [nMarker_Analyze];
-  su2double *Surface_NormalVelocity_Local    = new su2double [nMarker_Analyze];
-  su2double *Surface_StreamVelocity2_Local   = new su2double [nMarker_Analyze];
-  su2double *Surface_TransvVelocity2_Local   = new su2double [nMarker_Analyze];
-  su2double *Surface_Pressure_Local          = new su2double [nMarker_Analyze];
-  su2double *Surface_TotalTemperature_Local  = new su2double [nMarker_Analyze];
-  su2double *Surface_TotalPressure_Local     = new su2double [nMarker_Analyze];
-  su2double *Surface_Area_Local              = new su2double [nMarker_Analyze];
-  su2double *Surface_MassFlow_Abs_Local      = new su2double [nMarker_Analyze];
+  vector<su2double> Surface_MassFlow_Local          (nMarker_Analyze,0.0);
+  vector<su2double> Surface_Mach_Local              (nMarker_Analyze,0.0);
+  vector<su2double> Surface_Temperature_Local       (nMarker_Analyze,0.0);
+  vector<su2double> Surface_Density_Local           (nMarker_Analyze,0.0);
+  vector<su2double> Surface_Enthalpy_Local          (nMarker_Analyze,0.0);
+  vector<su2double> Surface_NormalVelocity_Local    (nMarker_Analyze,0.0);
+  vector<su2double> Surface_StreamVelocity2_Local   (nMarker_Analyze,0.0);
+  vector<su2double> Surface_TransvVelocity2_Local   (nMarker_Analyze,0.0);
+  vector<su2double> Surface_Pressure_Local          (nMarker_Analyze,0.0);
+  vector<su2double> Surface_TotalTemperature_Local  (nMarker_Analyze,0.0);
+  vector<su2double> Surface_TotalPressure_Local     (nMarker_Analyze,0.0);
+  vector<su2double> Surface_Area_Local              (nMarker_Analyze,0.0);
+  vector<su2double> Surface_MassFlow_Abs_Local      (nMarker_Analyze,0.0);
 
-  su2double *Surface_MassFlow_Total          = new su2double [nMarker_Analyze];
-  su2double *Surface_Mach_Total              = new su2double [nMarker_Analyze];
-  su2double *Surface_Temperature_Total       = new su2double [nMarker_Analyze];
-  su2double *Surface_Density_Total           = new su2double [nMarker_Analyze];
-  su2double *Surface_Enthalpy_Total          = new su2double [nMarker_Analyze];
-  su2double *Surface_NormalVelocity_Total    = new su2double [nMarker_Analyze];
-  su2double *Surface_StreamVelocity2_Total   = new su2double [nMarker_Analyze];
-  su2double *Surface_TransvVelocity2_Total   = new su2double [nMarker_Analyze];
-  su2double *Surface_Pressure_Total          = new su2double [nMarker_Analyze];
-  su2double *Surface_TotalTemperature_Total  = new su2double [nMarker_Analyze];
-  su2double *Surface_TotalPressure_Total     = new su2double [nMarker_Analyze];
-  su2double *Surface_Area_Total              = new su2double [nMarker_Analyze];
-  su2double *Surface_MassFlow_Abs_Total      = new su2double [nMarker_Analyze];
+  vector<su2double> Surface_MassFlow_Total          (nMarker_Analyze,0.0);
+  vector<su2double> Surface_Mach_Total              (nMarker_Analyze,0.0);
+  vector<su2double> Surface_Temperature_Total       (nMarker_Analyze,0.0);
+  vector<su2double> Surface_Density_Total           (nMarker_Analyze,0.0);
+  vector<su2double> Surface_Enthalpy_Total          (nMarker_Analyze,0.0);
+  vector<su2double> Surface_NormalVelocity_Total    (nMarker_Analyze,0.0);
+  vector<su2double> Surface_StreamVelocity2_Total   (nMarker_Analyze,0.0);
+  vector<su2double> Surface_TransvVelocity2_Total   (nMarker_Analyze,0.0);
+  vector<su2double> Surface_Pressure_Total          (nMarker_Analyze,0.0);
+  vector<su2double> Surface_TotalTemperature_Total  (nMarker_Analyze,0.0);
+  vector<su2double> Surface_TotalPressure_Total     (nMarker_Analyze,0.0);
+  vector<su2double> Surface_Area_Total              (nMarker_Analyze,0.0);
+  vector<su2double> Surface_MassFlow_Abs_Total      (nMarker_Analyze,0.0);
 
-  su2double *Surface_MomentumDistortion_Total = new su2double [nMarker_Analyze];
-
-  for (iMarker_Analyze = 0; iMarker_Analyze < nMarker_Analyze; iMarker_Analyze++) {
-    Surface_MassFlow_Local[iMarker_Analyze]          = 0.0;
-    Surface_Mach_Local[iMarker_Analyze]              = 0.0;
-    Surface_Temperature_Local[iMarker_Analyze]       = 0.0;
-    Surface_Density_Local[iMarker_Analyze]           = 0.0;
-    Surface_Enthalpy_Local[iMarker_Analyze]          = 0.0;
-    Surface_NormalVelocity_Local[iMarker_Analyze]    = 0.0;
-    Surface_StreamVelocity2_Local[iMarker_Analyze]   = 0.0;
-    Surface_TransvVelocity2_Local[iMarker_Analyze]   = 0.0;
-    Surface_Pressure_Local[iMarker_Analyze]          = 0.0;
-    Surface_TotalTemperature_Local[iMarker_Analyze]  = 0.0;
-    Surface_TotalPressure_Local[iMarker_Analyze]     = 0.0;
-    Surface_Area_Local[iMarker_Analyze]              = 0.0;
-    Surface_MassFlow_Abs_Local[iMarker_Analyze]      = 0.0;
-
-    Surface_MassFlow_Total[iMarker_Analyze]          = 0.0;
-    Surface_Mach_Total[iMarker_Analyze]              = 0.0;
-    Surface_Temperature_Total[iMarker_Analyze]       = 0.0;
-    Surface_Density_Total[iMarker_Analyze]           = 0.0;
-    Surface_Enthalpy_Total[iMarker_Analyze]          = 0.0;
-    Surface_NormalVelocity_Total[iMarker_Analyze]    = 0.0;
-    Surface_StreamVelocity2_Total[iMarker_Analyze]   = 0.0;
-    Surface_TransvVelocity2_Total[iMarker_Analyze]   = 0.0;
-    Surface_Pressure_Total[iMarker_Analyze]          = 0.0;
-    Surface_TotalTemperature_Total[iMarker_Analyze]  = 0.0;
-    Surface_TotalPressure_Total[iMarker_Analyze]     = 0.0;
-    Surface_Area_Total[iMarker_Analyze]              = 0.0;
-    Surface_MassFlow_Abs_Total[iMarker_Analyze]      = 0.0;
-
-    Surface_MomentumDistortion_Total[iMarker_Analyze] = 0.0;
-
-  }
+  vector<su2double> Surface_MomentumDistortion_Total (nMarker_Analyze,0.0);
 
   /*--- Compute the numerical fan face Mach number, mach number, temperature and the total area ---*/
 
@@ -380,8 +330,8 @@ void CFlowOutput::SetAnalyzeSurface(CSolver *solver, CGeometry *geometry, CConfi
 
   }
 
-  auto Allreduce = [nMarker_Analyze](const su2double* src, su2double* dst) {
-    SU2_MPI::Allreduce(src, dst, nMarker_Analyze, MPI_DOUBLE, MPI_SUM, SU2_MPI::GetComm());
+  auto Allreduce = [](const vector<su2double>& src, vector<su2double>& dst) {
+    SU2_MPI::Allreduce(src.data(), dst.data(), src.size(), MPI_DOUBLE, MPI_SUM, SU2_MPI::GetComm());
   };
 
   Allreduce(Surface_MassFlow_Local, Surface_MassFlow_Total);
@@ -630,51 +580,6 @@ void CFlowOutput::SetAnalyzeSurface(CSolver *solver, CGeometry *geometry, CConfi
     cout.unsetf(ios_base::floatfield);
 
   }
-
-  delete [] Surface_MassFlow_Local;
-  delete [] Surface_Mach_Local;
-  delete [] Surface_Temperature_Local;
-  delete [] Surface_Density_Local;
-  delete [] Surface_Enthalpy_Local;
-  delete [] Surface_NormalVelocity_Local;
-  delete [] Surface_StreamVelocity2_Local;
-  delete [] Surface_TransvVelocity2_Local;
-  delete [] Surface_Pressure_Local;
-  delete [] Surface_TotalTemperature_Local;
-  delete [] Surface_TotalPressure_Local;
-  delete [] Surface_Area_Local;
-  delete [] Surface_MassFlow_Abs_Local;
-
-  delete [] Surface_MassFlow_Total;
-  delete [] Surface_Mach_Total;
-  delete [] Surface_Temperature_Total;
-  delete [] Surface_Density_Total;
-  delete [] Surface_Enthalpy_Total;
-  delete [] Surface_NormalVelocity_Total;
-  delete [] Surface_StreamVelocity2_Total;
-  delete [] Surface_TransvVelocity2_Total;
-  delete [] Surface_Pressure_Total;
-  delete [] Surface_TotalTemperature_Total;
-  delete [] Surface_TotalPressure_Total;
-  delete [] Surface_Area_Total;
-  delete [] Surface_MassFlow_Abs_Total;
-  delete [] Surface_MomentumDistortion_Total;
-
-  delete [] Surface_MassFlow;
-  delete [] Surface_Mach;
-  delete [] Surface_Temperature;
-  delete [] Surface_Density;
-  delete [] Surface_Enthalpy;
-  delete [] Surface_NormalVelocity;
-  delete [] Surface_StreamVelocity2;
-  delete [] Surface_TransvVelocity2;
-  delete [] Surface_Pressure;
-  delete [] Surface_TotalTemperature;
-  delete [] Surface_TotalPressure;
-  delete [] Surface_Area;
-  delete [] Vector;
-  delete [] Surface_VelocityIdeal;
-  delete [] Surface_MassFlow_Abs;
 
   std::cout << std::resetiosflags(std::cout.flags());
 }

--- a/SU2_CFD/src/output/CNEMOCompOutput.cpp
+++ b/SU2_CFD/src/output/CNEMOCompOutput.cpp
@@ -391,17 +391,19 @@ void CNEMOCompOutput::SetVolumeOutputFields(CConfig *config){
     AddVolumeOutput("LIMITER_MOMENTUM-Z", "Limiter_Momentum_z", "LIMITER", "Limiter value of the z-momentum");
   AddVolumeOutput("LIMITER_ENERGY", "Limiter_Energy", "LIMITER", "Limiter value of the energy");
 
-  switch(config->GetKind_Turb_Model()){
-  case SST: case SST_SUST:
-    AddVolumeOutput("LIMITER_TKE", "Limiter_TKE", "LIMITER", "Limiter value of turb. kinetic energy");
-    AddVolumeOutput("LIMITER_DISSIPATION", "Limiter_Omega", "LIMITER", "Limiter value of dissipation rate");
-    break;
-  case SA: case SA_COMP: case SA_E:
-  case SA_E_COMP: case SA_NEG:
-    AddVolumeOutput("LIMITER_NU_TILDE", "Limiter_Nu_Tilde", "LIMITER", "Limiter value of the Spalart-Allmaras variable");
-    break;
-  case NONE:
-    break;
+  if (config->GetKind_SlopeLimit_Flow() != NO_LIMITER) {
+    switch(config->GetKind_Turb_Model()){
+    case SST: case SST_SUST:
+      AddVolumeOutput("LIMITER_TKE", "Limiter_TKE", "LIMITER", "Limiter value of turb. kinetic energy");
+      AddVolumeOutput("LIMITER_DISSIPATION", "Limiter_Omega", "LIMITER", "Limiter value of dissipation rate");
+      break;
+    case SA: case SA_COMP: case SA_E:
+    case SA_E_COMP: case SA_NEG:
+      AddVolumeOutput("LIMITER_NU_TILDE", "Limiter_Nu_Tilde", "LIMITER", "Limiter value of the Spalart-Allmaras variable");
+      break;
+    case NONE:
+      break;
+    }
   }
 
   // Roe Low Dissipation
@@ -535,17 +537,19 @@ void CNEMOCompOutput::LoadVolumeData(CConfig *config, CGeometry *geometry, CSolv
     SetVolumeOutputValue("LIMITER_ENERGY", iPoint, Node_Flow->GetLimiter_Primitive(iPoint, 3));
   }
 
-  switch(config->GetKind_Turb_Model()){
-  case SST: case SST_SUST:
-    SetVolumeOutputValue("LIMITER_TKE",         iPoint, Node_Turb->GetLimiter_Primitive(iPoint, 0));
-    SetVolumeOutputValue("LIMITER_DISSIPATION", iPoint, Node_Turb->GetLimiter_Primitive(iPoint, 1));
-    break;
-  case SA: case SA_COMP: case SA_E:
-  case SA_E_COMP: case SA_NEG:
-    SetVolumeOutputValue("LIMITER_NU_TILDE", iPoint, Node_Turb->GetLimiter_Primitive(iPoint, 0));
-    break;
-  case NONE:
-    break;
+  if (config->GetKind_SlopeLimit_Flow() != NO_LIMITER) {
+    switch(config->GetKind_Turb_Model()){
+    case SST: case SST_SUST:
+      SetVolumeOutputValue("LIMITER_TKE",         iPoint, Node_Turb->GetLimiter(iPoint, 0));
+      SetVolumeOutputValue("LIMITER_DISSIPATION", iPoint, Node_Turb->GetLimiter(iPoint, 1));
+      break;
+    case SA: case SA_COMP: case SA_E:
+    case SA_E_COMP: case SA_NEG:
+      SetVolumeOutputValue("LIMITER_NU_TILDE", iPoint, Node_Turb->GetLimiter(iPoint, 0));
+      break;
+    case NONE:
+      break;
+    }
   }
 
   if (config->GetKind_RoeLowDiss() != NO_ROELOWDISS){

--- a/SU2_CFD/src/solvers/CEulerSolver.cpp
+++ b/SU2_CFD/src/solvers/CEulerSolver.cpp
@@ -2330,7 +2330,6 @@ void CEulerSolver::Upwind_Residual(CGeometry *geometry, CSolver **solver_contain
     return;
   }
 
-  const auto InnerIter        = config->GetInnerIter();
   const bool implicit         = (config->GetKind_TimeIntScheme() == EULER_IMPLICIT);
   const bool ideal_gas        = (config->GetKind_FluidModel() == STANDARD_AIR) ||
                                 (config->GetKind_FluidModel() == IDEAL_GAS);
@@ -2340,8 +2339,7 @@ void CEulerSolver::Upwind_Residual(CGeometry *geometry, CSolver **solver_contain
   const auto kind_dissipation = config->GetKind_RoeLowDiss();
 
   const bool muscl            = (config->GetMUSCL_Flow() && (iMesh == MESH_0));
-  const bool limiter          = (config->GetKind_SlopeLimit_Flow() != NO_LIMITER) &&
-                                (InnerIter <= config->GetLimiterIter());
+  const bool limiter          = (config->GetKind_SlopeLimit_Flow() != NO_LIMITER);
   const bool van_albada       = (config->GetKind_SlopeLimit_Flow() == VAN_ALBADA_EDGE);
 
   /*--- Non-physical counter. ---*/
@@ -2414,13 +2412,6 @@ void CEulerSolver::Upwind_Residual(CGeometry *geometry, CSolver **solver_contain
       auto Gradient_i = nodes->GetGradient_Reconstruction(iPoint);
       auto Gradient_j = nodes->GetGradient_Reconstruction(jPoint);
 
-      su2double *Limiter_i = nullptr, *Limiter_j = nullptr;
-
-      if (limiter) {
-        Limiter_i = nodes->GetLimiter_Primitive(iPoint);
-        Limiter_j = nodes->GetLimiter_Primitive(jPoint);
-      }
-
       for (iVar = 0; iVar < nPrimVarGrad; iVar++) {
 
         su2double Project_Grad_i = 0.0;
@@ -2431,19 +2422,21 @@ void CEulerSolver::Upwind_Residual(CGeometry *geometry, CSolver **solver_contain
           Project_Grad_j -= Vector_ij[iDim]*Gradient_j[iVar][iDim];
         }
 
-        if (limiter) {
-          if (van_albada) {
-            su2double V_ij = V_j[iVar] - V_i[iVar];
-            Limiter_i[iVar] = V_ij*( 2.0*Project_Grad_i + V_ij) / (4*pow(Project_Grad_i, 2) + pow(V_ij, 2) + EPS);
-            Limiter_j[iVar] = V_ij*(-2.0*Project_Grad_j + V_ij) / (4*pow(Project_Grad_j, 2) + pow(V_ij, 2) + EPS);
-          }
-          Primitive_i[iVar] = V_i[iVar] + Limiter_i[iVar]*Project_Grad_i;
-          Primitive_j[iVar] = V_j[iVar] + Limiter_j[iVar]*Project_Grad_j;
+        su2double lim_i = 1.0;
+        su2double lim_j = 1.0;
+
+        if (van_albada) {
+          su2double V_ij = V_j[iVar] - V_i[iVar];
+          lim_i = V_ij*( 2.0*Project_Grad_i + V_ij) / (4*pow(Project_Grad_i, 2) + pow(V_ij, 2) + EPS);
+          lim_j = V_ij*(-2.0*Project_Grad_j + V_ij) / (4*pow(Project_Grad_j, 2) + pow(V_ij, 2) + EPS);
         }
-        else {
-          Primitive_i[iVar] = V_i[iVar] + Project_Grad_i;
-          Primitive_j[iVar] = V_j[iVar] + Project_Grad_j;
+        else if (limiter) {
+          lim_i = nodes->GetLimiter_Primitive(iPoint, iVar);
+          lim_j = nodes->GetLimiter_Primitive(jPoint, iVar);
         }
+
+        Primitive_i[iVar] = V_i[iVar] + lim_i * Project_Grad_i;
+        Primitive_j[iVar] = V_j[iVar] + lim_j * Project_Grad_j;
 
       }
 

--- a/SU2_CFD/src/solvers/CEulerSolver.cpp
+++ b/SU2_CFD/src/solvers/CEulerSolver.cpp
@@ -2253,7 +2253,7 @@ unsigned long CEulerSolver::SetPrimitive_Variables(CSolver **solver_container, c
   SU2_OMP_FOR_STAT(omp_chunk_size)
   for (unsigned long iPoint = 0; iPoint < nPoint; iPoint ++) {
 
-    /*--- Compressible flow, primitive variables nDim+5, (T, vx, vy, vz, P, rho, h, c, lamMu, eddyMu, ThCond, Cp) ---*/
+    /*--- Compressible flow, primitive variables nDim+9, (T, vx, vy, vz, P, rho, h, c, lamMu, eddyMu, ThCond, Cp) ---*/
 
     bool physical = nodes->SetPrimVar(iPoint, GetFluidModel());
     nodes->SetSecondaryVar(iPoint, GetFluidModel());

--- a/SU2_CFD/src/solvers/CIncEulerSolver.cpp
+++ b/SU2_CFD/src/solvers/CIncEulerSolver.cpp
@@ -1075,11 +1075,10 @@ void CIncEulerSolver::Upwind_Residual(CGeometry *geometry, CSolver **solver_cont
   SU2_OMP_MASTER
   ErrorCounter = 0;
 
-  const unsigned long InnerIter = config->GetInnerIter();
   const bool implicit   = (config->GetKind_TimeIntScheme() == EULER_IMPLICIT);
   const bool muscl      = (config->GetMUSCL_Flow() && (iMesh == MESH_0));
-  const bool limiter    = (config->GetKind_SlopeLimit_Flow() != NO_LIMITER) && (InnerIter <= config->GetLimiterIter());
-  const bool van_albada = config->GetKind_SlopeLimit_Flow() == VAN_ALBADA_EDGE;
+  const bool limiter    = (config->GetKind_SlopeLimit_Flow() != NO_LIMITER);
+  const bool van_albada = (config->GetKind_SlopeLimit_Flow() == VAN_ALBADA_EDGE);
 
   /*--- Loop over edge colors. ---*/
   for (auto color : EdgeColoring)
@@ -1120,31 +1119,31 @@ void CIncEulerSolver::Upwind_Residual(CGeometry *geometry, CSolver **solver_cont
       auto Gradient_i = nodes->GetGradient_Reconstruction(iPoint);
       auto Gradient_j = nodes->GetGradient_Reconstruction(jPoint);
 
-      su2double *Limiter_i = nullptr, *Limiter_j = nullptr;
-
-      if (limiter) {
-        Limiter_i = nodes->GetLimiter_Primitive(iPoint);
-        Limiter_j = nodes->GetLimiter_Primitive(jPoint);
-      }
-
       for (iVar = 0; iVar < nPrimVarGrad; iVar++) {
-        su2double Project_Grad_i = 0.0, Project_Grad_j = 0.0;
+
+        su2double Project_Grad_i = 0.0;
+        su2double Project_Grad_j = 0.0;
+
         for (iDim = 0; iDim < nDim; iDim++) {
           Project_Grad_i += Vector_ij[iDim]*Gradient_i[iVar][iDim];
           Project_Grad_j -= Vector_ij[iDim]*Gradient_j[iVar][iDim];
         }
-        if (limiter) {
-          if (van_albada){
-            Limiter_i[iVar] = (V_j[iVar]-V_i[iVar])*(2.0*Project_Grad_i + V_j[iVar]-V_i[iVar])/(4*Project_Grad_i*Project_Grad_i+(V_j[iVar]-V_i[iVar])*(V_j[iVar]-V_i[iVar])+EPS);
-            Limiter_j[iVar] = (V_j[iVar]-V_i[iVar])*(-2.0*Project_Grad_j + V_j[iVar]-V_i[iVar])/(4*Project_Grad_j*Project_Grad_j+(V_j[iVar]-V_i[iVar])*(V_j[iVar]-V_i[iVar])+EPS);
-          }
-          Primitive_i[iVar] = V_i[iVar] + Limiter_i[iVar]*Project_Grad_i;
-          Primitive_j[iVar] = V_j[iVar] + Limiter_j[iVar]*Project_Grad_j;
+
+        su2double lim_i = 1.0;
+        su2double lim_j = 1.0;
+
+        if (van_albada) {
+          su2double V_ij = V_j[iVar] - V_i[iVar];
+          lim_i = V_ij*( 2.0*Project_Grad_i + V_ij) / (4*pow(Project_Grad_i, 2) + pow(V_ij, 2) + EPS);
+          lim_j = V_ij*(-2.0*Project_Grad_j + V_ij) / (4*pow(Project_Grad_j, 2) + pow(V_ij, 2) + EPS);
         }
-        else {
-          Primitive_i[iVar] = V_i[iVar] + Project_Grad_i;
-          Primitive_j[iVar] = V_j[iVar] + Project_Grad_j;
+        else if (limiter) {
+          lim_i = nodes->GetLimiter_Primitive(iPoint, iVar);
+          lim_j = nodes->GetLimiter_Primitive(jPoint, iVar);
         }
+
+        Primitive_i[iVar] = V_i[iVar] + lim_i * Project_Grad_i;
+        Primitive_j[iVar] = V_j[iVar] + lim_j * Project_Grad_j;
       }
 
       for (iVar = nPrimVarGrad; iVar < nPrimVar; iVar++) {
@@ -1169,8 +1168,7 @@ void CIncEulerSolver::Upwind_Residual(CGeometry *geometry, CSolver **solver_cont
         nodes->SetNon_Physical(iPoint, neg_density_i || neg_temperature_i);
         nodes->SetNon_Physical(jPoint, neg_density_j || neg_temperature_j);
 
-        /* Lastly, check for existing first-order points still active
-         from previous iterations. */
+        /* Lastly, check for existing first-order points still active from previous iterations. */
 
         if (nodes->GetNon_Physical(iPoint)) {
           counter_local++;

--- a/SU2_CFD/src/solvers/CNEMOEulerSolver.cpp
+++ b/SU2_CFD/src/solvers/CNEMOEulerSolver.cpp
@@ -326,17 +326,17 @@ void CNEMOEulerSolver::Preprocessing(CGeometry *geometry, CSolver **solver_conta
                                      unsigned short iRKStep,
                                      unsigned short RunTime_EqSystem, bool Output) {
 
-  unsigned long InnerIter = config->GetInnerIter();
-  bool muscl              = config->GetMUSCL_Flow();
-  bool limiter            = ((config->GetKind_SlopeLimit_Flow() != NO_LIMITER) && (InnerIter <= config->GetLimiterIter()) && !(config->GetFrozen_Limiter_Disc()));
-  bool center             = config->GetKind_ConvNumScheme_Flow() == SPACE_CENTERED;
-  bool van_albada         = config->GetKind_SlopeLimit_Flow() == VAN_ALBADA_EDGE;
+  const unsigned long InnerIter = config->GetInnerIter();
+  const bool muscl       = config->GetMUSCL_Flow() && (iMesh == MESH_0);
+  const bool limiter     = (config->GetKind_SlopeLimit_Flow() != NO_LIMITER) && (InnerIter <= config->GetLimiterIter());
+  const bool center      = config->GetKind_ConvNumScheme_Flow() == SPACE_CENTERED;
+  const bool van_albada  = config->GetKind_SlopeLimit_Flow() == VAN_ALBADA_EDGE;
 
   /*--- Common preprocessing steps ---*/
   CommonPreprocessing(geometry, solver_container, config, iMesh, iRKStep, RunTime_EqSystem, Output);
 
   /*--- Upwind second order reconstruction ---*/
-  if ((muscl && !center) && (iMesh == MESH_0) && !Output) {
+  if (muscl && !center && !Output) {
 
     /*--- Calculate the gradients ---*/
     if (config->GetKind_Gradient_Method() == GREEN_GAUSS) {
@@ -347,7 +347,7 @@ void CNEMOEulerSolver::Preprocessing(CGeometry *geometry, CSolver **solver_conta
     }
 
     /*--- Limiter computation ---*/
-    if ((limiter) && (iMesh == MESH_0) && !Output && !van_albada) {
+    if (limiter && !van_albada) {
       SetPrimitive_Limiter(geometry, config);
     }
   }
@@ -516,11 +516,9 @@ void CNEMOEulerSolver::Upwind_Residual(CGeometry *geometry, CSolver **solver_con
                                        CConfig *config, unsigned short iMesh) {
 
   /*--- Set booleans based on config settings ---*/
-  const auto InnerIter        = config->GetInnerIter();
   //const bool implicit         = (config->GetKind_TimeIntScheme() == EULER_IMPLICIT);
   const bool muscl            = (config->GetMUSCL_Flow() && (iMesh == MESH_0));
-  const bool limiter          = (config->GetKind_SlopeLimit_Flow() != NO_LIMITER) &&
-                                (InnerIter <= config->GetLimiterIter());
+  const bool limiter          = (config->GetKind_SlopeLimit_Flow() != NO_LIMITER);
   const bool van_albada       = (config->GetKind_SlopeLimit_Flow() == VAN_ALBADA_EDGE);
 
   /*--- Non-physical counter. ---*/

--- a/SU2_CFD/src/solvers/CNEMONSSolver.cpp
+++ b/SU2_CFD/src/solvers/CNEMONSSolver.cpp
@@ -67,14 +67,11 @@ CNEMONSSolver::~CNEMONSSolver(void) {
 void CNEMONSSolver::Preprocessing(CGeometry *geometry, CSolver **solver_container, CConfig *config, unsigned short iMesh,
                               unsigned short iRKStep, unsigned short RunTime_EqSystem, bool Output) {
 
-  unsigned long InnerIter = config->GetInnerIter();
-  bool cont_adjoint       = config->GetContinuous_Adjoint();
-  bool limiter_flow       = (config->GetKind_SlopeLimit_Flow() != NO_LIMITER) && (InnerIter <= config->GetLimiterIter());
-  bool limiter_turb       = (config->GetKind_SlopeLimit_Turb() != NO_LIMITER) && (InnerIter <= config->GetLimiterIter());
-  bool limiter_adjflow    = (cont_adjoint && (config->GetKind_SlopeLimit_AdjFlow() != NO_LIMITER) && (InnerIter <= config->GetLimiterIter()));
-  bool van_albada         = config->GetKind_SlopeLimit_Flow() == VAN_ALBADA_EDGE;
-  bool muscl              = config->GetMUSCL_Flow();
-  bool center             = config->GetKind_ConvNumScheme_Flow() == SPACE_CENTERED;
+  const unsigned long InnerIter = config->GetInnerIter();
+  const bool limiter    = (config->GetKind_SlopeLimit_Flow() != NO_LIMITER) && (InnerIter <= config->GetLimiterIter());
+  const bool van_albada = config->GetKind_SlopeLimit_Flow() == VAN_ALBADA_EDGE;
+  const bool muscl      = config->GetMUSCL_Flow() && (iMesh == MESH_0);
+  const bool center     = config->GetKind_ConvNumScheme_Flow() == SPACE_CENTERED;
 
   /*--- Common preprocessing steps (implemented by CNEMOEulerSolver) ---*/
 
@@ -82,7 +79,7 @@ void CNEMONSSolver::Preprocessing(CGeometry *geometry, CSolver **solver_containe
 
   /*--- Compute gradient for MUSCL reconstruction. ---*/
 
-  if ((muscl && !center) && (iMesh == MESH_0)) {
+  if (config->GetReconstructionGradientRequired() && muscl && !center) {
     switch (config->GetKind_Gradient_Method_Recon()) {
       case GREEN_GAUSS:
         SetPrimitive_Gradient_GG(geometry, config, true); break;
@@ -102,10 +99,9 @@ void CNEMONSSolver::Preprocessing(CGeometry *geometry, CSolver **solver_containe
     SetPrimitive_Gradient_LS(geometry, config);
   }
 
-  /*--- Compute the limiter in case we need it in the turbulence model or to limit the
-   *    viscous terms (check this logic with JST and 2nd order turbulence model) ---*/
+  /*--- Compute the limiters ---*/
 
-  if ((iMesh == MESH_0) && (limiter_flow || limiter_turb || limiter_adjflow) && !Output && !van_albada) {
+  if (muscl && !center && limiter && !van_albada && !Output) {
     SetPrimitive_Limiter(geometry, config);
   }
 

--- a/SU2_CFD/src/solvers/CTurbSASolver.cpp
+++ b/SU2_CFD/src/solvers/CTurbSASolver.cpp
@@ -257,7 +257,7 @@ void CTurbSASolver::Preprocessing(CGeometry *geometry, CSolver **solver_containe
 
   /*--- Upwind second order reconstruction and gradients ---*/
 
-  if (config->GetReconstructionGradientRequired() && muscl) {
+  if (config->GetReconstructionGradientRequired()) {
     if (config->GetKind_Gradient_Method_Recon() == GREEN_GAUSS)
       SetSolution_Gradient_GG(geometry, config, true);
     if (config->GetKind_Gradient_Method_Recon() == LEAST_SQUARES)

--- a/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
+++ b/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
@@ -255,7 +255,7 @@ void CTurbSSTSolver::Preprocessing(CGeometry *geometry, CSolver **solver_contain
 
   /*--- Upwind second order reconstruction and gradients ---*/
 
-  if (config->GetReconstructionGradientRequired() && muscl) {
+  if (config->GetReconstructionGradientRequired()) {
     if (config->GetKind_Gradient_Method_Recon() == GREEN_GAUSS)
       SetSolution_Gradient_GG(geometry, config, true);
     if (config->GetKind_Gradient_Method_Recon() == LEAST_SQUARES)

--- a/SU2_CFD/src/variables/CEulerVariable.cpp
+++ b/SU2_CFD/src/variables/CEulerVariable.cpp
@@ -66,8 +66,7 @@ CEulerVariable::CEulerVariable(su2double density, const su2double *velocity, su2
 
   /*--- Allocate the slope limiter (MUSCL upwind) ---*/
 
-  if (config->GetMUSCL_Flow() &&
-      config->GetKind_SlopeLimit_Flow() != NO_LIMITER &&
+  if (config->GetKind_SlopeLimit_Flow() != NO_LIMITER &&
       config->GetKind_SlopeLimit_Flow() != VAN_ALBADA_EDGE) {
     Limiter_Primitive.resize(nPoint,nPrimVarGrad) = su2double(0.0);
     Solution_Max.resize(nPoint,nPrimVarGrad) = su2double(0.0);
@@ -119,7 +118,8 @@ CEulerVariable::CEulerVariable(su2double density, const su2double *velocity, su2
     Gradient_Primitive.resize(nPoint,nPrimVarGrad,nDim,0.0);
   }
 
-  if (config->GetMUSCL_Flow() && config->GetReconstructionGradientRequired()) {
+  if (config->GetReconstructionGradientRequired() &&
+      config->GetKind_ConvNumScheme_Flow() != SPACE_CENTERED) {
     Gradient_Aux.resize(nPoint,nPrimVarGrad,nDim,0.0);
   }
 

--- a/SU2_CFD/src/variables/CEulerVariable.cpp
+++ b/SU2_CFD/src/variables/CEulerVariable.cpp
@@ -32,11 +32,11 @@ CEulerVariable::CEulerVariable(su2double density, const su2double *velocity, su2
                                unsigned long ndim, unsigned long nvar, CConfig *config) : CVariable(npoint, ndim, nvar, config),
                                Gradient_Reconstruction(config->GetReconstructionGradientRequired() ? Gradient_Aux : Gradient_Primitive) {
 
-  bool dual_time = (config->GetTime_Marching() == DT_STEPPING_1ST) ||
-                   (config->GetTime_Marching() == DT_STEPPING_2ND);
-  bool viscous   = config->GetViscous();
-  bool windgust  = config->GetWind_Gust();
-  bool classical_rk4 = (config->GetKind_TimeIntScheme_Flow() == CLASSICAL_RK4_EXPLICIT);
+  const bool dual_time = (config->GetTime_Marching() == DT_STEPPING_1ST) ||
+                         (config->GetTime_Marching() == DT_STEPPING_2ND);
+  const bool viscous   = config->GetViscous();
+  const bool windgust  = config->GetWind_Gust();
+  const bool classical_rk4 = (config->GetKind_TimeIntScheme_Flow() == CLASSICAL_RK4_EXPLICIT);
 
   /*--- Allocate and initialize the primitive variables and gradients ---*/
 
@@ -59,19 +59,20 @@ CEulerVariable::CEulerVariable(su2double density, const su2double *velocity, su2
     }
   }
 
-  /*--- Allocate undivided laplacian (centered) and limiter (upwind)---*/
+  /*--- Allocate undivided laplacian (centered) ---*/
 
   if (config->GetKind_ConvNumScheme_Flow() == SPACE_CENTERED)
     Undivided_Laplacian.resize(nPoint,nVar);
 
-  /*--- Always allocate the slope limiter,
-   and the auxiliar variables (check the logic - JST with 2nd order Turb model - ) ---*/
+  /*--- Allocate the slope limiter (MUSCL upwind) ---*/
 
-  Limiter_Primitive.resize(nPoint,nPrimVarGrad) = su2double(0.0);
-  Limiter.resize(nPoint,nVar) = su2double(0.0);
-
-  Solution_Max.resize(nPoint,nPrimVarGrad) = su2double(0.0);
-  Solution_Min.resize(nPoint,nPrimVarGrad) = su2double(0.0);
+  if (config->GetMUSCL_Flow() &&
+      config->GetKind_SlopeLimit_Flow() != NO_LIMITER &&
+      config->GetKind_SlopeLimit_Flow() != VAN_ALBADA_EDGE) {
+    Limiter_Primitive.resize(nPoint,nPrimVarGrad) = su2double(0.0);
+    Solution_Max.resize(nPoint,nPrimVarGrad) = su2double(0.0);
+    Solution_Min.resize(nPoint,nPrimVarGrad) = su2double(0.0);
+  }
 
   /*--- Solution initialization ---*/
 
@@ -107,17 +108,18 @@ CEulerVariable::CEulerVariable(su2double density, const su2double *velocity, su2
     WindGustDer.resize(nPoint,nDim+1);
   }
 
-  /*--- Compressible flow, primitive variables nDim+5, (T, vx, vy, vz, P, rho, h, c) ---*/
+  /*--- Compressible flow, primitive variables (T, vx, vy, vz, P, rho, h, c, mu, mut, k, Cp) ---*/
 
   Primitive.resize(nPoint,nPrimVar) = su2double(0.0);
   Secondary.resize(nPoint,nSecondaryVar) = su2double(0.0);
 
-  /*--- Compressible flow, gradients primitive variables nDim+4, (T, vx, vy, vz, P, rho, h)
-        We need P, and rho for running the adjoint problem ---*/
+  /*--- Compressible flow, gradients primitive variables (T, vx, vy, vz, P, rho, h) ---*/
 
-  Gradient_Primitive.resize(nPoint,nPrimVarGrad,nDim,0.0);
+  if (config->GetMUSCL_Flow() || viscous) {
+    Gradient_Primitive.resize(nPoint,nPrimVarGrad,nDim,0.0);
+  }
 
-  if (config->GetReconstructionGradientRequired()) {
+  if (config->GetMUSCL_Flow() && config->GetReconstructionGradientRequired()) {
     Gradient_Aux.resize(nPoint,nPrimVarGrad,nDim,0.0);
   }
 

--- a/SU2_CFD/src/variables/CIncEulerVariable.cpp
+++ b/SU2_CFD/src/variables/CIncEulerVariable.cpp
@@ -61,8 +61,7 @@ CIncEulerVariable::CIncEulerVariable(su2double pressure, const su2double *veloci
 
   /*--- Allocate the slope limiter (MUSCL upwind) ---*/
 
-  if (config->GetMUSCL_Flow() &&
-      config->GetKind_SlopeLimit_Flow() != NO_LIMITER &&
+  if (config->GetKind_SlopeLimit_Flow() != NO_LIMITER &&
       config->GetKind_SlopeLimit_Flow() != VAN_ALBADA_EDGE) {
     Limiter_Primitive.resize(nPoint,nPrimVarGrad) = su2double(0.0);
     Solution_Max.resize(nPoint,nPrimVarGrad) = su2double(0.0);
@@ -97,7 +96,8 @@ CIncEulerVariable::CIncEulerVariable(su2double pressure, const su2double *veloci
     Gradient_Primitive.resize(nPoint,nPrimVarGrad,nDim,0.0);
   }
 
-  if (config->GetMUSCL_Flow() && config->GetReconstructionGradientRequired()) {
+  if (config->GetReconstructionGradientRequired() &&
+      config->GetKind_ConvNumScheme_Flow() != SPACE_CENTERED) {
     Gradient_Aux.resize(nPoint,nPrimVarGrad,nDim,0.0);
   }
 

--- a/SU2_CFD/src/variables/CIncEulerVariable.cpp
+++ b/SU2_CFD/src/variables/CIncEulerVariable.cpp
@@ -32,8 +32,9 @@ CIncEulerVariable::CIncEulerVariable(su2double pressure, const su2double *veloci
                                      unsigned long ndim, unsigned long nvar, CConfig *config) : CVariable(npoint, ndim, nvar, config),
                                      Gradient_Reconstruction(config->GetReconstructionGradientRequired() ? Gradient_Aux : Gradient_Primitive) {
 
-  bool dual_time    = (config->GetTime_Marching() == DT_STEPPING_1ST) ||
-                      (config->GetTime_Marching() == DT_STEPPING_2ND);
+  const bool dual_time = (config->GetTime_Marching() == DT_STEPPING_1ST) ||
+                         (config->GetTime_Marching() == DT_STEPPING_2ND);
+  const bool viscous   = config->GetViscous();
 
   /*--- Allocate and initialize the primitive variables and gradients ---*/
 
@@ -53,20 +54,20 @@ CIncEulerVariable::CIncEulerVariable(su2double pressure, const su2double *veloci
     }
   }
 
-  /*--- Allocate undivided laplacian (centered) and limiter (upwind)---*/
+  /*--- Allocate undivided laplacian (centered) ---*/
 
   if (config->GetKind_ConvNumScheme_Flow() == SPACE_CENTERED)
     Undivided_Laplacian.resize(nPoint,nVar);
 
-  /*--- Always allocate the slope limiter,
-   and the auxiliar variables (check the logic - JST with 2nd order Turb model - ) ---*/
+  /*--- Allocate the slope limiter (MUSCL upwind) ---*/
 
-  Limiter_Primitive.resize(nPoint,nPrimVarGrad) = su2double(0.0);
-
-  Limiter.resize(nPoint,nVar) = su2double(0.0);
-
-  Solution_Max.resize(nPoint,nPrimVarGrad) = su2double(0.0);
-  Solution_Min.resize(nPoint,nPrimVarGrad) = su2double(0.0);
+  if (config->GetMUSCL_Flow() &&
+      config->GetKind_SlopeLimit_Flow() != NO_LIMITER &&
+      config->GetKind_SlopeLimit_Flow() != VAN_ALBADA_EDGE) {
+    Limiter_Primitive.resize(nPoint,nPrimVarGrad) = su2double(0.0);
+    Solution_Max.resize(nPoint,nPrimVarGrad) = su2double(0.0);
+    Solution_Min.resize(nPoint,nPrimVarGrad) = su2double(0.0);
+  }
 
   /*--- Solution initialization ---*/
 
@@ -90,12 +91,13 @@ CIncEulerVariable::CIncEulerVariable(su2double pressure, const su2double *veloci
 
   Primitive.resize(nPoint,nPrimVar) = su2double(0.0);
 
-  /*--- Incompressible flow, gradients primitive variables nDim+4, (P, vx, vy, vz, T, rho, beta),
-        We need P, and rho for running the adjoint problem ---*/
+  /*--- Incompressible flow, gradients primitive variables nDim+4, (P, vx, vy, vz, T, rho, beta) ---*/
 
-  Gradient_Primitive.resize(nPoint,nPrimVarGrad,nDim,0.0);
+  if (config->GetMUSCL_Flow() || viscous) {
+    Gradient_Primitive.resize(nPoint,nPrimVarGrad,nDim,0.0);
+  }
 
-  if (config->GetReconstructionGradientRequired()) {
+  if (config->GetMUSCL_Flow() && config->GetReconstructionGradientRequired()) {
     Gradient_Aux.resize(nPoint,nPrimVarGrad,nDim,0.0);
   }
 

--- a/TestCases/parallel_regression.py
+++ b/TestCases/parallel_regression.py
@@ -559,7 +559,7 @@ def main():
     schubauer_klebanoff_transition.cfg_dir      = "transition/Schubauer_Klebanoff"
     schubauer_klebanoff_transition.cfg_file     = "transitional_BC_model_ConfigFile.cfg"
     schubauer_klebanoff_transition.test_iter    = 10
-    schubauer_klebanoff_transition.test_vals    = [-7.994740, -14.268326, 0.000046, 0.007987]
+    schubauer_klebanoff_transition.test_vals    = [-7.994740, -14.268433, 0.000046, 0.007987]
     schubauer_klebanoff_transition.su2_exec     = "parallel_computation.py -f"
     schubauer_klebanoff_transition.timeout      = 1600
     schubauer_klebanoff_transition.tol          = 0.00001

--- a/TestCases/serial_regression.py
+++ b/TestCases/serial_regression.py
@@ -643,7 +643,7 @@ def main():
     schubauer_klebanoff_transition.cfg_file     = "transitional_BC_model_ConfigFile.cfg"
     schubauer_klebanoff_transition.test_iter    = 10
     schubauer_klebanoff_transition.new_output   = True
-    schubauer_klebanoff_transition.test_vals    = [-8.029786, -14.268310, 0.000053, 0.007986] #last 4 columns
+    schubauer_klebanoff_transition.test_vals    = [-8.029786, -14.268417, 0.000053, 0.007986] #last 4 columns
     schubauer_klebanoff_transition.su2_exec     = "SU2_CFD"
     schubauer_klebanoff_transition.timeout      = 1600
     schubauer_klebanoff_transition.tol          = 0.00001


### PR DESCRIPTION
## Proposed Changes
Fix #1190
Prevent possible OpenMP bug for van Albada limiter.
Fix frozen limiter logic, freezing means "do not compute", and not "do not apply".
Fix limiter outputs for turbulence variables.

## PR Checklist
- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags, or simply --warnlevel=2 when using meson).
- [X] My contribution is commented and consistent with SU2 style.
- [X] I have added a test case that demonstrates my contribution, if necessary.
- [X] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
