### PR TITLE
Fix Multigrid for Incompressible NS with moving walls, and for NEMO NS in general

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,7 +79,11 @@ TestData
 # Ignore output files if tests are run locally
 *.vtk
 *.vtu
+*.vtm
+*.pvsm
 *.ref
+*.plt
+*.szplt
 
 Mercurial
 .hg*

--- a/SU2_CFD/include/variables/CAdjEulerVariable.hpp
+++ b/SU2_CFD/include/variables/CAdjEulerVariable.hpp
@@ -103,11 +103,29 @@ public:
   }
 
   /*!
+   * \brief Set the velocity vector from the old solution.
+   * \param[in] val_velocity - Pointer to the velocity.
+   */
+  inline void SetVelocity_Old(unsigned long iPoint, const su2double *val_velocity) final {
+    for (unsigned long iDim = 0; iDim < nDim; iDim++)
+      Solution_Old(iPoint,iDim+1) = val_velocity[iDim]*Solution(iPoint,0);
+  }
+
+  /*!
    * \brief Set the momentum part of the truncation error to zero.
    * \param[in] iPoint - Point index.
    */
   inline void SetVel_ResTruncError_Zero(unsigned long iPoint) final {
     for (unsigned long iDim = 0; iDim < nDim; iDim++) Res_TruncError(iPoint,iDim+1) = 0.0;
+  }
+
+  /*!
+   * \brief Specify a vector to set the velocity components of the solution. Multiplied by density for compressible cases.
+   * \param[in] iPoint - Point index.
+   * \param[in] val_vector - Pointer to the vector.
+   */
+  inline void SetVelSolutionVector(unsigned long iPoint, const su2double *val_vector) final {
+    for (unsigned long iDim = 0; iDim < nDim; iDim++) Solution(iPoint, iDim+1) = GetDensity(iPoint) * val_vector[iDim];
   }
 
   /*!

--- a/SU2_CFD/include/variables/CAdjEulerVariable.hpp
+++ b/SU2_CFD/include/variables/CAdjEulerVariable.hpp
@@ -103,6 +103,14 @@ public:
   }
 
   /*!
+   * \brief Set the momentum part of the truncation error to zero.
+   * \param[in] iPoint - Point index.
+   */
+  inline void SetVel_ResTruncError_Zero(unsigned long iPoint) final {
+    for (unsigned long iDim = 0; iDim < nDim; iDim++) Res_TruncError(iPoint,iDim+1) = 0.0;
+  }
+
+  /*!
    * \brief Get the value of the force projection vector.
    * \return Pointer to the force projection vector.
    */

--- a/SU2_CFD/include/variables/CEulerVariable.hpp
+++ b/SU2_CFD/include/variables/CEulerVariable.hpp
@@ -429,6 +429,14 @@ public:
   }
 
   /*!
+   * \brief Set the momentum part of the truncation error to zero.
+   * \param[in] iPoint - Point index.
+   */
+  inline void SetVel_ResTruncError_Zero(unsigned long iPoint) final {
+    for (unsigned long iDim = 0; iDim < nDim; iDim++) Res_TruncError(iPoint,iDim+1) = 0.0;
+  }
+
+  /*!
    * \brief Set the harmonic balance source term.
    * \param[in] iVar - Index of the variable.
    * \param[in] val_solution - Value of the harmonic balance source term. for the index <i>iVar</i>.

--- a/SU2_CFD/include/variables/CEulerVariable.hpp
+++ b/SU2_CFD/include/variables/CEulerVariable.hpp
@@ -487,4 +487,13 @@ public:
   inline su2double GetStrainMag(unsigned long iPoint) const final { return StrainMag(iPoint); }
   inline su2activevector& GetStrainMag() { return StrainMag; }
 
+  /*!
+   * \brief Specify a vector to set the velocity components of the solution. Multiplied by density for compressible cases.
+   * \param[in] iPoint - Point index.
+   * \param[in] val_vector - Pointer to the vector.
+   */
+  inline void SetVelSolutionVector(unsigned long iPoint, const su2double *val_vector) final {
+    for (unsigned long iDim = 0; iDim < nDim; iDim++) Solution(iPoint, iDim+1) = GetDensity(iPoint) * val_vector[iDim];
+  }
+
 };

--- a/SU2_CFD/include/variables/CIncEulerVariable.hpp
+++ b/SU2_CFD/include/variables/CIncEulerVariable.hpp
@@ -366,4 +366,13 @@ public:
   inline su2double GetStrainMag(unsigned long iPoint) const final { return StrainMag(iPoint); }
   inline su2activevector& GetStrainMag() { return StrainMag; }
 
+  /*!
+   * \brief Specify a vector to set the velocity components of the solution.
+   * \param[in] iPoint - Point index.
+   * \param[in] val_vector - Pointer to the vector.
+   */
+  inline void SetVelSolutionVector(unsigned long iPoint, const su2double *val_vector) final {
+    for (unsigned long iDim = 0; iDim < nDim; iDim++) Solution(iPoint, iDim+1) = val_vector[iDim];
+  }
+
 };

--- a/SU2_CFD/include/variables/CIncEulerVariable.hpp
+++ b/SU2_CFD/include/variables/CIncEulerVariable.hpp
@@ -327,6 +327,14 @@ public:
   }
 
   /*!
+   * \brief Set the momentum part of the truncation error to zero.
+   * \param[in] iPoint - Point index.
+   */
+  inline void SetVel_ResTruncError_Zero(unsigned long iPoint) final {
+    for (unsigned long iDim = 0; iDim < nDim; iDim++) Res_TruncError(iPoint,iDim+1) = 0.0;
+  }
+
+  /*!
    * \brief Set all the primitive variables for incompressible flows.
    */
   bool SetPrimVar(unsigned long iPoint, CFluidModel *FluidModel) final;

--- a/SU2_CFD/include/variables/CNEMOEulerVariable.hpp
+++ b/SU2_CFD/include/variables/CNEMOEulerVariable.hpp
@@ -576,4 +576,14 @@ public:
    */
   inline unsigned short GetRhoCvveIndex(void) { return RHOCVVE_INDEX; }
 
+  /*!
+   * \brief Specify a vector to set the velocity components of the solution. Multiplied by density for compressible cases.
+   * \param[in] iPoint - Point index.
+   * \param[in] val_vector - Pointer to the vector.
+   */
+  inline virtual void SetVelSolutionVector(unsigned long iPoint, const su2double *val_vector) final {
+    SU2_MPI::Error("Please add the correct <Density> for `multigrid` + `moving grid` and Solution-Position for momentum below!", CURRENT_FUNCTION);
+    for (unsigned long iDim = 0; iDim < nDim; iDim++) Solution(iPoint, nSpecies+iDim) = GetDensity(iPoint) * val_vector[iDim];
+  }
+
 };

--- a/SU2_CFD/include/variables/CNEMOEulerVariable.hpp
+++ b/SU2_CFD/include/variables/CNEMOEulerVariable.hpp
@@ -582,8 +582,16 @@ public:
    * \param[in] val_vector - Pointer to the vector.
    */
   inline void SetVelSolutionVector(unsigned long iPoint, const su2double *val_vector) final {
-    SU2_MPI::Error("Please add the correct <Density> for `multigrid` + `moving grid` and Solution-Position for momentum below!", CURRENT_FUNCTION);
-    for (unsigned long iDim = 0; iDim < nDim; iDim++) Solution(iPoint, nSpecies+iDim) = GetDensity(iPoint) * val_vector[iDim];
+    for (unsigned long iDim = 0; iDim < nDim; iDim++)
+      Solution(iPoint, nSpecies+iDim) = Primitive(iPoint,RHO_INDEX) * val_vector[iDim];
+  }
+
+  /*!
+   * \brief Set the momentum part of the truncation error to zero.
+   * \param[in] iPoint - Point index.
+   */
+  inline void SetVel_ResTruncError_Zero(unsigned long iPoint) final {
+    for (unsigned long iDim = 0; iDim < nDim; iDim++) Res_TruncError(iPoint,nSpecies+iDim) = 0.0;
   }
 
 };

--- a/SU2_CFD/include/variables/CNEMOEulerVariable.hpp
+++ b/SU2_CFD/include/variables/CNEMOEulerVariable.hpp
@@ -581,7 +581,7 @@ public:
    * \param[in] iPoint - Point index.
    * \param[in] val_vector - Pointer to the vector.
    */
-  inline virtual void SetVelSolutionVector(unsigned long iPoint, const su2double *val_vector) final {
+  inline void SetVelSolutionVector(unsigned long iPoint, const su2double *val_vector) final {
     SU2_MPI::Error("Please add the correct <Density> for `multigrid` + `moving grid` and Solution-Position for momentum below!", CURRENT_FUNCTION);
     for (unsigned long iDim = 0; iDim < nDim; iDim++) Solution(iPoint, nSpecies+iDim) = GetDensity(iPoint) * val_vector[iDim];
   }

--- a/SU2_CFD/include/variables/CVariable.hpp
+++ b/SU2_CFD/include/variables/CVariable.hpp
@@ -288,28 +288,12 @@ public:
   }
 
   /*!
-   * \brief Set to zero the velocity components of the solution.
-   * \param[in] iPoint - Point index.
-   */
-  inline void SetVelSolutionZero(unsigned long iPoint) {
-    for (unsigned long iDim = 0; iDim < nDim; iDim++) Solution(iPoint,iDim+1) = 0.0;
-  }
-
-  /*!
    * \brief Virtual Member. Specify a vector to set the velocity components of the solution.
    *        Multiplied by density for compressible cases.
    * \param[in] iPoint - Point index.
    * \param[in] val_vector - Pointer to the vector.
    */
   inline virtual void SetVelSolutionVector(unsigned long iPoint, const su2double *val_vector) { }
-
-  /*!
-   * \brief Set to zero velocity components of the solution.
-   * \param[in] iPoint - Point index.
-   */
-  inline void SetVelSolutionOldZero(unsigned long iPoint) {
-    for (unsigned long iDim = 0; iDim < nDim; iDim++) Solution_Old(iPoint, iDim+1) = 0.0;
-  }
 
   /*!
    * \brief Add a value to the solution.
@@ -511,12 +495,6 @@ public:
   }
 
   /*!
-   * \brief Set the velocity of the truncation error to zero.
-   * \param[in] iPoint - Point index.
-   */
-  inline virtual void SetVel_ResTruncError_Zero(unsigned long iPoint, unsigned long iSpecies) {}
-
-  /*!
    * \brief Get the value of the summed residual.
    * \param[in] iPoint - Point index.
    * \return Pointer to the summed residual.
@@ -661,12 +639,10 @@ public:
   inline void SetVal_ResTruncError_Zero(unsigned long iPoint, unsigned long iVar) {Res_TruncError(iPoint, iVar) = 0.0;}
 
   /*!
-   * \brief Set the velocity of the truncation error to zero.
+   * \brief Set the momentum part of the truncation error to zero.
    * \param[in] iPoint - Point index.
    */
-  inline void SetVel_ResTruncError_Zero(unsigned long iPoint) {
-    for (unsigned long iDim = 0; iDim < nDim; iDim++) Res_TruncError(iPoint,iDim+1) = 0.0;
-  }
+  inline virtual void SetVel_ResTruncError_Zero(unsigned long iPoint) { }
 
   /*!
    * \brief Set the velocity of the truncation error to zero.

--- a/SU2_CFD/include/variables/CVariable.hpp
+++ b/SU2_CFD/include/variables/CVariable.hpp
@@ -296,13 +296,12 @@ public:
   }
 
   /*!
-   * \brief Specify a vector to set the velocity components of the solution. Multiplied by density for compressible cases.
+   * \brief Virtual Member. Specify a vector to set the velocity components of the solution.
+   *        Multiplied by density for compressible cases.
    * \param[in] iPoint - Point index.
    * \param[in] val_vector - Pointer to the vector.
    */
-  inline virtual void SetVelSolutionVector(unsigned long iPoint, const su2double *val_vector) {
-    for (unsigned long iDim = 0; iDim < nDim; iDim++) Solution(iPoint, iDim+1) = Solution(iPoint, 0) * val_vector[iDim];
-  }
+  inline virtual void SetVelSolutionVector(unsigned long iPoint, const su2double *val_vector) { }
 
   /*!
    * \brief Set to zero velocity components of the solution.

--- a/SU2_CFD/include/variables/CVariable.hpp
+++ b/SU2_CFD/include/variables/CVariable.hpp
@@ -296,12 +296,12 @@ public:
   }
 
   /*!
-   * \brief Specify a vector to set the velocity components of the solution.
+   * \brief Specify a vector to set the velocity components of the solution. Multiplied by density for compressible cases.
    * \param[in] iPoint - Point index.
    * \param[in] val_vector - Pointer to the vector.
    */
-  inline void SetVelSolutionVector(unsigned long iPoint, const su2double *val_vector) {
-    for (unsigned long iDim = 0; iDim < nDim; iDim++) Solution(iPoint, iDim+1) = val_vector[iDim];
+  inline virtual void SetVelSolutionVector(unsigned long iPoint, const su2double *val_vector) {
+    for (unsigned long iDim = 0; iDim < nDim; iDim++) Solution(iPoint, iDim+1) = Solution(iPoint, 0) * val_vector[iDim];
   }
 
   /*!

--- a/SU2_CFD/src/integration/CMultiGridIntegration.cpp
+++ b/SU2_CFD/src/integration/CMultiGridIntegration.cpp
@@ -350,7 +350,8 @@ void CMultiGridIntegration::GetProlongated_Correction(unsigned short RunTime_EqS
         /*--- For dirichlet boundary condtions, set the correction to zero.
          Note that Solution_Old stores the correction not the actual value ---*/
 
-        sol_coarse->GetNodes()->SetVelSolutionOldZero(Point_Coarse);
+        su2double zero[3] = {0.0};
+        sol_coarse->GetNodes()->SetVelocity_Old(Point_Coarse, zero);
 
       }
     }
@@ -542,13 +543,12 @@ void CMultiGridIntegration::SetRestricted_Solution(unsigned short RunTime_EqSyst
                                                    CGeometry *geo_fine, CGeometry *geo_coarse, CConfig *config) {
 
   unsigned long iVertex, Point_Fine, Point_Coarse;
-  unsigned short iMarker, iVar, iChildren, iDim;
+  unsigned short iMarker, iVar, iChildren;
   su2double Area_Parent, Area_Children;
   const su2double *Solution_Fine = nullptr, *Grid_Vel = nullptr;
 
   const unsigned short Solver_Position = config->GetContainerPosition(RunTime_EqSystem);
   const unsigned short nVar = sol_coarse->GetnVar();
-  const unsigned short nDim = geo_fine->GetnDim();
   const bool grid_movement = config->GetGrid_Movement();
 
   su2double *Solution = new su2double[nVar];
@@ -598,8 +598,8 @@ void CMultiGridIntegration::SetRestricted_Solution(unsigned short RunTime_EqSyst
           }
           else {
             /*--- For stationary no-slip walls, set the velocity to zero. ---*/
-
-            sol_coarse->GetNodes()->SetVelSolutionZero(Point_Coarse);
+            su2double zero[3] = {0.0};
+            sol_coarse->GetNodes()->SetVelSolutionVector(Point_Coarse, zero);
           }
 
         }

--- a/SU2_CFD/src/integration/CMultiGridIntegration.cpp
+++ b/SU2_CFD/src/integration/CMultiGridIntegration.cpp
@@ -543,7 +543,7 @@ void CMultiGridIntegration::SetRestricted_Solution(unsigned short RunTime_EqSyst
 
   unsigned long iVertex, Point_Fine, Point_Coarse;
   unsigned short iMarker, iVar, iChildren, iDim;
-  su2double Area_Parent, Area_Children, Vector[3] = {0.0};
+  su2double Area_Parent, Area_Children;
   const su2double *Solution_Fine = nullptr, *Grid_Vel = nullptr;
 
   const unsigned short Solver_Position = config->GetContainerPosition(RunTime_EqSystem);
@@ -594,9 +594,7 @@ void CMultiGridIntegration::SetRestricted_Solution(unsigned short RunTime_EqSyst
 
           if (grid_movement) {
             Grid_Vel = geo_coarse->nodes->GetGridVel(Point_Coarse);
-            for (iDim = 0; iDim < nDim; iDim++)
-              Vector[iDim] = sol_coarse->GetNodes()->GetSolution(Point_Coarse,0)*Grid_Vel[iDim];
-            sol_coarse->GetNodes()->SetVelSolutionVector(Point_Coarse, Vector);
+            sol_coarse->GetNodes()->SetVelSolutionVector(Point_Coarse, Grid_Vel);
           }
           else {
             /*--- For stationary no-slip walls, set the velocity to zero. ---*/

--- a/SU2_CFD/src/solvers/CIncEulerSolver.cpp
+++ b/SU2_CFD/src/solvers/CIncEulerSolver.cpp
@@ -376,8 +376,8 @@ void CIncEulerSolver::SetNondimensionalization(CConfig *config, unsigned short i
   /*--- Get the freestream energy. Only useful if energy equation is active. ---*/
 
   Energy_FreeStream = auxFluidModel->GetStaticEnergy() + 0.5*ModVel_FreeStream*ModVel_FreeStream;
+  if (tkeNeeded) { Energy_FreeStream += Tke_FreeStream; };
   config->SetEnergy_FreeStream(Energy_FreeStream);
-  if (tkeNeeded) { Energy_FreeStream += Tke_FreeStream; }; config->SetEnergy_FreeStream(Energy_FreeStream);
 
   /*--- Compute Mach number ---*/
 
@@ -390,17 +390,17 @@ void CIncEulerSolver::SetNondimensionalization(CConfig *config, unsigned short i
 
   /*--- Divide by reference values, to compute the non-dimensional free-stream values ---*/
 
-  Pressure_FreeStreamND = Pressure_FreeStream/config->GetPressure_Ref(); config->SetPressure_FreeStreamND(Pressure_FreeStreamND);
+  Pressure_FreeStreamND = Pressure_FreeStream/config->GetPressure_Ref();       config->SetPressure_FreeStreamND(Pressure_FreeStreamND);
   Pressure_ThermodynamicND = Pressure_Thermodynamic/config->GetPressure_Ref(); config->SetPressure_ThermodynamicND(Pressure_ThermodynamicND);
-  Density_FreeStreamND  = Density_FreeStream/config->GetDensity_Ref();   config->SetDensity_FreeStreamND(Density_FreeStreamND);
+  Density_FreeStreamND  = Density_FreeStream/config->GetDensity_Ref();         config->SetDensity_FreeStreamND(Density_FreeStreamND);
 
   for (iDim = 0; iDim < nDim; iDim++) {
     Velocity_FreeStreamND[iDim] = config->GetVelocity_FreeStream()[iDim]/Velocity_Ref; config->SetVelocity_FreeStreamND(Velocity_FreeStreamND[iDim], iDim);
   }
 
   Temperature_FreeStreamND = Temperature_FreeStream/config->GetTemperature_Ref(); config->SetTemperature_FreeStreamND(Temperature_FreeStreamND);
-  Gas_ConstantND      = config->GetGas_Constant()/Gas_Constant_Ref;    config->SetGas_ConstantND(Gas_ConstantND);
-  Specific_Heat_CpND  = config->GetSpecific_Heat_Cp()/Gas_Constant_Ref; config->SetSpecific_Heat_CpND(Specific_Heat_CpND);
+  Gas_ConstantND      = config->GetGas_Constant()/Gas_Constant_Ref;               config->SetGas_ConstantND(Gas_ConstantND);
+  Specific_Heat_CpND  = config->GetSpecific_Heat_Cp()/Gas_Constant_Ref;           config->SetSpecific_Heat_CpND(Specific_Heat_CpND);
 
   /*--- We assume that Cp = Cv for our incompressible fluids. ---*/
   Specific_Heat_CvND  = config->GetSpecific_Heat_Cp()/Gas_Constant_Ref; config->SetSpecific_Heat_CvND(Specific_Heat_CvND);

--- a/TestCases/.gitignore
+++ b/TestCases/.gitignore
@@ -9,19 +9,23 @@
 # changes to the meshes/solutions/restarts.
 
 # Things appearing in TestCases/ repo to ignore:
+# mesh files
 *.su2
-*.dat
-*.vtk
-*.csv
-*.plt
-*.szplt
-*.pw
-*.IGS
 *.cgns
-*.tgz
-COPYING
-README.md
+*.pw
+
+# binary/ascii restart/solution files. Note that .csv can be a history, of_grad, etc file as well.
+*.dat
+*.csv
+
+# auto-generated files by regression tests
 *.autotest
 config_*.cfg
-*.eqn
+
+# flip the pickle
 *.pkl
+
+*.IGS
+*.tgz
+COPYING
+*.eqn


### PR DESCRIPTION
## Proposed Changes
During multigrid prolongation the no-slip (visc.) wall BC are set again. If there is Grid velocity it was multiplied by the 0th solution entry, both inc and compr. For compr flow it is density which is correct but for inc flow that is pressure. That is corrected by overloading.
 
In a little test with `TestCases/unsteady/pitching_naca0015_rans_inc/config_incomp_turb_sa.cfg` the linear solver diverged in the first iteration before, and now it works.

Discovered by @pcarruscag and discussed in last weeks DevMeeting, so props to him.

## PR Checklist
- [x] I am submitting my contribution to the develop branch.
- [ ] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags, or simply --warnlevel=2 when using meson).
- [x] My contribution is commented and consistent with SU2 style.
- [x] I have added a test case that demonstrates my contribution, if necessary. *not necessary*
- [x] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
