### PR TITLE
Fix on wall distance calculation from symmetry plane of mesh deformation

### DIFF
--- a/SU2_CFD/src/solvers/CMeshSolver.cpp
+++ b/SU2_CFD/src/solvers/CMeshSolver.cpp
@@ -298,7 +298,7 @@ void CMeshSolver::SetWallDistance(CGeometry *geometry, CConfig *config) {
 
   unsigned long nVertex_SolidWall = 0;
   for(auto iMarker=0u; iMarker<config->GetnMarker_All(); ++iMarker) {
-    if(config->GetSolid_Wall(iMarker)) {
+    if(config->GetSolid_Wall(iMarker) && !config->GetMarker_All_Deform_Mesh_Sym_Plane(iMarker)) {
       nVertex_SolidWall += geometry->GetnVertex(iMarker);
     }
   }
@@ -315,7 +315,7 @@ void CMeshSolver::SetWallDistance(CGeometry *geometry, CConfig *config) {
 
   for (unsigned long iMarker=0, ii=0, jj=0; iMarker<config->GetnMarker_All(); ++iMarker) {
 
-    if (!config->GetSolid_Wall(iMarker)) continue;
+    if (!config->GetSolid_Wall(iMarker) && !config->GetMarker_All_Deform_Mesh_Sym_Plane(iMarker)) continue;
 
     for (auto iVertex=0u; iVertex<geometry->GetnVertex(iMarker); ++iVertex) {
       auto iPoint = geometry->vertex[iMarker][iVertex]->GetNode();

--- a/SU2_CFD/src/solvers/CMeshSolver.cpp
+++ b/SU2_CFD/src/solvers/CMeshSolver.cpp
@@ -315,7 +315,7 @@ void CMeshSolver::SetWallDistance(CGeometry *geometry, CConfig *config) {
 
   for (unsigned long iMarker=0, ii=0, jj=0; iMarker<config->GetnMarker_All(); ++iMarker) {
 
-    if (!config->GetSolid_Wall(iMarker) && !config->GetMarker_All_Deform_Mesh_Sym_Plane(iMarker)) continue;
+    if (!config->GetSolid_Wall(iMarker) || config->GetMarker_All_Deform_Mesh_Sym_Plane(iMarker)) continue;
 
     for (auto iVertex=0u; iVertex<geometry->GetnVertex(iMarker); ++iVertex) {
       auto iPoint = geometry->vertex[iMarker][iVertex]->GetNode();


### PR DESCRIPTION
## Proposed Changes

In the calculation of the stiffness for the mesh deformation, if the symmetry plane for the deformation is too stiff, cells may get distorted and the simulation may crash.

This occurred when the wall distance stiffness was used, and the symmetry plane for the deformation was also a solid wall boundary. This small fix should avoid the issue.

## PR Checklist

- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags, or simply --warnlevel=2 when using meson).
- [X] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
