### PR TITLE
fix typo Linael -> Linear

### DIFF
--- a/TestCases/axisymmetric_rans/air_nozzle/air_nozzle.cfg
+++ b/TestCases/axisymmetric_rans/air_nozzle/air_nozzle.cfg
@@ -143,7 +143,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/cont_adj_euler/naca0012/inv_NACA0012.cfg
+++ b/TestCases/cont_adj_euler/naca0012/inv_NACA0012.cfg
@@ -112,7 +112,7 @@ LINEAR_SOLVER_ERROR= 1E-6
 % Max number of iterations of the linear solver for the implicit formulation
 LINEAR_SOLVER_ITER= 5
 %
-% Linael solver ILU preconditioner fill-in level (1 by default)
+% Linear solver ILU preconditioner fill-in level (1 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 
 % -------------------------- MULTIGRID PARAMETERS -----------------------------%

--- a/TestCases/cont_adj_euler/naca0012/inv_NACA0012_FD.cfg
+++ b/TestCases/cont_adj_euler/naca0012/inv_NACA0012_FD.cfg
@@ -110,7 +110,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (1 by default)
+% Linear solver ILU preconditioner fill-in level (1 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 
 % -------------------------- MULTIGRID PARAMETERS -----------------------------%

--- a/TestCases/cont_adj_euler/wedge/inv_wedge_ROE_multiobj.cfg
+++ b/TestCases/cont_adj_euler/wedge/inv_wedge_ROE_multiobj.cfg
@@ -112,7 +112,7 @@ LINEAR_SOLVER_ITER= 5
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (1 by default)
+% Linear solver ILU preconditioner fill-in level (1 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 
 

--- a/TestCases/coupled_cht/comp_2d/flow_cylinder.cfg
+++ b/TestCases/coupled_cht/comp_2d/flow_cylinder.cfg
@@ -97,7 +97,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/coupled_cht/comp_2d/solid_cylinder1.cfg
+++ b/TestCases/coupled_cht/comp_2d/solid_cylinder1.cfg
@@ -89,7 +89,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/coupled_cht/comp_2d/solid_cylinder2.cfg
+++ b/TestCases/coupled_cht/comp_2d/solid_cylinder2.cfg
@@ -98,7 +98,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/coupled_cht/comp_2d/solid_cylinder3.cfg
+++ b/TestCases/coupled_cht/comp_2d/solid_cylinder3.cfg
@@ -98,7 +98,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/coupled_cht/disc_adj_incomp_2d/flow_cylinder.cfg
+++ b/TestCases/coupled_cht/disc_adj_incomp_2d/flow_cylinder.cfg
@@ -151,7 +151,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/coupled_cht/disc_adj_incomp_2d/solid_cylinder1.cfg
+++ b/TestCases/coupled_cht/disc_adj_incomp_2d/solid_cylinder1.cfg
@@ -89,7 +89,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/coupled_cht/disc_adj_incomp_2d/solid_cylinder2.cfg
+++ b/TestCases/coupled_cht/disc_adj_incomp_2d/solid_cylinder2.cfg
@@ -98,7 +98,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/coupled_cht/disc_adj_incomp_2d/solid_cylinder3.cfg
+++ b/TestCases/coupled_cht/disc_adj_incomp_2d/solid_cylinder3.cfg
@@ -98,7 +98,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/coupled_cht/incomp_2d/flow_cylinder.cfg
+++ b/TestCases/coupled_cht/incomp_2d/flow_cylinder.cfg
@@ -148,7 +148,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/coupled_cht/incomp_2d/solid_cylinder1.cfg
+++ b/TestCases/coupled_cht/incomp_2d/solid_cylinder1.cfg
@@ -89,7 +89,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/coupled_cht/incomp_2d/solid_cylinder2.cfg
+++ b/TestCases/coupled_cht/incomp_2d/solid_cylinder2.cfg
@@ -98,7 +98,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/coupled_cht/incomp_2d/solid_cylinder3.cfg
+++ b/TestCases/coupled_cht/incomp_2d/solid_cylinder3.cfg
@@ -98,7 +98,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/coupled_cht/incomp_2d_unsteady/flow_cylinder.cfg
+++ b/TestCases/coupled_cht/incomp_2d_unsteady/flow_cylinder.cfg
@@ -135,7 +135,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/coupled_cht/incomp_2d_unsteady/solid_cylinder1.cfg
+++ b/TestCases/coupled_cht/incomp_2d_unsteady/solid_cylinder1.cfg
@@ -76,7 +76,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/coupled_cht/incomp_2d_unsteady/solid_cylinder2.cfg
+++ b/TestCases/coupled_cht/incomp_2d_unsteady/solid_cylinder2.cfg
@@ -76,7 +76,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/coupled_cht/incomp_2d_unsteady/solid_cylinder3.cfg
+++ b/TestCases/coupled_cht/incomp_2d_unsteady/solid_cylinder3.cfg
@@ -76,7 +76,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/disc_adj_euler/arina2k/Arina2KRS.cfg
+++ b/TestCases/disc_adj_euler/arina2k/Arina2KRS.cfg
@@ -288,7 +288,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= LU_SGS
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/disc_adj_euler/cylinder3D/inv_cylinder3D.cfg
+++ b/TestCases/disc_adj_euler/cylinder3D/inv_cylinder3D.cfg
@@ -206,7 +206,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/disc_adj_incomp_navierstokes/cylinder/heated_cylinder.cfg
+++ b/TestCases/disc_adj_incomp_navierstokes/cylinder/heated_cylinder.cfg
@@ -212,7 +212,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/disc_adj_incomp_rans/naca0012/turb_naca0012_sa.cfg
+++ b/TestCases/disc_adj_incomp_rans/naca0012/turb_naca0012_sa.cfg
@@ -131,7 +131,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (JACOBI, LINELET, LU_SGS)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/disc_adj_incomp_rans/naca0012/turb_naca0012_sst.cfg
+++ b/TestCases/disc_adj_incomp_rans/naca0012/turb_naca0012_sst.cfg
@@ -131,7 +131,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (JACOBI, LINELET, LU_SGS)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/incomp_euler/nozzle/inv_nozzle.cfg
+++ b/TestCases/incomp_euler/nozzle/inv_nozzle.cfg
@@ -119,7 +119,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/incomp_navierstokes/buoyancy_cavity/lam_buoyancy_cavity.cfg
+++ b/TestCases/incomp_navierstokes/buoyancy_cavity/lam_buoyancy_cavity.cfg
@@ -144,7 +144,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (JACOBI, LINELET, LU_SGS)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Min error of the linear solver for the implicit formulation

--- a/TestCases/incomp_navierstokes/cylinder/poly_cylinder.cfg
+++ b/TestCases/incomp_navierstokes/cylinder/poly_cylinder.cfg
@@ -195,7 +195,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/incomp_rans/rough_flatplate/rough_flatplate_incomp.cfg
+++ b/TestCases/incomp_rans/rough_flatplate/rough_flatplate_incomp.cfg
@@ -155,7 +155,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (JACOBI, LINELET, LU_SGS)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/mms/fvm_incomp_euler/inv_mms_jst.cfg
+++ b/TestCases/mms/fvm_incomp_euler/inv_mms_jst.cfg
@@ -111,7 +111,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (JACOBI, LINELET, LU_SGS)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/mms/fvm_incomp_navierstokes/lam_mms_fds.cfg
+++ b/TestCases/mms/fvm_incomp_navierstokes/lam_mms_fds.cfg
@@ -129,7 +129,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (JACOBI, LINELET, LU_SGS)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/mms/fvm_navierstokes/lam_mms_roe.cfg
+++ b/TestCases/mms/fvm_navierstokes/lam_mms_roe.cfg
@@ -146,7 +146,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (JACOBI, LINELET, LU_SGS)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/optimization_euler/multiobjective_wedge/inv_wedge_ROE_2surf_1obj.cfg
+++ b/TestCases/optimization_euler/multiobjective_wedge/inv_wedge_ROE_2surf_1obj.cfg
@@ -111,7 +111,7 @@ LINEAR_SOLVER_ITER= 5
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (1 by default)
+% Linear solver ILU preconditioner fill-in level (1 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 
 

--- a/TestCases/optimization_euler/multiobjective_wedge/inv_wedge_ROE_multiobj.cfg
+++ b/TestCases/optimization_euler/multiobjective_wedge/inv_wedge_ROE_multiobj.cfg
@@ -112,7 +112,7 @@ LINEAR_SOLVER_ITER= 5
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (1 by default)
+% Linear solver ILU preconditioner fill-in level (1 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 
 

--- a/TestCases/optimization_euler/multiobjective_wedge/inv_wedge_ROE_multiobj_1surf.cfg
+++ b/TestCases/optimization_euler/multiobjective_wedge/inv_wedge_ROE_multiobj_1surf.cfg
@@ -112,7 +112,7 @@ LINEAR_SOLVER_ITER= 5
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (1 by default)
+% Linear solver ILU preconditioner fill-in level (1 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 
 

--- a/TestCases/optimization_euler/multiobjective_wedge/inv_wedge_ROE_multiobj_combo.cfg
+++ b/TestCases/optimization_euler/multiobjective_wedge/inv_wedge_ROE_multiobj_combo.cfg
@@ -114,7 +114,7 @@ LINEAR_SOLVER_ITER= 5
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (1 by default)
+% Linear solver ILU preconditioner fill-in level (1 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 
 

--- a/TestCases/py_wrapper/flatPlate_rigidMotion/flatPlate_rigidMotion_Conf.cfg
+++ b/TestCases/py_wrapper/flatPlate_rigidMotion/flatPlate_rigidMotion_Conf.cfg
@@ -355,7 +355,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/TestCases/py_wrapper/flatPlate_unsteady_CHT/unsteady_CHT_FlatPlate_Conf.cfg
+++ b/TestCases/py_wrapper/flatPlate_unsteady_CHT/unsteady_CHT_FlatPlate_Conf.cfg
@@ -335,7 +335,7 @@ LINEAR_SOLVER= FGMRES
 % Preconditioner of the Krylov linear solver (ILU, LU_SGS, LINELET, JACOBI)
 LINEAR_SOLVER_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -1019,7 +1019,7 @@ LINEAR_SOLVER_PREC= ILU
 % Same for discrete adjoint (JACOBI or ILU), replaces LINEAR_SOLVER_PREC in SU2_*_AD codes.
 DISCADJ_LIN_PREC= ILU
 %
-% Linael solver ILU preconditioner fill-in level (0 by default)
+% Linear solver ILU preconditioner fill-in level (0 by default)
 LINEAR_SOLVER_ILU_FILL_IN= 0
 %
 % Minimum error of the linear solver for implicit formulations


### PR DESCRIPTION
## Proposed Changes
Description of `LINEAR_SOLVER_ILU_FILL_IN` wrote Linael instead of Linear .. and that was copied quite a few times
Done using `find ./ -type -f -exec sed -i -e 's/Linael/Linear/g' {} \;` in ./Testcases on Linux

As in none of the appearances the option is not using the default of zero, that option could be removed from all those testcases imo, but I put that up to discussion. As @pcarruscag mentioned in #1195 `[...]simplify the config by removing options that are not needed, this is to make it easier to maintain the testcases if there are changes to some options.`

Feel free to chip any other typos here. 

## Related Work
Seen in #1195 and annoyed me enough to open a PR, but of course not introduced there

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags, or simply --warnlevel=2 when using meson).
- [x] My contribution is commented and consistent with SU2 style.
- [x] I have added a test case that demonstrates my contribution, if necessary.
- [x] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
