### PR TITLE
k-omega SST 2D axisymmetric source terms

### DIFF
--- a/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
+++ b/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
@@ -334,7 +334,7 @@ private:
   /*!
    * \brief Add contribution due to axisymmetric formulation to 2D residual
    */
-  void ResidualAxisymmetric();
+  void ResidualAxisymmetric(su2double alfa_blended);
 
 public:
   /*!

--- a/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
+++ b/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
@@ -334,7 +334,7 @@ private:
   /*!
    * \brief Add contribution due to axisymmetric formulation to 2D residual
    */
-  void ResidualAxisymmetric(su2double alfa_blended);
+  void ResidualAxisymmetric(su2double alfa_blended, su2double zeta);
 
 public:
   /*!

--- a/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
+++ b/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
@@ -307,8 +307,8 @@ private:
   beta_2,
   sigma_k_1,
   sigma_k_2,
-  sigma_omega_1,
-  sigma_omega_2,
+  sigma_w_1,
+  sigma_w_2,
   beta_star,
   a1;
 
@@ -335,44 +335,40 @@ private:
    */
   inline void ResidualAxisymmetric(su2double alfa_blended, su2double zeta){
 
-    if (Coord_i[1] < EPS) {
-      return;
-    }
+    if (Coord_i[1] < EPS) return;
      
-    su2double yinv, rhov;
-    su2double sigma_k_i, sigma_omega_i;
-    su2double pk_axi, pw_axi, ck_axi, cw_axi, dk_axi, dw_axi;
+    su2double yinv, rhov, k, w;
+    su2double sigma_k_i, sigma_w_i;
+    su2double pk_axi, pw_axi, cdk_axi, cdw_axi;
 
     AD::SetPreaccIn(Coord_i[1]);
+    
     yinv = 1.0/Coord_i[1];
     rhov = Density_i*V_i[2];
+    k = TurbVar_i[0];
+    w = TurbVar_i[1];
     
     /*--- Compute blended constants ---*/
-    sigma_k_i = F1_i*sigma_k_1 + (1.0 - F1_i)*sigma_k_2;
-    sigma_omega_i = F1_i*sigma_omega_1 + (1.0 - F1_i)*sigma_omega_2;
+    sigma_k_i = F1_i*sigma_k_1+(1.0-F1_i)*sigma_k_2;
+    sigma_w_i = F1_i*sigma_w_1+(1.0-F1_i)*sigma_w_2;
 
     /*--- Production ---*/
-    pk_axi = max(0.0,2.0/3.0*rhov*TurbVar_i[0]*(2.0/zeta*(yinv*V_i[2]-PrimVar_Grad_i[2][1]
-                                                                -PrimVar_Grad_i[1][0]) -1.0));
-    pw_axi = alfa_blended*zeta/TurbVar_i[0]*pk_axi;
+    pk_axi = max(0.0,2.0/3.0*rhov*k*(2.0/zeta*(yinv*V_i[2]-PrimVar_Grad_i[2][1]-PrimVar_Grad_i[1][0])-1.0));
+    pw_axi = alfa_blended*zeta/k*pk_axi;
     
-    /*--- Convection ---*/
-    ck_axi = rhov*TurbVar_i[0];
-    cw_axi = rhov*TurbVar_i[1];
+    /*--- Convection-Diffusion ---*/
+    cdk_axi = rhov*k-(Laminar_Viscosity_i+sigma_k_i*Eddy_Viscosity_i)*TurbVar_Grad_i[0][1];
+    cdw_axi = rhov*w-(Laminar_Viscosity_i+sigma_w_i*Eddy_Viscosity_i)*TurbVar_Grad_i[1][1];
     
-    /*--- Diffusion ---*/
-    dk_axi = (Laminar_Viscosity_i+sigma_k_i*Eddy_Viscosity_i)*TurbVar_Grad_i[0][1];
-    dw_axi = (Laminar_Viscosity_i+sigma_omega_i*Eddy_Viscosity_i)*TurbVar_Grad_i[1][1];
-    
-    /*--- Add all terms to the residuals ---*/
-    Residual[0] += yinv*Volume*(pk_axi-ck_axi+dk_axi);
-    Residual[1] += yinv*Volume*(pw_axi-cw_axi+dw_axi);
+    /*--- Add terms to the residuals ---*/
+    Residual[0] += yinv*Volume*(pk_axi-cdk_axi);
+    Residual[1] += yinv*Volume*(pw_axi-cdw_axi);
   
-    /*--- Add contribution to the jacobian for implicit time integration---*/
-    Jacobian_i[0][0] += yinv*Volume*(sigma_k_i/zeta*TurbVar_Grad_i[0][1]-V_i[2]);
-    Jacobian_i[0][1] -= yinv*Volume*sigma_k_i*TurbVar_i[0]*TurbVar_Grad_i[0][1]/(zeta*zeta);
-    Jacobian_i[1][0] += yinv*Volume*sigma_k_i/zeta*TurbVar_Grad_i[1][1];
-    Jacobian_i[1][1] -= yinv*Volume*(sigma_k_i*TurbVar_i[0]*TurbVar_Grad_i[1][1]/(zeta*zeta)+V_i[2]);
+    /*--- Add contribution to the jacobian for implicit time integration--- */  
+    Jacobian_i[0][0] += yinv*Volume*(sigma_k_i*TurbVar_Grad_i[0][1]/zeta-V_i[2]);
+    Jacobian_i[0][1] += yinv*Volume*(-sigma_k_i*k*TurbVar_Grad_i[0][1]/(zeta*zeta));
+    Jacobian_i[1][0] += yinv*Volume*(sigma_w_i*TurbVar_Grad_i[1][1]/zeta);
+    Jacobian_i[1][1] += yinv*Volume*(-sigma_w_i*k*TurbVar_Grad_i[1][1]/(zeta*zeta)-V_i[2]);
 
   }
 

--- a/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
+++ b/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
@@ -338,44 +338,41 @@ private:
     if (Coord_i[1] < EPS) {
       return;
     }
+     
+    su2double yinv, rhov;
+    su2double sigma_k_i, sigma_omega_i;
+    su2double pk_axi, pw_axi, ck_axi, cw_axi, dk_axi, dw_axi;
     
-    else{
-      
-      su2double yinv, rhov;
-      su2double sigma_k_i, sigma_omega_i;
-      su2double pk_axi, pw_axi, ck_axi, cw_axi, dk_axi, dw_axi;
-      
-      yinv = 1.0/Coord_i[1];
-      rhov = Density_i*V_i[2];
-      
-      /*--- Compute blended constants ---*/
-      sigma_k_i = F1_i*sigma_k_1 + (1.0 - F1_i)*sigma_k_2;
-      sigma_omega_i = F1_i*sigma_omega_1 + (1.0 - F1_i)*sigma_omega_2;
+    yinv = 1.0/Coord_i[1];
+    rhov = Density_i*V_i[2];
+    
+    /*--- Compute blended constants ---*/
+    sigma_k_i = F1_i*sigma_k_1 + (1.0 - F1_i)*sigma_k_2;
+    sigma_omega_i = F1_i*sigma_omega_1 + (1.0 - F1_i)*sigma_omega_2;
+
+    /*--- Production ---*/
+    pk_axi = max(0.0,2.0/3.0*rhov*TurbVar_i[0]*(2.0/zeta*(yinv*V_i[2]-PrimVar_Grad_i[2][1]
+                                                                -PrimVar_Grad_i[1][0]) -1.0));
+    pw_axi = alfa_blended*zeta/TurbVar_i[0]*pk_axi;
+    
+    /*--- Convection ---*/
+    ck_axi = rhov*TurbVar_i[0];
+    cw_axi = rhov*TurbVar_i[1];
+    
+    /*--- Diffusion ---*/
+    dk_axi = (Laminar_Viscosity_i+sigma_k_i*Eddy_Viscosity_i)*TurbVar_Grad_i[0][1];
+    dw_axi = (Laminar_Viscosity_i+sigma_omega_i*Eddy_Viscosity_i)*TurbVar_Grad_i[1][1];
+    
+    /*--- Add all terms to the residuals ---*/
+    Residual[0] += yinv*Volume*(pk_axi-ck_axi+dk_axi);
+    Residual[1] += yinv*Volume*(pw_axi-cw_axi+dw_axi);
   
-      /*--- Production ---*/
-      pk_axi = max(0.0,2.0/3.0*rhov*TurbVar_i[0]*(2.0/zeta*(yinv*V_i[2]-PrimVar_Grad_i[2][1]
-                                                                  -PrimVar_Grad_i[1][0]) -1.0));
-      pw_axi = alfa_blended*zeta/TurbVar_i[0]*pk_axi;
-      
-      /*--- Convection ---*/
-      ck_axi = rhov*TurbVar_i[0];
-      cw_axi = rhov*TurbVar_i[1];
-      
-      /*--- Diffusion ---*/
-      dk_axi = (Laminar_Viscosity_i+sigma_k_i*Eddy_Viscosity_i)*TurbVar_Grad_i[0][1];
-      dw_axi = (Laminar_Viscosity_i+sigma_omega_i*Eddy_Viscosity_i)*TurbVar_Grad_i[1][1];
-      
-      /*--- Add all terms to the residuals ---*/
-      Residual[0] += yinv*Volume*(pk_axi-ck_axi+dk_axi);
-      Residual[1] += yinv*Volume*(pw_axi-cw_axi+dw_axi);
-    
-      /*--- Add contribution to the jacobian for implicit time integration---*/
-      Jacobian_i[0][0] += yinv*Volume*(sigma_k_i/zeta*TurbVar_Grad_i[0][1]-V_i[2]);
-      Jacobian_i[0][1] -= yinv*Volume*sigma_k_i*TurbVar_i[0]*TurbVar_Grad_i[0][1]/(zeta*zeta);
-      Jacobian_i[1][0] += yinv*Volume*sigma_k_i/zeta*TurbVar_Grad_i[1][1];
-      Jacobian_i[1][1] -= yinv*Volume*(sigma_k_i*TurbVar_i[0]*TurbVar_Grad_i[1][1]/(zeta*zeta)+V_i[2]);
-      
-    }
+    /*--- Add contribution to the jacobian for implicit time integration---*/
+    Jacobian_i[0][0] += yinv*Volume*(sigma_k_i/zeta*TurbVar_Grad_i[0][1]-V_i[2]);
+    Jacobian_i[0][1] -= yinv*Volume*sigma_k_i*TurbVar_i[0]*TurbVar_Grad_i[0][1]/(zeta*zeta);
+    Jacobian_i[1][0] += yinv*Volume*sigma_k_i/zeta*TurbVar_Grad_i[1][1];
+    Jacobian_i[1][1] -= yinv*Volume*(sigma_k_i*TurbVar_i[0]*TurbVar_Grad_i[1][1]/(zeta*zeta)+V_i[2]);
+
   }
 
 public:

--- a/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
+++ b/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
@@ -320,12 +320,18 @@ private:
 
   bool incompressible;
   bool sustaining_terms;
+  bool axisymmetric;
 
   /*!
    * \brief A virtual member. Get strain magnitude based on perturbed reynolds stress matrix
    * \param[in] turb_ke: turbulent kinetic energy of the node
    */
   void SetPerturbedStrainMag(su2double turb_ke);
+  
+  /*!
+   * \brief Add contribution due to axisymmetric formulation to 2D residual
+   */
+  void ResidualAxisymmetric();
 
 public:
   /*!

--- a/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
+++ b/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
@@ -305,6 +305,8 @@ private:
   alfa_2,
   beta_1,
   beta_2,
+  sigma_k_1,
+  sigma_k_2,
   sigma_omega_1,
   sigma_omega_2,
   beta_star,
@@ -320,6 +322,7 @@ private:
 
   bool incompressible;
   bool sustaining_terms;
+  bool implicit;
   bool axisymmetric;
 
   /*!
@@ -331,7 +334,7 @@ private:
   /*!
    * \brief Add contribution due to axisymmetric formulation to 2D residual
    */
-  void ResidualAxisymmetric();
+  void ResidualAxisymmetric(su2double beta_blended);
 
 public:
   /*!

--- a/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
+++ b/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
@@ -365,10 +365,10 @@ private:
     Residual[1] += yinv*Volume*(pw_axi-cdw_axi);
   
     /*--- Add contribution to the jacobian for implicit time integration (ignore to conserve diagonal dominance) ---*/
-    Jacobian_i[0][0] += yinv*Volume*(sigma_k_i*TurbVar_Grad_i[0][1]/zeta-V_i[2]);
-    Jacobian_i[0][1] += yinv*Volume*(-sigma_k_i*k*TurbVar_Grad_i[0][1]/(zeta*zeta));
-    Jacobian_i[1][0] += yinv*Volume*(sigma_w_i*TurbVar_Grad_i[1][1]/zeta);
-    Jacobian_i[1][1] += yinv*Volume*(-sigma_w_i*k*TurbVar_Grad_i[1][1]/(zeta*zeta)-V_i[2]);
+    //Jacobian_i[0][0] += yinv*Volume*(sigma_k_i*TurbVar_Grad_i[0][1]/zeta-V_i[2]);
+    //Jacobian_i[0][1] += yinv*Volume*(-sigma_k_i*k*TurbVar_Grad_i[0][1]/(zeta*zeta));
+    //Jacobian_i[1][0] += yinv*Volume*(sigma_w_i*TurbVar_Grad_i[1][1]/zeta);
+    //Jacobian_i[1][1] += yinv*Volume*(-sigma_w_i*k*TurbVar_Grad_i[1][1]/(zeta*zeta)-V_i[2]);
 
   }
 

--- a/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
+++ b/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
@@ -322,7 +322,6 @@ private:
 
   bool incompressible;
   bool sustaining_terms;
-  bool implicit;
   bool axisymmetric;
 
   /*!
@@ -334,7 +333,50 @@ private:
   /*!
    * \brief Add contribution due to axisymmetric formulation to 2D residual
    */
-  void ResidualAxisymmetric(su2double alfa_blended, su2double zeta);
+  inline void ResidualAxisymmetric(su2double alfa_blended, su2double zeta){
+
+    if (Coord_i[1] < EPS) {
+      return;
+    }
+    
+    else{
+      
+      su2double yinv, rhov;
+      su2double sigma_k_i, sigma_omega_i;
+      su2double pk_axi, pw_axi, ck_axi, cw_axi, dk_axi, dw_axi;
+      
+      yinv = 1.0/Coord_i[1];
+      rhov = Density_i*V_i[2];
+      
+      /*--- Compute blended constants ---*/
+      sigma_k_i = F1_i*sigma_k_1 + (1.0 - F1_i)*sigma_k_2;
+      sigma_omega_i = F1_i*sigma_omega_1 + (1.0 - F1_i)*sigma_omega_2;
+  
+      /*--- Production ---*/
+      pk_axi = max(0.0,2.0/3.0*rhov*TurbVar_i[0]*(2.0/zeta*(yinv*V_i[2]-PrimVar_Grad_i[2][1]
+                                                                  -PrimVar_Grad_i[1][0]) -1.0));
+      pw_axi = alfa_blended*zeta/TurbVar_i[0]*pk_axi;
+      
+      /*--- Convection ---*/
+      ck_axi = rhov*TurbVar_i[0];
+      cw_axi = rhov*TurbVar_i[1];
+      
+      /*--- Diffusion ---*/
+      dk_axi = (Laminar_Viscosity_i+sigma_k_i*Eddy_Viscosity_i)*TurbVar_Grad_i[0][1];
+      dw_axi = (Laminar_Viscosity_i+sigma_omega_i*Eddy_Viscosity_i)*TurbVar_Grad_i[1][1];
+      
+      /*--- Add all terms to the residuals ---*/
+      Residual[0] += yinv*Volume*(pk_axi-ck_axi+dk_axi);
+      Residual[1] += yinv*Volume*(pw_axi-cw_axi+dw_axi);
+    
+      /*--- Add contribution to the jacobian for implicit time integration---*/
+      Jacobian_i[0][0] += yinv*Volume*(sigma_k_i/zeta*TurbVar_Grad_i[0][1]-V_i[2]);
+      Jacobian_i[0][1] -= yinv*Volume*sigma_k_i*TurbVar_i[0]*TurbVar_Grad_i[0][1]/(zeta*zeta);
+      Jacobian_i[1][0] += yinv*Volume*sigma_k_i/zeta*TurbVar_Grad_i[1][1];
+      Jacobian_i[1][1] -= yinv*Volume*(sigma_k_i*TurbVar_i[0]*TurbVar_Grad_i[1][1]/(zeta*zeta)+V_i[2]);
+      
+    }
+  }
 
 public:
   /*!

--- a/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
+++ b/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
@@ -342,7 +342,8 @@ private:
     su2double yinv, rhov;
     su2double sigma_k_i, sigma_omega_i;
     su2double pk_axi, pw_axi, ck_axi, cw_axi, dk_axi, dw_axi;
-    
+
+    AD::SetPreaccIn(Coord_i[1]);
     yinv = 1.0/Coord_i[1];
     rhov = Density_i*V_i[2];
     

--- a/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
+++ b/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
@@ -363,12 +363,6 @@ private:
     /*--- Add terms to the residuals ---*/
     Residual[0] += yinv*Volume*(pk_axi-cdk_axi);
     Residual[1] += yinv*Volume*(pw_axi-cdw_axi);
-  
-    /*--- Add contribution to the jacobian for implicit time integration (ignore to conserve diagonal dominance) ---*/
-    //Jacobian_i[0][0] += yinv*Volume*(sigma_k_i*TurbVar_Grad_i[0][1]/zeta-V_i[2]);
-    //Jacobian_i[0][1] += yinv*Volume*(-sigma_k_i*k*TurbVar_Grad_i[0][1]/(zeta*zeta));
-    //Jacobian_i[1][0] += yinv*Volume*(sigma_w_i*TurbVar_Grad_i[1][1]/zeta);
-    //Jacobian_i[1][1] += yinv*Volume*(-sigma_w_i*k*TurbVar_Grad_i[1][1]/(zeta*zeta)-V_i[2]);
 
   }
 

--- a/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
+++ b/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
@@ -364,11 +364,11 @@ private:
     Residual[0] += yinv*Volume*(pk_axi-cdk_axi);
     Residual[1] += yinv*Volume*(pw_axi-cdw_axi);
   
-    /*--- Add contribution to the jacobian for implicit time integration--- */  
-    Jacobian_i[0][0] += yinv*Volume*(sigma_k_i*TurbVar_Grad_i[0][1]/zeta-V_i[2]);
-    Jacobian_i[0][1] += yinv*Volume*(-sigma_k_i*k*TurbVar_Grad_i[0][1]/(zeta*zeta));
-    Jacobian_i[1][0] += yinv*Volume*(sigma_w_i*TurbVar_Grad_i[1][1]/zeta);
-    Jacobian_i[1][1] += yinv*Volume*(-sigma_w_i*k*TurbVar_Grad_i[1][1]/(zeta*zeta)-V_i[2]);
+    /*--- Add contribution to the jacobian for implicit time integration--- (ignore to conserve diagonal dominance)*/ 
+    //Jacobian_i[0][0] += yinv*Volume*(sigma_k_i*TurbVar_Grad_i[0][1]/zeta-V_i[2]);
+    //Jacobian_i[0][1] += yinv*Volume*(-sigma_k_i*k*TurbVar_Grad_i[0][1]/(zeta*zeta));
+    //Jacobian_i[1][0] += yinv*Volume*(sigma_w_i*TurbVar_Grad_i[1][1]/zeta);
+    //Jacobian_i[1][1] += yinv*Volume*(-sigma_w_i*k*TurbVar_Grad_i[1][1]/(zeta*zeta)-V_i[2]);
 
   }
 

--- a/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
+++ b/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
@@ -336,18 +336,18 @@ private:
   inline void ResidualAxisymmetric(su2double alfa_blended, su2double zeta){
 
     if (Coord_i[1] < EPS) return;
-     
+
     su2double yinv, rhov, k, w;
     su2double sigma_k_i, sigma_w_i;
     su2double pk_axi, pw_axi, cdk_axi, cdw_axi;
 
     AD::SetPreaccIn(Coord_i[1]);
-    
+
     yinv = 1.0/Coord_i[1];
     rhov = Density_i*V_i[2];
     k = TurbVar_i[0];
     w = TurbVar_i[1];
-    
+
     /*--- Compute blended constants ---*/
     sigma_k_i = F1_i*sigma_k_1+(1.0-F1_i)*sigma_k_2;
     sigma_w_i = F1_i*sigma_w_1+(1.0-F1_i)*sigma_w_2;
@@ -355,20 +355,20 @@ private:
     /*--- Production ---*/
     pk_axi = max(0.0,2.0/3.0*rhov*k*(2.0/zeta*(yinv*V_i[2]-PrimVar_Grad_i[2][1]-PrimVar_Grad_i[1][0])-1.0));
     pw_axi = alfa_blended*zeta/k*pk_axi;
-    
+
     /*--- Convection-Diffusion ---*/
     cdk_axi = rhov*k-(Laminar_Viscosity_i+sigma_k_i*Eddy_Viscosity_i)*TurbVar_Grad_i[0][1];
     cdw_axi = rhov*w-(Laminar_Viscosity_i+sigma_w_i*Eddy_Viscosity_i)*TurbVar_Grad_i[1][1];
-    
+
     /*--- Add terms to the residuals ---*/
     Residual[0] += yinv*Volume*(pk_axi-cdk_axi);
     Residual[1] += yinv*Volume*(pw_axi-cdw_axi);
   
-    /*--- Add contribution to the jacobian for implicit time integration--- (ignore to conserve diagonal dominance)*/ 
-    //Jacobian_i[0][0] += yinv*Volume*(sigma_k_i*TurbVar_Grad_i[0][1]/zeta-V_i[2]);
-    //Jacobian_i[0][1] += yinv*Volume*(-sigma_k_i*k*TurbVar_Grad_i[0][1]/(zeta*zeta));
-    //Jacobian_i[1][0] += yinv*Volume*(sigma_w_i*TurbVar_Grad_i[1][1]/zeta);
-    //Jacobian_i[1][1] += yinv*Volume*(-sigma_w_i*k*TurbVar_Grad_i[1][1]/(zeta*zeta)-V_i[2]);
+    /*--- Add contribution to the jacobian for implicit time integration (ignore to conserve diagonal dominance) ---*/
+    Jacobian_i[0][0] += yinv*Volume*(sigma_k_i*TurbVar_Grad_i[0][1]/zeta-V_i[2]);
+    Jacobian_i[0][1] += yinv*Volume*(-sigma_k_i*k*TurbVar_Grad_i[0][1]/(zeta*zeta));
+    Jacobian_i[1][0] += yinv*Volume*(sigma_w_i*TurbVar_Grad_i[1][1]/zeta);
+    Jacobian_i[1][1] += yinv*Volume*(-sigma_w_i*k*TurbVar_Grad_i[1][1]/(zeta*zeta)-V_i[2]);
 
   }
 

--- a/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
+++ b/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
@@ -334,7 +334,7 @@ private:
   /*!
    * \brief Add contribution due to axisymmetric formulation to 2D residual
    */
-  void ResidualAxisymmetric(su2double beta_blended);
+  void ResidualAxisymmetric();
 
 public:
   /*!

--- a/SU2_CFD/src/numerics/turbulent/turb_sources.cpp
+++ b/SU2_CFD/src/numerics/turbulent/turb_sources.cpp
@@ -965,8 +965,12 @@ void CSourcePieceWise_TurbSST::ResidualAxisymmetric(su2double alfa_blended, su2d
     Residual[1] += yinv*Volume*(pw_axi-cw_axi+dw_axi);
   
     if (implicit) {
-     Jacobian_i[0][0] -= yinv*Volume*V_i[2];
-     Jacobian_i[1][1] -= yinv*Volume*V_i[2];
+     Jacobian_i[0][0] += yinv*Volume*(sigma_k_i/zeta*TurbVar_Grad_i[0][1]-V_i[2]);
+     Jacobian_i[0][1] += -yinv*Volume*sigma_k_i*TurbVar_i[0]*TurbVar_Grad_i[0][1]
+                                                            /(TurbVar_i[1]*TurbVar_i[1]);
+     Jacobian_i[1][0] += yinv*Volume*sigma_k_i/zeta*TurbVar_Grad_i[1][1];
+     Jacobian_i[1][1] += yinv*Volume*(-sigma_k_i*TurbVar_i[0]*TurbVar_Grad_i[1][1]
+                                                            /(TurbVar_i[1]*TurbVar_i[1])-V_i[2]);
     } 
     
   }

--- a/SU2_CFD/src/numerics/turbulent/turb_sources.cpp
+++ b/SU2_CFD/src/numerics/turbulent/turb_sources.cpp
@@ -966,11 +966,9 @@ void CSourcePieceWise_TurbSST::ResidualAxisymmetric(su2double alfa_blended, su2d
   
     if (implicit) {
      Jacobian_i[0][0] += yinv*Volume*(sigma_k_i/zeta*TurbVar_Grad_i[0][1]-V_i[2]);
-     Jacobian_i[0][1] += -yinv*Volume*sigma_k_i*TurbVar_i[0]*TurbVar_Grad_i[0][1]
-                                                            /(TurbVar_i[1]*TurbVar_i[1]);
+     Jacobian_i[0][1] -= yinv*Volume*sigma_k_i*TurbVar_i[0]*TurbVar_Grad_i[0][1]/(zeta*zeta);
      Jacobian_i[1][0] += yinv*Volume*sigma_k_i/zeta*TurbVar_Grad_i[1][1];
-     Jacobian_i[1][1] += yinv*Volume*(-sigma_k_i*TurbVar_i[0]*TurbVar_Grad_i[1][1]
-                                                            /(TurbVar_i[1]*TurbVar_i[1])-V_i[2]);
+     Jacobian_i[1][1] -= yinv*Volume*(sigma_k_i*TurbVar_i[0]*TurbVar_Grad_i[1][1]/(zeta*zeta)+V_i[2]);
     } 
     
   }

--- a/SU2_CFD/src/numerics/turbulent/turb_sources.cpp
+++ b/SU2_CFD/src/numerics/turbulent/turb_sources.cpp
@@ -911,7 +911,7 @@ CNumerics::ResidualType<> CSourcePieceWise_TurbSST::ComputeResidual(const CConfi
   
   /*--- Contribution due to 2D axisymmetric formulation ---*/
   
-  if (axisymmetric) ResidualAxisymmetric(beta_blended);
+  if (axisymmetric) ResidualAxisymmetric();
 
   AD::SetPreaccOut(Residual, nVar);
   AD::EndPreacc();
@@ -937,15 +937,15 @@ void CSourcePieceWise_TurbSST::SetPerturbedStrainMag(su2double turb_ke){
 
 }
 
-void CSourcePieceWise_TurbSST::ResidualAxisymmetric(su2double beta_blended){
+void CSourcePieceWise_TurbSST::ResidualAxisymmetric(){
 
   if (Coord_i[1] > EPS) {
     
     su2double yinv = 1.0/Coord_i[1];
     
     /*--- Residual Convection ---*/
-    Residual[0] -= yinv*Volume*beta_star*V_i[1]*Density_i*TurbVar_i[0];
-    Residual[1] -= yinv*Volume*beta_blended*V_i[1]*Density_i*TurbVar_i[1];
+    Residual[0] -= yinv*Volume*V_i[1]*Density_i*TurbVar_i[0];
+    Residual[1] -= yinv*Volume*V_i[1]*Density_i*TurbVar_i[1];
 
     if (implicit) {
      Jacobian_i[0][0] -= yinv*Volume*V_i[1];

--- a/SU2_CFD/src/numerics/turbulent/turb_sources.cpp
+++ b/SU2_CFD/src/numerics/turbulent/turb_sources.cpp
@@ -761,10 +761,13 @@ CSourcePieceWise_TurbSST::CSourcePieceWise_TurbSST(unsigned short val_nDim,
 
   incompressible = (config->GetKind_Regime() == INCOMPRESSIBLE);
   sustaining_terms = (config->GetKind_Turb_Model() == SST_SUST);
-  axisymmetric = (config->GetAxisymmetric() == YES);
+  implicit = (config->GetKind_TimeIntScheme_Flow() == EULER_IMPLICIT);
+  axisymmetric = config->GetAxisymmetric();
 
   /*--- Closure constants ---*/
   beta_star     = constants[6];
+  sigma_k_1     = constants[0];
+  sigma_k_1     = constants[1];
   sigma_omega_1 = constants[2];
   sigma_omega_2 = constants[3];
   beta_1        = constants[4];
@@ -777,9 +780,11 @@ CSourcePieceWise_TurbSST::CSourcePieceWise_TurbSST(unsigned short val_nDim,
   kAmb     = val_kine_Inf;
   omegaAmb = val_omega_Inf;
 
-  /*--- "Allocate" the Jacobian using the static buffer. ---*/
-  Jacobian_i[0] = Jacobian_Buffer;
-  Jacobian_i[1] = Jacobian_Buffer+2;
+  if (implicit) {
+    /*--- "Allocate" the Jacobian using the static buffer. ---*/
+    Jacobian_i[0] = Jacobian_Buffer;
+    Jacobian_i[1] = Jacobian_Buffer+2;
+  }
 
 }
 
@@ -817,92 +822,96 @@ CNumerics::ResidualType<> CSourcePieceWise_TurbSST::ComputeResidual(const CConfi
   }
 
   Residual[0] = 0.0;       Residual[1] = 0.0;
-  Jacobian_i[0][0] = 0.0;  Jacobian_i[0][1] = 0.0;
-  Jacobian_i[1][0] = 0.0;  Jacobian_i[1][1] = 0.0;
-
+  
+  if (implicit) {
+    Jacobian_i[0][0] = 0.0;  Jacobian_i[0][1] = 0.0;
+    Jacobian_i[1][0] = 0.0;  Jacobian_i[1][1] = 0.0;
+  }
+  
   /*--- Computation of blended constants for the source terms---*/
 
   alfa_blended = F1_i*alfa_1 + (1.0 - F1_i)*alfa_2;
   beta_blended = F1_i*beta_1 + (1.0 - F1_i)*beta_2;
 
   if (dist_i > 1e-10) {
-
-   /*--- Production ---*/
-
-   diverg = 0.0;
-   for (iDim = 0; iDim < nDim; iDim++)
-     diverg += PrimVar_Grad_i[iDim+1][iDim];
-
-   /* if using UQ methodolgy, calculate production using perturbed Reynolds stress matrix */
-
-   if (using_uq){
-     ComputePerturbedRSM(nDim, Eig_Val_Comp, uq_permute, uq_delta_b, uq_urlx,
-                         PrimVar_Grad_i+1, Density_i, Eddy_Viscosity_i,
-                         TurbVar_i[0], MeanPerturbedRSM);
-     SetPerturbedStrainMag(TurbVar_i[0]);
-     pk = Eddy_Viscosity_i*PerturbedStrainMag*PerturbedStrainMag
-          - 2.0/3.0*Density_i*TurbVar_i[0]*diverg;
-   }
-   else {
-     pk = Eddy_Viscosity_i*StrainMag_i*StrainMag_i - 2.0/3.0*Density_i*TurbVar_i[0]*diverg;
-   }
-
-
-   pk = min(pk,20.0*beta_star*Density_i*TurbVar_i[1]*TurbVar_i[0]);
-   pk = max(pk,0.0);
-
-   zeta = max(TurbVar_i[1], VorticityMag*F2_i/a1);
-
-   /* if using UQ methodolgy, calculate production using perturbed Reynolds stress matrix */
-
-   if (using_uq){
-     pw = PerturbedStrainMag * PerturbedStrainMag - 2.0/3.0*zeta*diverg;
-   }
-   else {
-     pw = StrainMag_i*StrainMag_i - 2.0/3.0*zeta*diverg;
-   }
-   pw = alfa_blended*Density_i*max(pw,0.0);
-
-   /*--- Sustaining terms, if desired. Note that if the production terms are
-         larger equal than the sustaining terms, the original formulation is
-         obtained again. This is in contrast to the version in literature
-         where the sustaining terms are simply added. This latter approach could
-         lead to problems for very big values of the free-stream turbulence
-         intensity. ---*/
-
-   if ( sustaining_terms ) {
-     const su2double sust_k = beta_star*Density_i*kAmb*omegaAmb;
-     const su2double sust_w = beta_blended*Density_i*omegaAmb*omegaAmb;
-
-     pk = max(pk, sust_k);
-     pw = max(pw, sust_w);
-   }
-
-   /*--- Add the production terms to the residuals. ---*/
-
-   Residual[0] += pk*Volume;
-   Residual[1] += pw*Volume;
-
-   /*--- Dissipation ---*/
-
-   Residual[0] -= beta_star*Density_i*TurbVar_i[1]*TurbVar_i[0]*Volume;
-   Residual[1] -= beta_blended*Density_i*TurbVar_i[1]*TurbVar_i[1]*Volume;
-
-   /*--- Cross diffusion ---*/
-
-   Residual[1] += (1.0 - F1_i)*CDkw_i*Volume;
-
-   /*--- Implicit part ---*/
-
-   Jacobian_i[0][0] = -beta_star*TurbVar_i[1]*Volume;
-   Jacobian_i[0][1] = -beta_star*TurbVar_i[0]*Volume;
-   Jacobian_i[1][0] = 0.0;
-   Jacobian_i[1][1] = -2.0*beta_blended*TurbVar_i[1]*Volume;
+    
+    /*--- Production ---*/
+    
+    diverg = 0.0;
+    for (iDim = 0; iDim < nDim; iDim++)
+      diverg += PrimVar_Grad_i[iDim+1][iDim];
+    
+    /* if using UQ methodolgy, calculate production using perturbed Reynolds stress matrix */
+    
+    if (using_uq){
+      ComputePerturbedRSM(nDim, Eig_Val_Comp, uq_permute, uq_delta_b, uq_urlx,
+                          PrimVar_Grad_i+1, Density_i, Eddy_Viscosity_i,
+                          TurbVar_i[0], MeanPerturbedRSM);
+      SetPerturbedStrainMag(TurbVar_i[0]);
+      pk = Eddy_Viscosity_i*PerturbedStrainMag*PerturbedStrainMag
+           - 2.0/3.0*Density_i*TurbVar_i[0]*diverg;
+    }
+    else {
+      pk = Eddy_Viscosity_i*StrainMag_i*StrainMag_i - 2.0/3.0*Density_i*TurbVar_i[0]*diverg;
+    }
+    
+    pk = min(pk,20.0*beta_star*Density_i*TurbVar_i[1]*TurbVar_i[0]);
+    pk = max(pk,0.0);
+    
+    zeta = max(TurbVar_i[1], VorticityMag*F2_i/a1);
+    
+    /* if using UQ methodolgy, calculate production using perturbed Reynolds stress matrix */
+    
+    if (using_uq){
+      pw = PerturbedStrainMag * PerturbedStrainMag - 2.0/3.0*zeta*diverg;
+    }
+    else {
+      pw = StrainMag_i*StrainMag_i - 2.0/3.0*zeta*diverg;
+    }
+    pw = alfa_blended*Density_i*max(pw,0.0);
+    
+    /*--- Sustaining terms, if desired. Note that if the production terms are
+          larger equal than the sustaining terms, the original formulation is
+          obtained again. This is in contrast to the version in literature
+          where the sustaining terms are simply added. This latter approach could
+          lead to problems for very big values of the free-stream turbulence
+          intensity. ---*/
+    
+    if ( sustaining_terms ) {
+      const su2double sust_k = beta_star*Density_i*kAmb*omegaAmb;
+      const su2double sust_w = beta_blended*Density_i*omegaAmb*omegaAmb;
+    
+      pk = max(pk, sust_k);
+      pw = max(pw, sust_w);
+    }
+    
+    /*--- Add the production terms to the residuals. ---*/
+    
+    Residual[0] += pk*Volume;
+    Residual[1] += pw*Volume;
+    
+    /*--- Dissipation ---*/
+    
+    Residual[0] -= beta_star*Density_i*TurbVar_i[1]*TurbVar_i[0]*Volume;
+    Residual[1] -= beta_blended*Density_i*TurbVar_i[1]*TurbVar_i[1]*Volume;
+    
+    /*--- Cross diffusion ---*/
+    
+    Residual[1] += (1.0 - F1_i)*CDkw_i*Volume;
+    
+    /*--- Implicit part ---*/
+    
+    if (implicit) {
+     Jacobian_i[0][0] = -beta_star*TurbVar_i[1]*Volume;
+     Jacobian_i[0][1] = -beta_star*TurbVar_i[0]*Volume;
+     Jacobian_i[1][0] = 0.0;
+     Jacobian_i[1][1] = -2.0*beta_blended*TurbVar_i[1]*Volume;
+    }
   }
   
   /*--- Contribution due to 2D axisymmetric formulation ---*/
   
-  if (axisymmetric) ResidualAxisymmetric();
+  if (axisymmetric) ResidualAxisymmetric(beta_blended);
 
   AD::SetPreaccOut(Residual, nVar);
   AD::EndPreacc();
@@ -928,8 +937,29 @@ void CSourcePieceWise_TurbSST::SetPerturbedStrainMag(su2double turb_ke){
 
 }
 
-void CSourcePieceWise_TurbSST::ResidualAxisymmetric(){
+void CSourcePieceWise_TurbSST::ResidualAxisymmetric(su2double beta_blended){
 
-	//TODO Axisym source terms 
+  if (Coord_i[1] > EPS) {
+    
+    su2double yinv = 1.0/Coord_i[1];
+    
+    /*--- Residual Convection ---*/
+    Residual[0] -= yinv*Volume*beta_star*V_i[1]*Density_i*TurbVar_i[0];
+    Residual[1] -= yinv*Volume*beta_blended*V_i[1]*Density_i*TurbVar_i[1];
+
+    if (implicit) {
+     Jacobian_i[0][0] -= yinv*Volume*V_i[1];
+     Jacobian_i[1][1] -= yinv*Volume*V_i[1];
+    }
+    
+    /*--- Compute the blended constant for the viscous terms ---*/
+    su2double sigma_k_i = F1_i*sigma_k_1 + (1.0 - F1_i)*sigma_k_2;
+    su2double sigma_omega_i = F1_i*sigma_omega_1 + (1.0 - F1_i)*sigma_omega_2;
+    
+    /*--- Residual Diffusion ---*/
+    Residual[0] += yinv*Volume*(Laminar_Viscosity_i+sigma_k_i*Eddy_Viscosity_i)*TurbVar_Grad_i[0][1];
+    Residual[1] += yinv*Volume*(Laminar_Viscosity_i+sigma_omega_i*Eddy_Viscosity_i)*TurbVar_Grad_i[1][1];
+    
+  }
 
 }

--- a/SU2_CFD/src/numerics/turbulent/turb_sources.cpp
+++ b/SU2_CFD/src/numerics/turbulent/turb_sources.cpp
@@ -764,16 +764,16 @@ CSourcePieceWise_TurbSST::CSourcePieceWise_TurbSST(unsigned short val_nDim,
   axisymmetric = config->GetAxisymmetric();
 
   /*--- Closure constants ---*/
-  beta_star     = constants[6];
   sigma_k_1     = constants[0];
   sigma_k_2     = constants[1];
-  sigma_omega_1 = constants[2];
-  sigma_omega_2 = constants[3];
+  sigma_w_1     = constants[2];
+  sigma_w_2     = constants[3];
   beta_1        = constants[4];
   beta_2        = constants[5];
+  beta_star     = constants[6];
+  a1            = constants[7];
   alfa_1        = constants[8];
   alfa_2        = constants[9];
-  a1            = constants[7];
 
   /*--- Set the ambient values of k and omega to the free stream values. ---*/
   kAmb     = val_kine_Inf;
@@ -848,7 +848,6 @@ CNumerics::ResidualType<> CSourcePieceWise_TurbSST::ComputeResidual(const CConfi
    else {
      pk = Eddy_Viscosity_i*StrainMag_i*StrainMag_i - 2.0/3.0*Density_i*TurbVar_i[0]*diverg;
    }
-
 
    pk = min(pk,20.0*beta_star*Density_i*TurbVar_i[1]*TurbVar_i[0]);
    pk = max(pk,0.0);

--- a/SU2_CFD/src/numerics/turbulent/turb_sources.cpp
+++ b/SU2_CFD/src/numerics/turbulent/turb_sources.cpp
@@ -767,7 +767,7 @@ CSourcePieceWise_TurbSST::CSourcePieceWise_TurbSST(unsigned short val_nDim,
   /*--- Closure constants ---*/
   beta_star     = constants[6];
   sigma_k_1     = constants[0];
-  sigma_k_1     = constants[1];
+  sigma_k_2     = constants[1];
   sigma_omega_1 = constants[2];
   sigma_omega_2 = constants[3];
   beta_1        = constants[4];

--- a/SU2_CFD/src/numerics/turbulent/turb_sources.cpp
+++ b/SU2_CFD/src/numerics/turbulent/turb_sources.cpp
@@ -761,6 +761,7 @@ CSourcePieceWise_TurbSST::CSourcePieceWise_TurbSST(unsigned short val_nDim,
 
   incompressible = (config->GetKind_Regime() == INCOMPRESSIBLE);
   sustaining_terms = (config->GetKind_Turb_Model() == SST_SUST);
+  axisymmetric = (config->GetAxisymmetric() == YES);
 
   /*--- Closure constants ---*/
   beta_star     = constants[6];
@@ -898,6 +899,10 @@ CNumerics::ResidualType<> CSourcePieceWise_TurbSST::ComputeResidual(const CConfi
    Jacobian_i[1][0] = 0.0;
    Jacobian_i[1][1] = -2.0*beta_blended*TurbVar_i[1]*Volume;
   }
+  
+  /*--- Contribution due to 2D axisymmetric formulation ---*/
+  
+  if (axisymmetric) ResidualAxisymmetric();
 
   AD::SetPreaccOut(Residual, nVar);
   AD::EndPreacc();
@@ -920,5 +925,11 @@ void CSourcePieceWise_TurbSST::SetPerturbedStrainMag(su2double turb_ke){
     }
   }
   PerturbedStrainMag = sqrt(2.0*PerturbedStrainMag);
+
+}
+
+void CSourcePieceWise_TurbSST::ResidualAxisymmetric(){
+
+	//TODO Axisym source terms 
 
 }

--- a/SU2_CFD/src/numerics/turbulent/turb_sources.cpp
+++ b/SU2_CFD/src/numerics/turbulent/turb_sources.cpp
@@ -912,7 +912,7 @@ CNumerics::ResidualType<> CSourcePieceWise_TurbSST::ComputeResidual(const CConfi
   return ResidualType<>(Residual, Jacobian_i, nullptr);
 
 }
-  
+
 void CSourcePieceWise_TurbSST::SetPerturbedStrainMag(su2double turb_ke){
 
   /*--- Compute norm of perturbed strain rate tensor. ---*/

--- a/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
+++ b/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
@@ -322,6 +322,8 @@ void CTurbSSTSolver::Postprocessing(CGeometry *geometry, CSolver **solver_contai
 
 void CTurbSSTSolver::Source_Residual(CGeometry *geometry, CSolver **solver_container,
                                      CNumerics **numerics_container, CConfig *config, unsigned short iMesh) {
+                                       
+  bool axisymmetric = config->GetAxisymmetric();
 
   CVariable* flowNodes = solver_container[FLOW_SOL]->GetNodes();
 
@@ -372,6 +374,11 @@ void CTurbSSTSolver::Source_Residual(CGeometry *geometry, CSolver **solver_conta
 
     numerics->SetCrossDiff(nodes->GetCrossDiff(iPoint),0.0);
 
+    if (axisymmetric){
+      /*--- Set y coordinate ---*/
+      numerics->SetCoord(geometry->nodes->GetCoord(iPoint), geometry->nodes->GetCoord(iPoint));
+    }
+    
     /*--- Compute the source term ---*/
 
     auto residual = numerics->ComputeResidual(config);

--- a/TestCases/axisymmetric_rans/air_nozzle/air_nozzle.cfg
+++ b/TestCases/axisymmetric_rans/air_nozzle/air_nozzle.cfg
@@ -132,15 +132,6 @@ MUSCL_FLOW= YES
 % Slope limiter (NONE, VENKATAKRISHNAN, VENKATAKRISHNAN_WANG,
 %                BARTH_JESPERSEN, VAN_ALBADA_EDGE)
 SLOPE_LIMITER_FLOW= NONE
-% 
-%Coefficient for the Venkat's limiter (upwind scheme). A larger values decrease
-%             the extent of limiting, values approaching zero cause
-%             lower-order approximation to the solution (0.05 by default)
-VENKAT_LIMITER_COEFF= 0.05
-%
-% Monotonic Upwind Scheme for Conservation Laws (TVD) in the turbulence equations.
-%           Required for 2nd order upwind schemes (NO, YES)
-MUSCL_TURB= NO
 
 % ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
 %
@@ -165,24 +156,6 @@ LINEAR_SOLVER_ITER= 10
 %
 % Multi-grid levels (0 = no multi-grid)
 MGLEVEL= 0
-%
-% Multi-grid cycle (V_CYCLE, W_CYCLE, FULLMG_CYCLE)
-MGCYCLE= V_CYCLE
-%
-% Multi-grid pre-smoothing level
-MG_PRE_SMOOTH= ( 1, 2, 3, 3 )
-%
-% Multi-grid post-smoothing level
-MG_POST_SMOOTH= ( 0, 0, 0, 0 )
-%
-% Jacobi implicit smoothing of the correction
-MG_CORRECTION_SMOOTH= ( 0, 0, 0, 0 )
-%
-% Damping factor for the residual restriction
-MG_DAMP_RESTRICTION= 0.75
-%
-% Damping factor for the correction prolongation
-MG_DAMP_PROLONGATION= 0.75
 
 % -------------------- FLOW NUMERICAL METHOD DEFINITION -----------------------%
 %
@@ -231,23 +204,8 @@ MESH_FILENAME= nozzle.su2
 % Mesh input file format (SU2, CGNS)
 MESH_FORMAT= SU2
 %
-% Mesh output file
-MESH_OUT_FILENAME= mesh_out.su2
-%
 % Restart flow input file
 SOLUTION_FILENAME= solution_flow.dat
-%
-% Output file convergence history (w/o extension)
-CONV_FILENAME= history
-%
-% Output file restart flow
-RESTART_FILENAME= restart_flow.dat
-%
-% Output file flow (w/o extension) variables
-VOLUME_FILENAME= flow
-%
-% Output file surface flow coefficient (w/o extension)
-SURFACE_FILENAME= surface_flow
 %
 % Writing solution file frequency
 OUTPUT_WRT_FREQ= 1000

--- a/TestCases/axisymmetric_rans/air_nozzle/air_nozzle.cfg
+++ b/TestCases/axisymmetric_rans/air_nozzle/air_nozzle.cfg
@@ -1,0 +1,256 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                              %
+% SU2 configuration file                                                       %
+% Case description: Axisymmetric supersonic converging-diverging air nozzle    %
+% Author: Florian Dittmann                                                     %
+% Date: 2021.12.02                                                             %
+% File Version 7.10 "Blackbird"                                                %
+%                                                                              %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% ------------- DIRECT, ADJOINT, AND LINEARIZED PROBLEM DEFINITION ------------%
+%
+% Physical governing equations (EULER, NAVIER_STOKES,
+%                               FEM_EULER, FEM_NAVIER_STOKES, FEM_RANS, FEM_LES,
+%                               WAVE_EQUATION, HEAT_EQUATION, FEM_ELASTICITY,
+%                               POISSON_EQUATION)
+SOLVER= RANS
+%
+% Specify turbulence model (NONE, SA, SA_NEG, SST, SA_E, SA_COMP, SA_E_COMP)
+KIND_TURB_MODEL= SST
+%
+% Mathematical problem (DIRECT, CONTINUOUS_ADJOINT, DISCRETE_ADJOINT)
+MATH_PROBLEM= DIRECT
+%
+% Restart solution (NO, YES)
+RESTART_SOL= YES
+%
+% System of measurements (SI, US)
+% International system of units (SI): ( meters, kilograms, Kelvins,
+%                                       Newtons = kg m/s^2, Pascals = N/m^2,
+%                                       Density = kg/m^3, Speed = m/s,
+%                                       Equiv. Area = m^2 )
+% United States customary units (US): ( inches, slug, Rankines, lbf = slug ft/s^2,
+%                                       psf = lbf/ft^2, Density = slug/ft^3,
+%                                       Speed = ft/s, Equiv. Area = ft^2 )
+SYSTEM_MEASUREMENTS= SI
+%
+AXISYMMETRIC= YES
+%
+% -------------------- COMPRESSIBLE FREE-STREAM DEFINITION --------------------%
+%
+% Mach number (non-dimensional, based on the free-stream values)
+MACH_NUMBER= 1E-9
+%
+% Angle of attack (degrees, only for compressible flows)
+AOA= 0.0
+%
+% Side-slip angle (degrees, only for compressible flows)
+SIDESLIP_ANGLE= 0.0
+%
+% Init option to choose between Reynolds (default) or thermodynamics quantities
+% for initializing the solution (REYNOLDS, TD_CONDITIONS)
+INIT_OPTION= TD_CONDITIONS
+%
+% Free-stream option to choose between density and temperature (default) for
+% initializing the solution (TEMPERATURE_FS, DENSITY_FS)
+FREESTREAM_OPTION= TEMPERATURE_FS
+%
+% Free-stream pressure (101325.0 N/m^2, 2116.216 psf by default)
+FREESTREAM_PRESSURE= 1400000
+%
+% Free-stream temperature (288.15 K, 518.67 R by default)
+FREESTREAM_TEMPERATURE= 373.15
+%
+% Compressible flow non-dimensionalization (DIMENSIONAL, FREESTREAM_PRESS_EQ_ONE,
+%                              FREESTREAM_VEL_EQ_MACH, FREESTREAM_VEL_EQ_ONE)
+REF_DIMENSIONALIZATION= DIMENSIONAL
+
+% ---- IDEAL GAS, POLYTROPIC, VAN DER WAALS AND PENG ROBINSON CONSTANTS -------%
+%
+% Fluid model (STANDARD_AIR, IDEAL_GAS, VW_GAS, PR_GAS,
+%              CONSTANT_DENSITY, INC_IDEAL_GAS, INC_IDEAL_GAS_POLY)
+FLUID_MODEL= STANDARD_AIR
+
+% --------------------------- VISCOSITY MODEL ---------------------------------%
+%
+% Viscosity model (SUTHERLAND, CONSTANT_VISCOSITY, POLYNOMIAL_VISCOSITY).
+VISCOSITY_MODEL= CONSTANT_VISCOSITY
+%
+% Molecular Viscosity that would be constant (1.716E-5 by default)
+MU_CONSTANT= 1.716E-5 
+
+% --------------------------- THERMAL CONDUCTIVITY MODEL ----------------------%
+%
+% Laminar Conductivity model (CONSTANT_CONDUCTIVITY, CONSTANT_PRANDTL,
+% POLYNOMIAL_CONDUCTIVITY).
+CONDUCTIVITY_MODEL= CONSTANT_PRANDTL
+%
+% Laminar Prandtl number (0.72 (air), only for CONSTANT_PRANDTL)
+PRANDTL_LAM= 0.72
+%
+% Turbulent Prandtl number (0.9 (air) by default)
+PRANDTL_TURB= 0.90
+
+% -------------------- BOUNDARY CONDITION DEFINITION --------------------------%
+%
+% Navier-Stokes (no-slip), constant heat flux wall  marker(s) (NONE = no marker)
+% Format: ( marker name, constant heat flux (J/m^2), ... )
+MARKER_HEATFLUX= ( WALL, 0.0 )
+%
+% Symmetry boundary marker(s) (NONE = no marker)
+MARKER_SYM= ( SYMMETRY )
+%
+% Riemann boundary marker(s) (NONE = no marker)
+% Format: (marker, data kind flag, list of data)
+MARKER_RIEMANN= ( INFLOW, TOTAL_CONDITIONS_PT, 1400000.0, 373.15, 1.0, 0.0, 0.0, OUTFLOW, STATIC_PRESSURE, 100000.0, 0.0, 0.0, 0.0, 0.0 )
+
+% ------------- COMMON PARAMETERS DEFINING THE NUMERICAL METHOD ---------------%
+%
+% Numerical method for spatial gradients (GREEN_GAUSS, WEIGHTED_LEAST_SQUARES)
+NUM_METHOD_GRAD= GREEN_GAUSS
+%
+% CFL number (initial value for the adaptive CFL number)
+CFL_NUMBER= 1000.0
+%
+% Adaptive CFL number (NO, YES)
+CFL_ADAPT= NO
+%
+% Parameters of the adaptive CFL number (factor down, factor up, CFL min value,
+%                                        CFL max value )
+CFL_ADAPT_PARAM= ( 0.1, 2.0, 10.0, 1000.0 )
+%
+% Maximum Delta Time in local time stepping simulations
+MAX_DELTA_TIME= 1E6
+
+% ----------- SLOPE LIMITER AND DISSIPATION SENSOR DEFINITION -----------------%
+%
+% Monotonic Upwind Scheme for Conservation Laws (TVD) in the flow equations.
+%           Required for 2nd order upwind schemes (NO, YES)
+MUSCL_FLOW= YES
+%
+% Slope limiter (NONE, VENKATAKRISHNAN, VENKATAKRISHNAN_WANG,
+%                BARTH_JESPERSEN, VAN_ALBADA_EDGE)
+SLOPE_LIMITER_FLOW= NONE
+% 
+%Coefficient for the Venkat's limiter (upwind scheme). A larger values decrease
+%             the extent of limiting, values approaching zero cause
+%             lower-order approximation to the solution (0.05 by default)
+VENKAT_LIMITER_COEFF= 0.05
+%
+% Monotonic Upwind Scheme for Conservation Laws (TVD) in the turbulence equations.
+%           Required for 2nd order upwind schemes (NO, YES)
+MUSCL_TURB= NO
+
+% ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
+%
+% Linear solver or smoother for implicit formulations (BCGSTAB, FGMRES, SMOOTHER_JACOBI,
+%                                                      SMOOTHER_ILU, SMOOTHER_LUSGS,
+%                                                      SMOOTHER_LINELET)
+LINEAR_SOLVER= FGMRES
+%
+% Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
+LINEAR_SOLVER_PREC= ILU
+%
+% Linael solver ILU preconditioner fill-in level (0 by default)
+LINEAR_SOLVER_ILU_FILL_IN= 0
+%
+% Minimum error of the linear solver for implicit formulations
+LINEAR_SOLVER_ERROR= 0.01
+%
+% Max number of iterations of the linear solver for the implicit formulation
+LINEAR_SOLVER_ITER= 10
+
+% -------------------------- MULTIGRID PARAMETERS -----------------------------%
+%
+% Multi-grid levels (0 = no multi-grid)
+MGLEVEL= 0
+%
+% Multi-grid cycle (V_CYCLE, W_CYCLE, FULLMG_CYCLE)
+MGCYCLE= V_CYCLE
+%
+% Multi-grid pre-smoothing level
+MG_PRE_SMOOTH= ( 1, 2, 3, 3 )
+%
+% Multi-grid post-smoothing level
+MG_POST_SMOOTH= ( 0, 0, 0, 0 )
+%
+% Jacobi implicit smoothing of the correction
+MG_CORRECTION_SMOOTH= ( 0, 0, 0, 0 )
+%
+% Damping factor for the residual restriction
+MG_DAMP_RESTRICTION= 0.75
+%
+% Damping factor for the correction prolongation
+MG_DAMP_PROLONGATION= 0.75
+
+% -------------------- FLOW NUMERICAL METHOD DEFINITION -----------------------%
+%
+% Convective numerical method (JST, LAX-FRIEDRICH, CUSP, ROE, AUSM, AUSMPLUSUP, AUSMPLUSUP2, HLLC,
+%                              TURKEL_PREC, MSW, FDS)
+CONV_NUM_METHOD_FLOW= ROE
+%
+% Entropy fix coefficient (0.0 implies no entropy fixing, 1.0 implies scalar
+%                          artificial dissipation)
+ENTROPY_FIX_COEFF= 0.1
+%
+% Time discretization (RUNGE-KUTTA_EXPLICIT, EULER_IMPLICIT, EULER_EXPLICIT)
+TIME_DISCRE_FLOW= EULER_IMPLICIT
+%
+
+% -------------------- TURBULENT NUMERICAL METHOD DEFINITION ------------------%
+%
+% Convective numerical method (SCALAR_UPWIND)
+CONV_NUM_METHOD_TURB= SCALAR_UPWIND
+%
+% Time discretization (EULER_IMPLICIT)
+TIME_DISCRE_TURB= EULER_IMPLICIT
+%
+% Reduction factor of the CFL coefficient in the turbulence problem
+CFL_REDUCTION_TURB= 1.0
+
+% --------------------------- CONVERGENCE PARAMETERS --------------------------%
+%
+% Number of total iterations
+ITER= 1000
+%
+% Convergence criteria (CAUCHY, RESIDUAL)
+CONV_CRITERIA= RESIDUAL
+%
+% Min value of the residual (log10 of the residual)
+CONV_RESIDUAL_MINVAL= -12
+%
+% Start convergence criteria at iteration number
+CONV_STARTITER= 10
+
+% ------------------------- INPUT/OUTPUT INFORMATION --------------------------%
+%
+% Mesh input file
+MESH_FILENAME= nozzle.su2
+%
+% Mesh input file format (SU2, CGNS)
+MESH_FORMAT= SU2
+%
+% Mesh output file
+MESH_OUT_FILENAME= mesh_out.su2
+%
+% Restart flow input file
+SOLUTION_FILENAME= solution_flow.dat
+%
+% Output file convergence history (w/o extension)
+CONV_FILENAME= history
+%
+% Output file restart flow
+RESTART_FILENAME= restart_flow.dat
+%
+% Output file flow (w/o extension) variables
+VOLUME_FILENAME= flow
+%
+% Output file surface flow coefficient (w/o extension)
+SURFACE_FILENAME= surface_flow
+%
+% Writing solution file frequency
+OUTPUT_WRT_FREQ= 1000
+%
+% Screen output
+SCREEN_OUTPUT= (INNER_ITER, RMS_DENSITY, RMS_ENERGY, RMS_TKE, RMS_DISSIPATION)

--- a/TestCases/hybrid_regression.py
+++ b/TestCases/hybrid_regression.py
@@ -210,6 +210,18 @@ def main():
     propeller.test_vals = [-3.389576, -8.409529, 0.000048, 0.056329]
     test_list.append(propeller)
 
+    #######################################
+    ### Axisymmetric Compressible RANS  ###
+    #######################################
+    
+    # Axisymmetric air nozzle (transonic)
+    axi_rans_air_nozzle           = TestCase('axi_rans_air_nozzle')
+    axi_rans_air_nozzle.cfg_dir   = "axisymmetric_rans/air_nozzle"
+    axi_rans_air_nozzle.cfg_file  = "air_nozzle.cfg"
+    axi_rans_air_nozzle.test_iter = 10
+    axi_rans_air_nozzle.test_vals = [-12.094937, -6.622043, -8.814412, -2.393288]
+    test_list.append(axi_rans_air_nozzle)
+
     #################################
     ## Compressible RANS Restart  ###
     #################################

--- a/TestCases/parallel_regression.py
+++ b/TestCases/parallel_regression.py
@@ -347,6 +347,21 @@ def main():
     propeller.tol       = 0.00001
     test_list.append(propeller)
 
+    #######################################
+    ### Axisymmetric Compressible RANS  ###
+    #######################################
+    
+    # Axisymmetric air nozzle (transonic)
+    axi_rans_air_nozzle           = TestCase('axi_rans_air_nozzle')
+    axi_rans_air_nozzle.cfg_dir   = "axisymmetric_rans/air_nozzle"
+    axi_rans_air_nozzle.cfg_file  = "air_nozzle.cfg"
+    axi_rans_air_nozzle.test_iter = 10
+    axi_rans_air_nozzle.test_vals = [ -12.096569, -6.625843, -8.807541, -2.393279]
+    axi_rans_air_nozzle.su2_exec  = "mpirun -n 2 SU2_CFD"
+    axi_rans_air_nozzle.timeout   = 1600
+    axi_rans_air_nozzle.tol       = 0.0001
+    test_list.append(axi_rans_air_nozzle)
+
     #################################
     ## Compressible RANS Restart  ###
     #################################

--- a/TestCases/serial_regression.py
+++ b/TestCases/serial_regression.py
@@ -375,6 +375,21 @@ def main():
     propeller.tol       = 0.00001
     test_list.append(propeller)
 
+    #######################################
+    ### Axisymmetric Compressible RANS  ###
+    #######################################
+    
+    # Axisymmetric air nozzle (transonic)
+    axi_rans_air_nozzle           = TestCase('axi_rans_air_nozzle')
+    axi_rans_air_nozzle.cfg_dir   = "axisymmetric_rans/air_nozzle"
+    axi_rans_air_nozzle.cfg_file  = "air_nozzle.cfg"
+    axi_rans_air_nozzle.test_iter = 10
+    axi_rans_air_nozzle.test_vals = [ -12.093130, -6.619801, -8.806060, -2.393278]
+    axi_rans_air_nozzle.su2_exec  = "SU2_CFD"
+    axi_rans_air_nozzle.timeout   = 1600
+    axi_rans_air_nozzle.tol       = 0.0001
+    test_list.append(axi_rans_air_nozzle)
+
     #################################
     ## Compressible RANS Restart  ###
     #################################


### PR DESCRIPTION
This implements the k-omega SST source terms for 2D axisymmetric problems in a new member function of the existing source term class (it would never be used independently of it so I did not create a new class). There are some minor changes to the existing source term residual function like using that `TWO3` instead of `2.0/3.0`.

The extra source terms are the difference between the equations in 2D cartesian and 3D cylindrical coordinates under an assumption of axisymmetry without swirl. They are almost the same as those for Wilcox's k-omega shown in this image (taken from http://eprints.gla.ac.uk/184394/1/184394.pdf). 
![kwcyl](https://user-images.githubusercontent.com/55834287/107506869-056e0300-6b9f-11eb-834b-f82d6b502690.png)
Only the constants have been swapped for the blended ones and the changed definition of the eddy viscosity is taken into account (see [menter1994.pdf](https://github.com/su2code/SU2/files/5957873/menter1994.pdf)). Cross diffusion is the same as in 2D when assuming there is no azimuth gradient.

Note that these source terms have the opposite sign (RHS) of the flow equations source terms (LHS) since the block is subtracted and not added.

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags, or simply --warnlevel=2 when using meson).
- [x] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.

Looking into creating an axisymmetric RANS test/regression case