### PR TITLE
Strict compiler warning policy for CI builds

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -19,19 +19,19 @@ jobs:
         config_set: [BaseMPI, ReverseMPI, ForwardMPI, BaseNoMPI, ReverseNoMPI, ForwardNoMPI, BaseOMP]
         include:
           - config_set: BaseMPI
-            flags: '-Denable-pywrapper=true -Denable-tests=true --werror'
+            flags: '-Denable-pywrapper=true -Denable-tests=true --warnlevel=3 --werror'
           - config_set: ReverseMPI
-            flags: '-Denable-autodiff=true -Denable-normal=false -Denable-pywrapper=true -Denable-tests=true --werror'
+            flags: '-Denable-autodiff=true -Denable-normal=false -Denable-pywrapper=true -Denable-tests=true --warnlevel=3 --werror'
           - config_set: ForwardMPI
-            flags: '-Denable-directdiff=true -Denable-normal=false -Denable-tests=true --werror'
+            flags: '-Denable-directdiff=true -Denable-normal=false -Denable-tests=true --warnlevel=3 --werror'
           - config_set: BaseNoMPI
-            flags: '-Denable-pywrapper=true -Dwith-mpi=disabled -Denable-tests=true --werror'
+            flags: '-Denable-pywrapper=true -Dwith-mpi=disabled -Denable-tests=true --warnlevel=3 --werror'
           - config_set: ReverseNoMPI
-            flags: '-Denable-autodiff=true -Denable-normal=false -Dwith-mpi=disabled -Denable-pywrapper=true -Denable-tests=true --werror'
+            flags: '-Denable-autodiff=true -Denable-normal=false -Dwith-mpi=disabled -Denable-pywrapper=true -Denable-tests=true --warnlevel=3 --werror'
           - config_set: ForwardNoMPI
-            flags: '-Denable-directdiff=true -Denable-normal=false -Dwith-mpi=disabled  -Denable-tests=true --werror'
+            flags: '-Denable-directdiff=true -Denable-normal=false -Dwith-mpi=disabled -Denable-tests=true --warnlevel=3 --werror'
           - config_set: BaseOMP
-            flags: '-Dwith-omp=true -Denable-mixedprec=true -Denable-tecio=false --werror'
+            flags: '-Dwith-omp=true -Denable-mixedprec=true -Denable-tecio=false --warnlevel=3 --werror'
     runs-on: ubuntu-latest
     steps:
       - name: Cache Object Files

--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -4142,9 +4142,7 @@ void CConfig::SetPostprocessing(unsigned short val_software, unsigned short val_
   /* Check if the byte alignment of the matrix multiplications is a
      multiple of 64. */
   if( byteAlignmentMatMul%64 ) {
-    if(rank == MASTER_NODE)
-      cout << "ALIGNED_BYTES_MATMUL must be a multiple of 64." << endl;
-    exit(EXIT_FAILURE);
+    SU2_MPI::Error("ALIGNED_BYTES_MATMUL must be a multiple of 64.", CURRENT_FUNCTION);
   }
 
   /* Determine the value of sizeMatMulPadding, which is the matrix size in

--- a/SU2_CFD/include/numerics_simd/flow/diffusion/common.hpp
+++ b/SU2_CFD/include/numerics_simd/flow/diffusion/common.hpp
@@ -71,7 +71,7 @@ FORCEINLINE void correctGradient(const PrimitiveType& V,
  */
 template<size_t nVar, size_t nDim>
 FORCEINLINE MatrixDbl<nDim> stressTensor(Double viscosity,
-                                         const MatrixDbl<nVar,nDim> grad) {
+                                         const MatrixDbl<nVar,nDim>& grad) {
   /*--- Hydrostatic term. ---*/
   Double velDiv = 0.0;
   for (size_t iDim = 0; iDim < nDim; ++iDim) {
@@ -154,7 +154,7 @@ FORCEINLINE void addQCR(const MatrixType& grad, MatrixDbl<nDim>& tau) {
  */
 template<size_t nVar, size_t nDim, class PrimitiveType>
 FORCEINLINE MatrixDbl<nDim,nVar> stressTensorJacobian(const PrimitiveType& V,
-                                                      const VectorDbl<nDim> normal,
+                                                      const VectorDbl<nDim>& normal,
                                                       Double dist_ij) {
   Double viscosity = V.laminarVisc() + V.eddyVisc();
   Double xi = viscosity / (V.density() * dist_ij);

--- a/SU2_CFD/include/sgs_model.inl
+++ b/SU2_CFD/include/sgs_model.inl
@@ -6,7 +6,7 @@
  *
  * SU2 Project Website: https://su2code.github.io
  *
- * The SU2 Project is maintained by the SU2 Foundation 
+ * The SU2 Project is maintained by the SU2 Foundation
  * (http://su2foundation.org)
  *
  * Copyright 2012-2020, SU2 Contributors (cf. AUTHORS.md)
@@ -191,8 +191,7 @@ inline void CSmagorinskyModel::ComputeGradEddyViscosity_2D(const su2double rho,
                                                            const su2double distToWall,
                                                                  su2double &dMuTdx,
                                                                  su2double &dMuTdy) {
-  cout << "CSmagorinskyModel::ComputeGradEddyViscosity_2D: Not implemented yet" << endl;
-  exit(1);
+  SU2_MPI::Error("Not implemented yet", CURRENT_FUNCTION);
 }
 
 inline void CSmagorinskyModel::ComputeGradEddyViscosity_3D(const su2double rho,
@@ -231,8 +230,7 @@ inline void CSmagorinskyModel::ComputeGradEddyViscosity_3D(const su2double rho,
                                                                  su2double &dMuTdx,
                                                                  su2double &dMuTdy,
                                                                  su2double &dMuTdz) {
-  cout << "CSmagorinskyModel::ComputeGradEddyViscosity_3D: Not implemented yet" << endl;
-  exit(1);
+  SU2_MPI::Error("Not implemented yet", CURRENT_FUNCTION);
 }
 
 inline CWALEModel::CWALEModel(void) : CSGSModel() {
@@ -363,8 +361,7 @@ inline void CWALEModel::ComputeGradEddyViscosity_2D(const su2double rho,
                                                     const su2double distToWall,
                                                           su2double &dMuTdx,
                                                           su2double &dMuTdy) {
-  cout << "CWALEModel::ComputeGradEddyViscosity_2D: Not implemented yet" << endl;
-  exit(1);
+  SU2_MPI::Error("Not implemented yet", CURRENT_FUNCTION);
 }
 
 inline void CWALEModel::ComputeGradEddyViscosity_3D(const su2double rho,
@@ -403,12 +400,11 @@ inline void CWALEModel::ComputeGradEddyViscosity_3D(const su2double rho,
                                                           su2double &dMuTdx,
                                                           su2double &dMuTdy,
                                                           su2double &dMuTdz) {
-  cout << "CWALEModel::ComputeGradEddyViscosity_3D: Not implemented yet" << endl;
-  exit(1);
+  SU2_MPI::Error("Not implemented yet", CURRENT_FUNCTION);
 }
 
 inline CVremanModel::CVremanModel(void) : CSGSModel() {
-  
+
   /* const_Vreman = 2.5*Cs*Cs where Cs is the Smagorinsky constant */
   const_Vreman = 0.07;
 }
@@ -422,8 +418,8 @@ inline su2double CVremanModel::ComputeEddyViscosity_2D(const su2double rho,
                                                      const su2double dvdy,
                                                      const su2double lenScale,
                                                      const su2double distToWall) {
-  cout << "CVremanModel::ComputeEddyViscosity_2D: Not implemented yet" << endl;
-  exit(1);
+  SU2_MPI::Error("Not implemented yet", CURRENT_FUNCTION);
+  return 0;
 }
 
 inline su2double CVremanModel::ComputeEddyViscosity_3D(const su2double rho,
@@ -438,7 +434,7 @@ inline su2double CVremanModel::ComputeEddyViscosity_3D(const su2double rho,
                                                      const su2double dwdz,
                                                      const su2double lenScale,
                                                      const su2double distToWall) {
-  
+
   su2double alpha11 = dudx;
   su2double alpha22 = dvdy;
   su2double alpha33 = dwdz;
@@ -495,8 +491,7 @@ inline void CVremanModel::ComputeGradEddyViscosity_2D(const su2double rho,
                                                     const su2double distToWall,
                                                     su2double &dMuTdx,
                                                     su2double &dMuTdy) {
-  cout << "CWALEModel::ComputeGradEddyViscosity_2D: Not implemented yet" << endl;
-  exit(1);
+  SU2_MPI::Error("Not implemented yet", CURRENT_FUNCTION);
 }
 
 inline void CVremanModel::ComputeGradEddyViscosity_3D(const su2double rho,
@@ -535,6 +530,5 @@ inline void CVremanModel::ComputeGradEddyViscosity_3D(const su2double rho,
                                                     su2double &dMuTdx,
                                                     su2double &dMuTdy,
                                                     su2double &dMuTdz) {
-  cout << "CWALEModel::ComputeGradEddyViscosity_3D: Not implemented yet" << endl;
-  exit(1);
+  SU2_MPI::Error("Not implemented yet", CURRENT_FUNCTION);
 }

--- a/SU2_CFD/include/solvers/CEulerSolver.hpp
+++ b/SU2_CFD/include/solvers/CEulerSolver.hpp
@@ -43,42 +43,38 @@ protected:
   Prandtl_Lam = 0.0,    /*!< \brief Laminar Prandtl number. */
   Prandtl_Turb = 0.0;   /*!< \brief Turbulent Prandtl number. */
 
-  su2double
-  AllBound_CEquivArea_Inv = 0.0, /*!< \brief equivalent area coefficient (inviscid contribution) for all the boundaries. */
-  *CEquivArea_Mnt = nullptr,     /*!< \brief Equivalent area (inviscid contribution) for each boundary. */
-  *CEquivArea_Inv = nullptr;     /*!< \brief Equivalent area (inviscid contribution) for each boundary. */
+  su2double AllBound_CEquivArea_Inv=0.0; /*!< \brief equivalent area coefficient (inviscid contribution) for all the boundaries. */
+  vector<su2double> CEquivArea_Mnt;      /*!< \brief Equivalent area (inviscid contribution) for each boundary. */
+  vector<su2double> CEquivArea_Inv;      /*!< \brief Equivalent area (inviscid contribution) for each boundary. */
 
+  vector<su2double> Inflow_MassFlow;     /*!< \brief Mass flow rate for each boundary. */
+  vector<su2double> Exhaust_MassFlow;    /*!< \brief Mass flow rate for each boundary. */
+  vector<su2double> Inflow_Pressure;     /*!< \brief Fan face pressure for each boundary. */
+  vector<su2double> Inflow_Mach;         /*!< \brief Fan face mach number for each boundary. */
+  vector<su2double> Inflow_Area;         /*!< \brief Boundary total area. */
+  vector<su2double> Exhaust_Area;        /*!< \brief Boundary total area. */
+  vector<su2double> Exhaust_Pressure;    /*!< \brief Fan face pressure for each boundary. */
+  vector<su2double> Exhaust_Temperature; /*!< \brief Fan face mach number for each boundary. */
   su2double
-  *Inflow_MassFlow = nullptr,    /*!< \brief Mass flow rate for each boundary. */
-  *Exhaust_MassFlow = nullptr,   /*!< \brief Mass flow rate for each boundary. */
-  *Inflow_Pressure = nullptr,    /*!< \brief Fan face pressure for each boundary. */
-  *Inflow_Mach = nullptr,        /*!< \brief Fan face mach number for each boundary. */
-  *Inflow_Area = nullptr,        /*!< \brief Boundary total area. */
-  *Exhaust_Area = nullptr,       /*!< \brief Boundary total area. */
-  *Exhaust_Pressure = nullptr,   /*!< \brief Fan face pressure for each boundary. */
-  *Exhaust_Temperature = nullptr,/*!< \brief Fan face mach number for each boundary. */
   Inflow_MassFlow_Total = 0.0,   /*!< \brief Mass flow rate for each boundary. */
   Exhaust_MassFlow_Total = 0.0,  /*!< \brief Mass flow rate for each boundary. */
   Inflow_Pressure_Total = 0.0,   /*!< \brief Fan face pressure for each boundary. */
   Inflow_Mach_Total = 0.0,       /*!< \brief Fan face mach number for each boundary. */
   InverseDesign = 0.0;           /*!< \brief Inverse design functional for each boundary. */
-  unsigned long
-  **DonorGlobalIndex = nullptr;  /*!< \brief Value of the donor global index. */
-  su2double
-  ***DonorPrimVar = nullptr,     /*!< \brief Value of the donor variables at each boundary. */
-  **ActDisk_DeltaP = nullptr,    /*!< \brief Value of the Delta P. */
-  **ActDisk_DeltaT = nullptr;    /*!< \brief Value of the Delta T. */
+  vector<vector<unsigned long> > DonorGlobalIndex;  /*!< \brief Value of the donor global index. */
+  vector<su2activematrix> DonorPrimVar;       /*!< \brief Value of the donor variables at each boundary. */
+  vector<vector<su2double> > ActDisk_DeltaP;  /*!< \brief Value of the Delta P. */
+  vector<vector<su2double> > ActDisk_DeltaT;  /*!< \brief Value of the Delta T. */
 
   su2activevector
   ActDisk_R;         /*!< \brief Value of the actuator disk Radius. */
   su2activematrix
   ActDisk_C,         /*!< \brief Value of the actuator disk Center. */
   ActDisk_Axis;      /*!< \brief Value of the actuator disk Axis. */
-  su2double
-  **ActDisk_Fa,        /*!< \brief Value of the actuator disk Axial Force per Unit Area. */
-  **ActDisk_Fx,        /*!< \brief Value of the actuator disk X component of the radial and tangential forces per Unit Area resultant. */
-  **ActDisk_Fy,        /*!< \brief Value of the actuator disk Y component of the radial and tangential forces per Unit Area resultant. */
-  **ActDisk_Fz;        /*!< \brief Value of the actuator disk Z component of the radial and tangential forces per Unit Area resultant. */
+  vector<vector<su2double> > ActDisk_Fa; /*!< \brief Value of the actuator disk Axial Force per Unit Area. */
+  vector<vector<su2double> > ActDisk_Fx; /*!< \brief Value of the actuator disk X component of the radial and tangential forces per Unit Area resultant. */
+  vector<vector<su2double> > ActDisk_Fy; /*!< \brief Value of the actuator disk Y component of the radial and tangential forces per Unit Area resultant. */
+  vector<vector<su2double> > ActDisk_Fz; /*!< \brief Value of the actuator disk Z component of the radial and tangential forces per Unit Area resultant. */
 
   su2double
   Total_CL_Prev = 0.0,        /*!< \brief Total lift coefficient for all the boundaries (fixed lift mode). */

--- a/SU2_CFD/include/solvers/CFVMFlowSolverBase.hpp
+++ b/SU2_CFD/include/solvers/CFVMFlowSolverBase.hpp
@@ -166,7 +166,7 @@ class CFVMFlowSolverBase : public CSolver {
 
   /*--- Sliding meshes variables ---*/
 
-  su2double**** SlidingState = nullptr;
+  vector<su2matrix<su2double*> > SlidingState; // vector of matrix of pointers... inner dim alloc'd elsewhere (welcome, to the twilight zone)
   vector<vector<int> > SlidingStateNodes;
 
   /*--- Shallow copy of grid coloring for OpenMP parallelization. ---*/

--- a/SU2_CFD/include/solvers/CFVMFlowSolverBase.hpp
+++ b/SU2_CFD/include/solvers/CFVMFlowSolverBase.hpp
@@ -137,28 +137,28 @@ class CFVMFlowSolverBase : public CSolver {
   su2double Total_Heat = 0.0;           /*!< \brief Total heat load for all the boundaries. */
   su2double Total_MaxHeat = 0.0;        /*!< \brief Maximum heat flux on all boundaries. */
   su2double AllBound_CNearFieldOF_Inv = 0.0; /*!< \brief Near-Field press coeff (inviscid) for all the boundaries. */
-  su2double* CNearFieldOF_Inv = nullptr;     /*!< \brief Near field pressure (inviscid) for each boundary. */
-  su2double* Surface_HF_Visc = nullptr;      /*!< \brief Total (integrated) heat flux for each monitored surface. */
-  su2double* Surface_MaxHF_Visc = nullptr;   /*!< \brief Maximum heat flux for each monitored surface. */
-  su2double* HF_Visc = nullptr;              /*!< \brief Heat load (viscous contribution) for each boundary. */
-  su2double* MaxHF_Visc = nullptr;           /*!< \brief Maximum heat flux (viscous contribution) for each boundary. */
-  su2double AllBound_HF_Visc = 0.0;          /*!< \brief Heat load (viscous contribution) for all the boundaries. */
-  su2double AllBound_MaxHF_Visc = 0.0;       /*!< \brief Maximum heat flux (viscous contribution) for all boundaries. */
+  vector<su2double> CNearFieldOF_Inv;    /*!< \brief Near field pressure (inviscid) for each boundary. */
+  vector<su2double> Surface_HF_Visc;     /*!< \brief Total (integrated) heat flux for each monitored surface. */
+  vector<su2double> Surface_MaxHF_Visc;  /*!< \brief Maximum heat flux for each monitored surface. */
+  vector<su2double> HF_Visc;             /*!< \brief Heat load (viscous contribution) for each boundary. */
+  vector<su2double> MaxHF_Visc;          /*!< \brief Maximum heat flux (viscous contribution) for each boundary. */
+  su2double AllBound_HF_Visc = 0.0;      /*!< \brief Heat load (viscous contribution) for all the boundaries. */
+  su2double AllBound_MaxHF_Visc = 0.0;   /*!< \brief Maximum heat flux (viscous contribution) for all boundaries. */
 
-  su2double** Inlet_Ptotal = nullptr;      /*!< \brief Value of the Total P. */
-  su2double** Inlet_Ttotal = nullptr;      /*!< \brief Value of the Total T. */
-  su2double*** Inlet_FlowDir = nullptr;    /*!< \brief Value of the Flow Direction. */
-  su2double** HeatFlux = nullptr;          /*!< \brief Heat transfer coefficient for each boundary and vertex. */
-  su2double** HeatFluxTarget = nullptr;    /*!< \brief Heat transfer coefficient for each boundary and vertex. */
-  su2double*** CharacPrimVar = nullptr;    /*!< \brief Value of the characteristic variables at each boundary. */
-  su2double*** CSkinFriction = nullptr;    /*!< \brief Skin friction coefficient for each boundary and vertex. */
-  su2double** WallShearStress = nullptr;   /*!< \brief Wall Shear Stress for each boundary and vertex. */
-  su2double*** HeatConjugateVar = nullptr; /*!< \brief CHT variables for each boundary and vertex. */
-  su2double** CPressure = nullptr;         /*!< \brief Pressure coefficient for each boundary and vertex. */
-  su2double** CPressureTarget = nullptr;   /*!< \brief Target Pressure coefficient for each boundary and vertex. */
-  su2double** YPlus = nullptr;             /*!< \brief Yplus for each boundary and vertex. */
+  vector<vector<su2double> > Inlet_Ptotal;      /*!< \brief Value of the Total P. */
+  vector<vector<su2double> > Inlet_Ttotal;      /*!< \brief Value of the Total T. */
+  vector<su2activematrix> Inlet_FlowDir;        /*!< \brief Value of the Flow Direction. */
+  vector<vector<su2double> > HeatFlux;          /*!< \brief Heat transfer coefficient for each boundary and vertex. */
+  vector<vector<su2double> > HeatFluxTarget;    /*!< \brief Heat transfer coefficient for each boundary and vertex. */
+  vector<su2activematrix> CharacPrimVar;        /*!< \brief Value of the characteristic variables at each boundary. */
+  vector<su2activematrix> CSkinFriction;        /*!< \brief Skin friction coefficient for each boundary and vertex. */
+  vector<vector<su2double> > WallShearStress;   /*!< \brief Wall Shear Stress for each boundary and vertex. */
+  vector<su2activematrix> HeatConjugateVar;     /*!< \brief CHT variables for each boundary and vertex. */
+  vector<vector<su2double> > CPressure;         /*!< \brief Pressure coefficient for each boundary and vertex. */
+  vector<vector<su2double> > CPressureTarget;   /*!< \brief Target Pressure coefficient for each boundary and vertex. */
+  vector<vector<su2double> > YPlus;             /*!< \brief Yplus for each boundary and vertex. */
 
-  bool space_centered;       /*!< \brief True if space centered scheeme used. */
+  bool space_centered;       /*!< \brief True if space centered scheme used. */
   bool euler_implicit;       /*!< \brief True if euler implicit scheme used. */
   bool least_squares;        /*!< \brief True if computing gradients by least squares. */
   su2double Gamma;           /*!< \brief Fluid's Gamma constant (ratio of specific heats). */
@@ -167,7 +167,7 @@ class CFVMFlowSolverBase : public CSolver {
   /*--- Sliding meshes variables ---*/
 
   su2double**** SlidingState = nullptr;
-  int** SlidingStateNodes = nullptr;
+  vector<vector<int> > SlidingStateNodes;
 
   /*--- Shallow copy of grid coloring for OpenMP parallelization. ---*/
 
@@ -2193,7 +2193,7 @@ class CFVMFlowSolverBase : public CSolver {
    * \param[in] val_vertex - Vertex of the marker <i>val_marker</i> where the coefficient is evaluated.
    * \return Value of the pressure coefficient.
    */
-  inline su2double* GetCharacPrimVar(unsigned short val_marker, unsigned long val_vertex) const final {
+  inline su2double* GetCharacPrimVar(unsigned short val_marker, unsigned long val_vertex) final {
     return CharacPrimVar[val_marker][val_vertex];
   }
 
@@ -2251,8 +2251,6 @@ class CFVMFlowSolverBase : public CSolver {
      * checking to prevent segmentation faults ---*/
     if (val_marker >= nMarker)
       SU2_MPI::Error("Out-of-bounds marker index used on inlet.", CURRENT_FUNCTION);
-    else if (Inlet_Ttotal == nullptr || Inlet_Ttotal[val_marker] == nullptr)
-      SU2_MPI::Error("Tried to set custom inlet BC on an invalid marker.", CURRENT_FUNCTION);
     else if (val_vertex >= nVertex[val_marker])
       SU2_MPI::Error("Out-of-bounds vertex index used on inlet.", CURRENT_FUNCTION);
     else
@@ -2270,8 +2268,6 @@ class CFVMFlowSolverBase : public CSolver {
      * checking to prevent segmentation faults ---*/
     if (val_marker >= nMarker)
       SU2_MPI::Error("Out-of-bounds marker index used on inlet.", CURRENT_FUNCTION);
-    else if (Inlet_Ptotal == nullptr || Inlet_Ptotal[val_marker] == nullptr)
-      SU2_MPI::Error("Tried to set custom inlet BC on an invalid marker.", CURRENT_FUNCTION);
     else if (val_vertex >= nVertex[val_marker])
       SU2_MPI::Error("Out-of-bounds vertex index used on inlet.", CURRENT_FUNCTION);
     else
@@ -2291,8 +2287,6 @@ class CFVMFlowSolverBase : public CSolver {
      * checking to prevent segmentation faults ---*/
     if (val_marker >= nMarker)
       SU2_MPI::Error("Out-of-bounds marker index used on inlet.", CURRENT_FUNCTION);
-    else if (Inlet_FlowDir == nullptr || Inlet_FlowDir[val_marker] == nullptr)
-      SU2_MPI::Error("Tried to set custom inlet BC on an invalid marker.", CURRENT_FUNCTION);
     else if (val_vertex >= nVertex[val_marker])
       SU2_MPI::Error("Out-of-bounds vertex index used on inlet.", CURRENT_FUNCTION);
     else

--- a/SU2_CFD/include/solvers/CFVMFlowSolverBase.hpp
+++ b/SU2_CFD/include/solvers/CFVMFlowSolverBase.hpp
@@ -180,7 +180,7 @@ class CFVMFlowSolverBase : public CSolver {
   static constexpr bool ReducerStrategy = false;
 #endif
 
-  /*--- Edge fluxes, for OpenMP parallelization off difficult-to-color grids.
+  /*--- Edge fluxes, for OpenMP parallelization of difficult-to-color grids.
    * We first store the fluxes and then compute the sum for each cell.
    * This strategy is thread-safe but lower performance than writting to both
    * end points of each edge, so we only use it when necessary, i.e. when the

--- a/SU2_CFD/include/solvers/CFVMFlowSolverBase.inl
+++ b/SU2_CFD/include/solvers/CFVMFlowSolverBase.inl
@@ -85,7 +85,7 @@ void CFVMFlowSolverBase<V, R>::AeroCoeffsArray::setZero(int i) {
 template <class V, ENUM_REGIME R>
 void CFVMFlowSolverBase<V, R>::Allocate(const CConfig& config) {
   unsigned short iVar;
-  unsigned long iPoint, iMarker;
+  unsigned long iMarker;
 
   /*--- Define some auxiliar vector related with the residual ---*/
 
@@ -173,16 +173,13 @@ void CFVMFlowSolverBase<V, R>::Allocate(const CConfig& config) {
 
   /*--- Initializate quantities for SlidingMesh Interface ---*/
 
-  SlidingState = new su2double***[nMarker]();
+  SlidingState.resize(nMarker);
   SlidingStateNodes.resize(nMarker);
 
   for (iMarker = 0; iMarker < nMarker; iMarker++) {
     if (config.GetMarker_All_KindBC(iMarker) == FLUID_INTERFACE) {
-      SlidingState[iMarker] = new su2double**[nVertex[iMarker]]();
+      SlidingState[iMarker].resize(nVertex[iMarker], nPrimVar+1) = nullptr;
       SlidingStateNodes[iMarker].resize(nVertex[iMarker],0);
-
-      for (iPoint = 0; iPoint < nVertex[iMarker]; iPoint++)
-        SlidingState[iMarker][iPoint] = new su2double*[nPrimVar + 1]();
     }
   }
 
@@ -372,21 +369,9 @@ void CFVMFlowSolverBase<V, R>::HybridParallelInitialization(const CConfig& confi
 
 template <class V, ENUM_REGIME R>
 CFVMFlowSolverBase<V, R>::~CFVMFlowSolverBase() {
-  unsigned short iVar;
-  unsigned long iMarker, iVertex;
 
-  if (SlidingState != nullptr) {
-    for (iMarker = 0; iMarker < nMarker; iMarker++) {
-      if (SlidingState[iMarker] != nullptr) {
-        for (iVertex = 0; iVertex < nVertex[iMarker]; iVertex++)
-          if (SlidingState[iMarker][iVertex] != nullptr) {
-            for (iVar = 0; iVar < nPrimVar + 1; iVar++) delete[] SlidingState[iMarker][iVertex][iVar];
-            delete[] SlidingState[iMarker][iVertex];
-          }
-        delete[] SlidingState[iMarker];
-      }
-    }
-    delete[] SlidingState;
+  for (auto& mat : SlidingState) {
+    for (auto ptr : mat) delete [] ptr;
   }
 
   delete nodes;

--- a/SU2_CFD/include/solvers/CFVMFlowSolverBase.inl
+++ b/SU2_CFD/include/solvers/CFVMFlowSolverBase.inl
@@ -84,8 +84,8 @@ void CFVMFlowSolverBase<V, R>::AeroCoeffsArray::setZero(int i) {
 
 template <class V, ENUM_REGIME R>
 void CFVMFlowSolverBase<V, R>::Allocate(const CConfig& config) {
-  unsigned short iDim, iVar, iMarker;
-  unsigned long iPoint, iVertex;
+  unsigned short iVar;
+  unsigned long iPoint, iMarker;
 
   /*--- Define some auxiliar vector related with the residual ---*/
 
@@ -116,19 +116,16 @@ void CFVMFlowSolverBase<V, R>::Allocate(const CConfig& config) {
 
   /*--- Allocates a 2D array with variable "outer" sizes and init to 0. ---*/
 
-  auto Alloc2D = [](unsigned long M, const unsigned long* N, su2double**& X) {
-    X = new su2double*[M];
-    for (unsigned long i = 0; i < M; ++i) X[i] = new su2double[N[i]]();
+  auto Alloc2D = [](unsigned long M, const unsigned long* N, vector<vector<su2double> >& X) {
+    X.resize(M);
+    for (unsigned long i = 0; i < M; ++i) X[i].resize(N[i],0.0);
   };
 
   /*--- Allocates a 3D array with variable "middle" sizes and init to 0. ---*/
 
-  auto Alloc3D = [](unsigned long M, const unsigned long* N, unsigned long P, su2double***& X) {
-    X = new su2double**[M];
-    for (unsigned long i = 0; i < M; ++i) {
-      X[i] = new su2double*[N[i]];
-      for (unsigned long j = 0; j < N[i]; ++j) X[i][j] = new su2double[P]();
-    }
+  auto Alloc3D = [](unsigned long M, const unsigned long* N, unsigned long P, vector<su2activematrix>& X) {
+    X.resize(M);
+    for (unsigned long i = 0; i < M; ++i) X[i].resize(N[i],P) = su2double(0.0);
   };
 
   /*--- Store the value of the characteristic primitive variables at the boundaries ---*/
@@ -164,25 +161,25 @@ void CFVMFlowSolverBase<V, R>::Allocate(const CConfig& config) {
 
   /*--- Heat flux coefficients. ---*/
 
-  HF_Visc = new su2double[nMarker];
-  MaxHF_Visc = new su2double[nMarker];
+  HF_Visc.resize(nMarker,0.0);
+  MaxHF_Visc.resize(nMarker,0.0);
 
-  Surface_HF_Visc = new su2double[config.GetnMarker_Monitoring()];
-  Surface_MaxHF_Visc = new su2double[config.GetnMarker_Monitoring()];
+  Surface_HF_Visc.resize(config.GetnMarker_Monitoring());
+  Surface_MaxHF_Visc.resize(config.GetnMarker_Monitoring());
 
   /*--- Supersonic coefficients ---*/
 
-  CNearFieldOF_Inv = new su2double[nMarker];
+  CNearFieldOF_Inv.resize(nMarker,0.0);
 
   /*--- Initializate quantities for SlidingMesh Interface ---*/
 
   SlidingState = new su2double***[nMarker]();
-  SlidingStateNodes = new int*[nMarker]();
+  SlidingStateNodes.resize(nMarker);
 
   for (iMarker = 0; iMarker < nMarker; iMarker++) {
     if (config.GetMarker_All_KindBC(iMarker) == FLUID_INTERFACE) {
       SlidingState[iMarker] = new su2double**[nVertex[iMarker]]();
-      SlidingStateNodes[iMarker] = new int[nVertex[iMarker]]();
+      SlidingStateNodes[iMarker].resize(nVertex[iMarker],0);
 
       for (iPoint = 0; iPoint < nVertex[iMarker]; iPoint++)
         SlidingState[iMarker][iPoint] = new su2double*[nPrimVar + 1]();
@@ -200,13 +197,9 @@ void CFVMFlowSolverBase<V, R>::Allocate(const CConfig& config) {
 
   /*--- Skin friction in all the markers ---*/
 
-  CSkinFriction = new su2double**[nMarker];
-  for (iMarker = 0; iMarker < nMarker; iMarker++) {
-    CSkinFriction[iMarker] = new su2double*[nDim];
-    for (iDim = 0; iDim < nDim; iDim++) {
-      CSkinFriction[iMarker][iDim] = new su2double[nVertex[iMarker]]();
-    }
-  }
+  CSkinFriction.resize(nMarker);
+  for (iMarker = 0; iMarker < nMarker; iMarker++)
+    CSkinFriction[iMarker].resize(nDim, nVertex[iMarker]) = su2double(0.0);
 
   /*--- Wall Shear Stress in all the markers ---*/
 
@@ -216,14 +209,8 @@ void CFVMFlowSolverBase<V, R>::Allocate(const CConfig& config) {
    used for coupling with a solid donor cell ---*/
   constexpr auto nHeatConjugateVar = 4u;
 
-  HeatConjugateVar = new su2double**[nMarker];
-  for (iMarker = 0; iMarker < nMarker; iMarker++) {
-    HeatConjugateVar[iMarker] = new su2double*[nVertex[iMarker]];
-    for (iVertex = 0; iVertex < nVertex[iMarker]; iVertex++) {
-      HeatConjugateVar[iMarker][iVertex] = new su2double[nHeatConjugateVar]();
-      HeatConjugateVar[iMarker][iVertex][0] = config.GetTemperature_FreeStreamND();
-    }
-  }
+  Alloc3D(nMarker, nVertex, nHeatConjugateVar, HeatConjugateVar);
+  for (auto& x : HeatConjugateVar) x = config.GetTemperature_FreeStreamND();
 
   if (MGLevel == MESH_0) {
     VertexTraction.resize(nMarker);
@@ -385,14 +372,8 @@ void CFVMFlowSolverBase<V, R>::HybridParallelInitialization(const CConfig& confi
 
 template <class V, ENUM_REGIME R>
 CFVMFlowSolverBase<V, R>::~CFVMFlowSolverBase() {
-  unsigned short iMarker, iVar, iDim;
-  unsigned long iVertex;
-
-  delete[] CNearFieldOF_Inv;
-  delete[] HF_Visc;
-  delete[] MaxHF_Visc;
-  delete[] Surface_HF_Visc;
-  delete[] Surface_MaxHF_Visc;
+  unsigned short iVar;
+  unsigned long iMarker, iVertex;
 
   if (SlidingState != nullptr) {
     for (iMarker = 0; iMarker < nMarker; iMarker++) {
@@ -406,101 +387,6 @@ CFVMFlowSolverBase<V, R>::~CFVMFlowSolverBase() {
       }
     }
     delete[] SlidingState;
-  }
-
-  if (SlidingStateNodes != nullptr) {
-    for (iMarker = 0; iMarker < nMarker; iMarker++) {
-      if (SlidingStateNodes[iMarker] != nullptr) delete[] SlidingStateNodes[iMarker];
-    }
-    delete[] SlidingStateNodes;
-  }
-
-  if (CPressure != nullptr) {
-    for (iMarker = 0; iMarker < nMarker; iMarker++) delete[] CPressure[iMarker];
-    delete[] CPressure;
-  }
-
-  if (CPressureTarget != nullptr) {
-    for (iMarker = 0; iMarker < nMarker; iMarker++) delete[] CPressureTarget[iMarker];
-    delete[] CPressureTarget;
-  }
-
-  if (CharacPrimVar != nullptr) {
-    for (iMarker = 0; iMarker < nMarker; iMarker++) {
-      for (iVertex = 0; iVertex < nVertex[iMarker]; iVertex++) delete[] CharacPrimVar[iMarker][iVertex];
-      delete[] CharacPrimVar[iMarker];
-    }
-    delete[] CharacPrimVar;
-  }
-
-  if (Inlet_Ttotal != nullptr) {
-    for (iMarker = 0; iMarker < nMarker; iMarker++)
-      if (Inlet_Ttotal[iMarker] != nullptr) delete[] Inlet_Ttotal[iMarker];
-    delete[] Inlet_Ttotal;
-  }
-
-  if (Inlet_Ptotal != nullptr) {
-    for (iMarker = 0; iMarker < nMarker; iMarker++)
-      if (Inlet_Ptotal[iMarker] != nullptr) delete[] Inlet_Ptotal[iMarker];
-    delete[] Inlet_Ptotal;
-  }
-
-  if (Inlet_FlowDir != nullptr) {
-    for (iMarker = 0; iMarker < nMarker; iMarker++) {
-      if (Inlet_FlowDir[iMarker] != nullptr) {
-        for (iVertex = 0; iVertex < nVertex[iMarker]; iVertex++) delete[] Inlet_FlowDir[iMarker][iVertex];
-        delete[] Inlet_FlowDir[iMarker];
-      }
-    }
-    delete[] Inlet_FlowDir;
-  }
-
-  if (HeatFlux != nullptr) {
-    for (iMarker = 0; iMarker < nMarker; iMarker++) {
-      delete[] HeatFlux[iMarker];
-    }
-    delete[] HeatFlux;
-  }
-
-  if (HeatFluxTarget != nullptr) {
-    for (iMarker = 0; iMarker < nMarker; iMarker++) {
-      delete[] HeatFluxTarget[iMarker];
-    }
-    delete[] HeatFluxTarget;
-  }
-
-  if (YPlus != nullptr) {
-    for (iMarker = 0; iMarker < nMarker; iMarker++) {
-      delete[] YPlus[iMarker];
-    }
-    delete[] YPlus;
-  }
-
-  if (CSkinFriction != nullptr) {
-    for (iMarker = 0; iMarker < nMarker; iMarker++) {
-      for (iDim = 0; iDim < nDim; iDim++) {
-        delete[] CSkinFriction[iMarker][iDim];
-      }
-      delete[] CSkinFriction[iMarker];
-    }
-    delete[] CSkinFriction;
-  }
-
-  if (WallShearStress != nullptr) {
-    for (iMarker = 0; iMarker < nMarker; iMarker++) {
-      delete[] WallShearStress[iMarker];
-    }
-    delete[] WallShearStress;
-  }
-
-  if (HeatConjugateVar != nullptr) {
-    for (iMarker = 0; iMarker < nMarker; iMarker++) {
-      for (iVertex = 0; iVertex < nVertex[iMarker]; iVertex++) {
-        delete[] HeatConjugateVar[iMarker][iVertex];
-      }
-      delete[] HeatConjugateVar[iMarker];
-    }
-    delete[] HeatConjugateVar;
   }
 
   delete nodes;
@@ -2890,8 +2776,8 @@ void CFVMFlowSolverBase<V, FlowRegime>::Friction_Forces(const CGeometry* geometr
     Allreduce_inplace(nMarkerMon, SurfaceViscCoeff.CMy);
     Allreduce_inplace(nMarkerMon, SurfaceViscCoeff.CMz);
 
-    Allreduce_inplace(nMarkerMon, Surface_HF_Visc);
-    Allreduce_inplace(nMarkerMon, Surface_MaxHF_Visc);
+    Allreduce_inplace(nMarkerMon, Surface_HF_Visc.data());
+    Allreduce_inplace(nMarkerMon, Surface_MaxHF_Visc.data());
 
     delete[] buffer;
   }

--- a/SU2_CFD/include/solvers/CNEMONSSolver.hpp
+++ b/SU2_CFD/include/solvers/CNEMONSSolver.hpp
@@ -38,7 +38,6 @@
  * \brief Main class for defining the NEMO Navier-Stokes flow solver.
  * \ingroup Navier_Stokes_Equations
  * \author S. R. Copeland, F. Palacios, W. Maier.
- * \version 7.0.8
  *
  */
 class CNEMONSSolver final : public CNEMOEulerSolver {
@@ -46,10 +45,6 @@ private:
 
   su2double Prandtl_Lam,     /*!< \brief Laminar Prandtl number. */
   Prandtl_Turb;              /*!< \brief Turbulent Prandtl number. */
- 
-  su2double StrainMag_Max,
-  Omega_Max;                 /*!< \brief Maximum Strain Rate magnitude and Omega. */
-  su2double *primitives_aux; /*!< \brief Primitive auxiliary variables (Y_s, T, Tve, ...) in compressible flows. */
 
   /*!
    * \brief Compute the velocity^2, SoundSpeed, Pressure, Enthalpy, Viscosity.
@@ -77,7 +72,7 @@ public:
   /*!
    * \brief Destructor of the class.
    */
-  ~CNEMONSSolver(void) override;
+  ~CNEMONSSolver() = default;
 
   /*!
    * \brief Compute the gradient of the primitive variables using Green-Gauss method,

--- a/SU2_CFD/include/solvers/CNSSolver.hpp
+++ b/SU2_CFD/include/solvers/CNSSolver.hpp
@@ -37,11 +37,11 @@
  */
 class CNSSolver final : public CEulerSolver {
 private:
-  su2double
-  *Surface_Buffet_Metric = nullptr, /*!< \brief Integrated separation sensor for each monitoring surface. */
-  *Buffet_Metric = nullptr,         /*!< \brief Integrated separation sensor for each boundary. */
-  **Buffet_Sensor = nullptr,        /*!< \brief Separation sensor for each boundary and vertex. */
-  Total_Buffet_Metric = 0.0;        /*!< \brief Integrated separation sensor for all the boundaries. */
+
+  vector<su2double> Surface_Buffet_Metric;  /*!< \brief Integrated separation sensor for each monitoring surface. */
+  vector<su2double> Buffet_Metric;          /*!< \brief Integrated separation sensor for each boundary. */
+  vector<vector<su2double> > Buffet_Sensor; /*!< \brief Separation sensor for each boundary and vertex. */
+  su2double Total_Buffet_Metric = 0.0;      /*!< \brief Integrated separation sensor for all the boundaries. */
 
   /*!
    * \brief A virtual member.
@@ -131,7 +131,7 @@ public:
   /*!
    * \brief Destructor of the class.
    */
-  ~CNSSolver(void) override;
+  ~CNSSolver() = default;
 
   /*!
    * \brief Provide the buffet metric.

--- a/SU2_CFD/include/solvers/CSolver.hpp
+++ b/SU2_CFD/include/solvers/CSolver.hpp
@@ -2976,7 +2976,7 @@ public:
    * \return Value of the pressure coefficient.
    */
   inline virtual su2double *GetCharacPrimVar(unsigned short val_marker,
-                                             unsigned long val_vertex) const { return nullptr; }
+                                             unsigned long val_vertex) { return nullptr; }
 
   /*!
    * \brief A virtual member

--- a/SU2_CFD/include/solvers/CTurbSASolver.hpp
+++ b/SU2_CFD/include/solvers/CTurbSASolver.hpp
@@ -71,7 +71,7 @@ public:
   /*!
    * \brief Constructor of the class.
    */
-  CTurbSASolver(void);
+  CTurbSASolver();
 
   /*!
    * \overload
@@ -85,7 +85,7 @@ public:
   /*!
    * \brief Destructor of the class.
    */
-  ~CTurbSASolver(void) override;
+  ~CTurbSASolver() = default;
 
   /*!
    * \brief Restart residual and compute gradients.

--- a/SU2_CFD/include/solvers/CTurbSSTSolver.hpp
+++ b/SU2_CFD/include/solvers/CTurbSSTSolver.hpp
@@ -59,7 +59,7 @@ public:
   /*!
    * \brief Destructor of the class.
    */
-  ~CTurbSSTSolver(void) override;
+  ~CTurbSSTSolver() = default;
 
   /*!
    * \brief Restart residual and compute gradients.

--- a/SU2_CFD/include/solvers/CTurbSolver.hpp
+++ b/SU2_CFD/include/solvers/CTurbSolver.hpp
@@ -52,13 +52,13 @@ protected:
   lowerlimit[MAXNVAR] = {0.0},  /*!< \brief contains lower limits for turbulence variables. */
   upperlimit[MAXNVAR] = {0.0},  /*!< \brief contains upper limits for turbulence variables. */
   Gamma,                        /*!< \brief Fluid's Gamma constant (ratio of specific heats). */
-  Gamma_Minus_One,              /*!< \brief Fluids's Gamma - 1.0  . */
-  ***Inlet_TurbVars = nullptr;  /*!< \brief Turbulence variables at inlet profiles */
+  Gamma_Minus_One;              /*!< \brief Fluids's Gamma - 1.0  . */
+  vector<su2activematrix> Inlet_TurbVars;  /*!< \brief Turbulence variables at inlet profiles */
 
   /*--- Sliding meshes variables. ---*/
 
-  su2double ****SlidingState = nullptr;
-  int **SlidingStateNodes = nullptr;
+  vector<su2matrix<su2double*> > SlidingState; // vector of matrix of pointers... inner dim alloc'd elsewhere (welcome, to the twilight zone)
+  vector<vector<int> > SlidingStateNodes;
 
   /*--- Shallow copy of grid coloring for OpenMP parallelization. ---*/
 
@@ -371,8 +371,6 @@ public:
      * checking to prevent segmentation faults ---*/
     if (val_marker >= nMarker)
       SU2_MPI::Error("Out-of-bounds marker index used on inlet.", CURRENT_FUNCTION);
-    else if (Inlet_TurbVars == nullptr || Inlet_TurbVars[val_marker] == nullptr)
-      SU2_MPI::Error("Tried to set custom inlet BC on an invalid marker.", CURRENT_FUNCTION);
     else if (val_vertex >= nVertex[val_marker])
       SU2_MPI::Error("Out-of-bounds vertex index used on inlet.", CURRENT_FUNCTION);
     else if (val_dim >= nVar)

--- a/SU2_CFD/src/fluid/CNEMOGas.cpp
+++ b/SU2_CFD/src/fluid/CNEMOGas.cpp
@@ -37,16 +37,16 @@ CNEMOGas::CNEMOGas(const CConfig* config, unsigned short val_nDim): CFluidModel(
   MolarMass.resize(nSpecies,0.0);
   MolarFractions.resize(nSpecies,0.0);
   rhos.resize(nSpecies,0.0);
-  Cvtrs.resize(nSpecies,0.0);         
-  Cvves.resize(nSpecies,0.0);               
-  eves.resize(nSpecies,0.0);            
-  hs.resize(nSpecies,0.0);            
-  ws.resize(nSpecies,0.0);            
+  Cvtrs.resize(nSpecies,0.0);
+  Cvves.resize(nSpecies,0.0);
+  eves.resize(nSpecies,0.0);
+  hs.resize(nSpecies,0.0);
+  ws.resize(nSpecies,0.0);
   DiffusionCoeff.resize(nSpecies,0.0);
   Enthalpy_Formation.resize(nSpecies,0.0);
   Ref_Temperature.resize(nSpecies,0.0);
   temperatures.resize(nEnergyEq,0.0);
-  energies.resize(nEnergyEq,0.0);  
+  energies.resize(nEnergyEq,0.0);
   ThermalConductivities.resize(nEnergyEq,0.0);
 
   gas_model            = config->GetGasModel();
@@ -62,12 +62,12 @@ void CNEMOGas::SetTDStatePTTv(su2double val_pressure, const su2double *val_massf
   su2double denom;
 
   for (iSpecies = 0; iSpecies < nHeavy; iSpecies++)
-    MassFrac[iSpecies] = val_massfrac[iSpecies];                   
-  Pressure = val_pressure;                   
-  T        = val_temperature;                
-  Tve      = val_temperature_ve; 
-  
-  denom   = 0.0;   
+    MassFrac[iSpecies] = val_massfrac[iSpecies];
+  Pressure = val_pressure;
+  T        = val_temperature;
+  Tve      = val_temperature_ve;
+
+  denom   = 0.0;
 
   /*--- Calculate mixture density from supplied primitive quantities ---*/
   for (iSpecies = 0; iSpecies < nHeavy; iSpecies++)
@@ -79,7 +79,7 @@ void CNEMOGas::SetTDStatePTTv(su2double val_pressure, const su2double *val_massf
   for (iSpecies = 0; iSpecies < nSpecies; iSpecies++){
     rhos[iSpecies]     = MassFrac[iSpecies]*Density;
     MassFrac[iSpecies] = rhos[iSpecies]/Density;
-  } 
+  }
 }
 
 su2double CNEMOGas::ComputeSoundSpeed(){
@@ -87,7 +87,7 @@ su2double CNEMOGas::ComputeSoundSpeed(){
   su2double conc, rhoCvtr;
 
   conc    = 0.0;
-  rhoCvtr = 0.0; 
+  rhoCvtr = 0.0;
   Density = 0.0;
 
   auto& Cvtrs = GetSpeciesCvTraRot();
@@ -127,7 +127,7 @@ su2double CNEMOGas::ComputeGasConstant(){
   for (iSpecies = 0; iSpecies < nHeavy; iSpecies++)
     Mass += MassFrac[iSpecies] * MolarMass[iSpecies];
   GasConstant = Ru / Mass;
- 
+
   return GasConstant;
 }
 
@@ -166,8 +166,7 @@ void CNEMOGas::ComputedPdU(su2double *V, vector<su2double>& val_eves, su2double 
   su2double CvtrBAR, rhoCvtr, rhoCvve, rho_el, sqvel, conc, ef;
 
   if (val_dPdU == NULL) {
-    cout << "ERROR: CNEMOGas - CalcdPdU - Array dPdU not allocated!" << endl;
-    exit(1);
+    SU2_MPI::Error("Array dPdU not allocated!", CURRENT_FUNCTION);
   }
 
   /*--- Determine the electron density (if ionized) ---*/
@@ -188,7 +187,7 @@ void CNEMOGas::ComputedPdU(su2double *V, vector<su2double>& val_eves, su2double 
   Cvtrs              = GetSpeciesCvTraRot();
   Enthalpy_Formation = GetSpeciesFormationEnthalpy();
   Ref_Temperature    = GetRefTemperature();
-  
+
   /*--- Rename for convenience ---*/
   rhoCvtr = V[RHOCVTR_INDEX];
   rhoCvve = V[RHOCVVE_INDEX];
@@ -241,7 +240,7 @@ void CNEMOGas::ComputedPdU(su2double *V, vector<su2double>& val_eves, su2double 
 
   /*--- Vib.-el energy derivative ---*/
   val_dPdU[nSpecies+nDim+1] = -val_dPdU[nSpecies+nDim] +
-                               rho_el*Ru/MolarMass[nSpecies-1]*1.0/rhoCvve;    
+                               rho_el*Ru/MolarMass[nSpecies-1]*1.0/rhoCvve;
 
 }
 
@@ -273,9 +272,9 @@ void CNEMOGas::ComputedTdU(su2double *V, su2double *val_dTdU){
     ef    = Enthalpy_Formation[iSpecies] - Ru/MolarMass[iSpecies]*Ref_Temperature[iSpecies];
     val_dTdU[iSpecies]   = (-ef + 0.5*v2 + Cvtrs[iSpecies]*(Ref_Temperature[iSpecies]-T)) / rhoCvtr;
   }
+
   if (ionization) {
-    cout << "CNEMOGas: NEED TO IMPLEMENT dTdU for IONIZED MIX" << endl;
-    exit(1);
+    SU2_MPI::Error("NEED TO IMPLEMENT dTdU for IONIZED MIX",CURRENT_FUNCTION);
   }
 
   /*--- Momentum derivatives ---*/
@@ -286,15 +285,15 @@ void CNEMOGas::ComputedTdU(su2double *V, su2double *val_dTdU){
   val_dTdU[nSpecies+nDim]   =  1.0 / V[RHOCVTR_INDEX];
   val_dTdU[nSpecies+nDim+1] = -1.0 / V[RHOCVTR_INDEX];
 
-}    
+}
 
 void CNEMOGas::ComputedTvedU(su2double *V, vector<su2double>& val_eves, su2double *val_dTvedU){
 
   su2double rhoCvve;
 
-  /*--- Necessary indexes to assess primitive variables ---*/  
+  /*--- Necessary indexes to assess primitive variables ---*/
   unsigned long RHOCVVE_INDEX = nSpecies+nDim+7;
- 
+
   /*--- Rename for convenience ---*/
   rhoCvve = V[RHOCVVE_INDEX];
 
@@ -308,7 +307,7 @@ void CNEMOGas::ComputedTvedU(su2double *V, vector<su2double>& val_eves, su2doubl
 
   /*--- Energy derivatives ---*/
   val_dTvedU[nSpecies+nDim]   = 0.0;
-  val_dTvedU[nSpecies+nDim+1] = 1.0 / rhoCvve;  
+  val_dTvedU[nSpecies+nDim+1] = 1.0 / rhoCvve;
 
 }
 

--- a/SU2_CFD/src/fluid/CSU2TCLib.cpp
+++ b/SU2_CFD/src/fluid/CSU2TCLib.cpp
@@ -66,7 +66,7 @@ CSU2TCLib::CSU2TCLib(const CConfig* config, unsigned short val_nDim, bool viscou
     if (mf != 1.0) {
       cout << "CONFIG ERROR: Intial gas mass fractions do not sum to 1!" << " mf is equal to "<< mf <<endl;
     }
-    
+
     /*--- Define parameters of the gas model ---*/
     gamma       = 1.667;
     nReactions  = 0;
@@ -78,9 +78,9 @@ CSU2TCLib::CSU2TCLib(const CConfig* config, unsigned short val_nDim, bool viscou
     // Characteristic vibrational temperatures
     CharVibTemp[0] = 0.0;
 
-    Enthalpy_Formation[0] = 0.0;    
+    Enthalpy_Formation[0] = 0.0;
     Ref_Temperature[0] = 0.0;
-    nElStates[0] = 7;                 
+    nElStates[0] = 7;
 
     for (iSpecies = 0; iSpecies < nSpecies; iSpecies++)
       maxEl = max(maxEl, nElStates[iSpecies]);
@@ -90,16 +90,16 @@ CSU2TCLib::CSU2TCLib(const CConfig* config, unsigned short val_nDim, bool viscou
     ElDegeneracy.resize(nSpecies,maxEl) = su2double(0.0);
 
     /*--- AR: Blottner coefficients. ---*/
-    Blottner(0,0) = 3.83444322E-03;   Blottner(0,1) = 6.74718764E-01;   Blottner(0,2) = -1.24290388E+01; 
-    
+    Blottner(0,0) = 3.83444322E-03;   Blottner(0,1) = 6.74718764E-01;   Blottner(0,2) = -1.24290388E+01;
+
     /*--- AR: 7 states ---*/
     CharElTemp(0,0) = 0.000000000000000E+00;
     CharElTemp(0,1) = 1.611135736988230E+05;
     CharElTemp(0,2) = 1.625833076870950E+05;
     CharElTemp(0,3) = 1.636126382960720E+05;
     CharElTemp(0,4) = 1.642329518358000E+05;
-    CharElTemp(0,5) = 1.649426852542080E+05;   
-    CharElTemp(0,6) = 1.653517702884570E+05; 
+    CharElTemp(0,5) = 1.649426852542080E+05;
+    CharElTemp(0,6) = 1.653517702884570E+05;
     ElDegeneracy(0,0) = 1;
     ElDegeneracy(0,1) = 9;
     ElDegeneracy(0,2) = 21;
@@ -252,7 +252,7 @@ CSU2TCLib::CSU2TCLib(const CConfig* config, unsigned short val_nDim, bool viscou
     Omega11(0,1,0) = -8.3493693E-03;  Omega11(0,1,1) = 1.7808911E-01;   Omega11(0,1,2) = -1.4466155E+00;  Omega11(0,1,3) = 1.9324210E+03;
     Omega11(1,0,0) = -8.3493693E-03;  Omega11(1,0,1) = 1.7808911E-01;   Omega11(1,0,2) = -1.4466155E+00;  Omega11(1,0,3) = 1.9324210E+03;
     Omega11(1,1,0) = -7.7439615E-03;  Omega11(1,1,1) = 1.7129007E-01;   Omega11(1,1,2) = -1.4809088E+00;  Omega11(1,1,3) = 2.1284951E+03;
- 
+
   } else if (gas_model == "AIR-5"){
 
     /*--- Check for errors in the initialization ---*/
@@ -1085,7 +1085,7 @@ void CSU2TCLib::DiffusionCoeffWBE(){
 
     if (nSpecies==1) DiffusionCoeff[0] = 0;
     else DiffusionCoeff[iSpecies] = (1-MolarFracWBE[iSpecies])/denom;
-  }    
+  }
 }
 
 void CSU2TCLib::ViscosityWBE(){
@@ -1189,26 +1189,26 @@ void CSU2TCLib::DiffusionCoeffGY(){
       jSpecies = nSpecies-1;
       Mj       = MolarMass[jSpecies];
       gam_j    = rhos[iSpecies] / (Density*Mj);
-      
+
       /*--- Calculate the Omega^(0,0)_ij collision cross section ---*/
       Omega_ij = 1E-20 * Omega00(iSpecies,jSpecies,3)
           * pow(Tve, Omega00(iSpecies,jSpecies,0)*log(Tve)*log(Tve)
           + Omega00(iSpecies,jSpecies,1)*log(Tve)
           + Omega00(iSpecies,jSpecies,2));
-      
+
       /*--- Calculate "delta1_ij" ---*/
       d1_ij = 8.0/3.0 * sqrt((2.0*Mi*Mj) / (pi*Ru*Tve*(Mi+Mj))) * Omega_ij;
     }
-    
+
     /*--- Assign species diffusion coefficient ---*/
     DiffusionCoeff[iSpecies] = gam_t*gam_t*Mi*(1-Mi*gam_i) / denom;
   }
   if (ionization) {
     iSpecies = nSpecies-1;
-    
+
     /*--- Initialize the species diffusion coefficient ---*/
     DiffusionCoeff[iSpecies] = 0.0;
-    
+
     /*--- Calculate molar concentration ---*/
     Mi      = MolarMass[iSpecies];
     gam_i   = rhos[iSpecies] / (Density*Mi);
@@ -1217,16 +1217,16 @@ void CSU2TCLib::DiffusionCoeffGY(){
       if (iSpecies != jSpecies) {
         Mj    = MolarMass[jSpecies];
         gam_j = rhos[iSpecies] / (Density*Mj);
-        
+
         /*--- Calculate the Omega^(0,0)_ij collision cross section ---*/
         Omega_ij = 1E-20 * Omega00(iSpecies,jSpecies,3)
             * pow(Tve, Omega00(iSpecies,jSpecies,0)*log(Tve)*log(Tve)
             + Omega00(iSpecies,jSpecies,1)*log(Tve)
             + Omega00(iSpecies,jSpecies,2));
-        
+
         /*--- Calculate "delta1_ij" ---*/
         d1_ij = 8.0/3.0 * sqrt((2.0*Mi*Mj) / (pi*Ru*Tve*(Mi+Mj))) * Omega_ij;
-        
+
         /*--- Calculate heavy-particle binary diffusion coefficient ---*/
         D_ij = kb*Tve/(Pressure*d1_ij);
         denom += gam_j/D_ij;
@@ -1307,8 +1307,7 @@ void CSU2TCLib::ThermalConductivitiesGY(){
   kb   = BOLTZMANN_CONSTANT;
 
   if (ionization) {
-    cout << "SetThermalConductivity: NEEDS REVISION w/ IONIZATION" << endl;
-    exit(1);
+    SU2_MPI::Error("NEEDS REVISION w/ IONIZATION",CURRENT_FUNCTION);
   }
 
   /*--- Mixture vibrational-electronic specific heat ---*/
@@ -1444,7 +1443,7 @@ void CSU2TCLib::GetChemistryEquilConstants(unsigned short iReaction){
     RxnConstantTable(4,0) = 0.52455; RxnConstantTable(4,1) = 2.4715;  RxnConstantTable(4,2) = 1.7342;  RxnConstantTable(4,3) = -6.55534;  RxnConstantTable(4,4) = 0.030209;
     RxnConstantTable(5,0) = 0.50989; RxnConstantTable(5,1) = 2.4773;  RxnConstantTable(5,2) = 1.7132;  RxnConstantTable(5,3) = -6.5441;   RxnConstantTable(5,4) = 0.029591;
 
-  } else if (gas_model == "N2"){ 
+  } else if (gas_model == "N2"){
 
     //N2 + M -> 2N + M
     RxnConstantTable(0,0) = 3.4907;  RxnConstantTable(0,1) = 0.83133; RxnConstantTable(0,2) = 4.0978;  RxnConstantTable(0,3) = -12.728; RxnConstantTable(0,4) = 0.07487;   //n = 1E14
@@ -1517,7 +1516,7 @@ void CSU2TCLib::GetChemistryEquilConstants(unsigned short iReaction){
       RxnConstantTable(5,0) = -0.002428; RxnConstantTable(5,1) = -1.7415; RxnConstantTable(5,2) = -1.2331;   RxnConstantTable(5,3) = -0.95365;  RxnConstantTable(5,4) = -0.04585;
     }
 
-  } else if (gas_model == "AIR-7"){  
+  } else if (gas_model == "AIR-7"){
 
     if (iReaction <= 6) {
 

--- a/SU2_CFD/src/numerics/NEMO/CNEMONumerics.cpp
+++ b/SU2_CFD/src/numerics/NEMO/CNEMONumerics.cpp
@@ -55,7 +55,7 @@ CNEMONumerics::CNEMONumerics(unsigned short val_nDim, unsigned short val_nVar,
     EDDY_VISC_INDEX = nSpecies+nDim+9;
 
     /*--- Read from CConfig ---*/
-    implicit   = (config->GetKind_TimeIntScheme_Flow() == EULER_IMPLICIT); 
+    implicit   = (config->GetKind_TimeIntScheme_Flow() == EULER_IMPLICIT);
 
     ionization = config->GetIonization();
     if (ionization) { nHeavy = nSpecies-1; nEl = 1; }
@@ -69,7 +69,7 @@ CNEMONumerics::CNEMONumerics(unsigned short val_nDim, unsigned short val_nVar,
         #else
           SU2_MPI::Error(string("Mutation++ has not been configured/compiled. Add 1) '-Denable-mpp=true' to your meson string or 2) '-DHAVE_MPP' to the CXX FLAGS of your configure string, and recompile."),
           CURRENT_FUNCTION);
-        #endif    
+        #endif
       break;
       case SU2_NONEQ:
         fluidmodel = new CSU2TCLib(config, nDim, false);
@@ -163,7 +163,7 @@ void CNEMONumerics::GetInviscidProjJac(const su2double *val_U,    const su2doubl
   const su2double *rhos;
 
   rhos = &val_V[RHOS_INDEX];
-  
+
   /*--- Initialize the Jacobian tensor ---*/
   for (iVar = 0; iVar < nVar; iVar++)
     for (jVar = 0; jVar < nVar; jVar++)
@@ -265,7 +265,7 @@ void CNEMONumerics::GetViscousProjFlux(su2double *val_primvar,
   Ru  = 1000.0*RuSI;
 
   hs = fluidmodel->ComputeSpeciesEnthalpy(T, Tve, val_eve);
-  
+
   /*--- Scale thermal conductivity with turb visc ---*/
   // TODO: Need to determine proper way to incorporate eddy viscosity
   // This is only scaling Kve by same factor as ktr
@@ -295,13 +295,12 @@ void CNEMONumerics::GetViscousProjFlux(su2double *val_primvar,
   /*--- Populate entries in the viscous flux vector ---*/
   for (iDim = 0; iDim < nDim; iDim++) {
     /*--- Species diffusion velocity ---*/
-    for (iSpecies = 0; iSpecies < nHeavy; iSpecies++) { 
+    for (iSpecies = 0; iSpecies < nHeavy; iSpecies++) {
       Flux_Tensor[iSpecies][iDim] = rho*Ds[iSpecies]*GV[RHOS_INDEX+iSpecies][iDim]
           - V[RHOS_INDEX+iSpecies]*Vector[iDim];
     }
     if (ionization) {
-      cout << "GetViscProjFlux -- NEED TO IMPLEMENT IONIZED FUNCTIONALITY!!!" << endl;
-      exit(1);
+      SU2_MPI::Error("NEED TO IMPLEMENT IONIZED FUNCTIONALITY!!!",CURRENT_FUNCTION);
     }
 
     /*--- Shear stress related terms ---*/
@@ -708,7 +707,7 @@ void CNEMONumerics::GetPMatrix(const su2double *U, const su2double *V, const su2
       val_p_tensor[nSpecies+iDim][nSpecies+1]   = m[iDim];
       val_p_tensor[nSpecies+iDim][nSpecies+2]   = (V[VEL_INDEX+iDim]+a*val_normal[iDim]) / (2.0*a2);
       val_p_tensor[nSpecies+iDim][nSpecies+3]   = (V[VEL_INDEX+iDim]-a*val_normal[iDim]) / (2.0*a2);
-      val_p_tensor[nSpecies+iDim][nSpecies+4]   = 0.0;  
+      val_p_tensor[nSpecies+iDim][nSpecies+4]   = 0.0;
     }
 
     val_p_tensor[nSpecies+3][nSpecies]   = vV;

--- a/SU2_CFD/src/output/filewriter/CTecplotBinaryFileWriter.cpp
+++ b/SU2_CFD/src/output/filewriter/CTecplotBinaryFileWriter.cpp
@@ -55,14 +55,13 @@ void CTecplotBinaryFileWriter::Write_Data(){
 
   /*--- Reduce the total number of each element. ---*/
 
-  unsigned long nParallel_Line = dataSorter->GetnElem(LINE),
-                nParallel_Tria = dataSorter->GetnElem(TRIANGLE),
+  unsigned long nParallel_Tria = dataSorter->GetnElem(TRIANGLE),
                 nParallel_Quad = dataSorter->GetnElem(QUADRILATERAL),
                 nParallel_Tetr = dataSorter->GetnElem(TETRAHEDRON),
                 nParallel_Hexa = dataSorter->GetnElem(HEXAHEDRON),
                 nParallel_Pris = dataSorter->GetnElem(PRISM),
                 nParallel_Pyra = dataSorter->GetnElem(PYRAMID);
-  
+
   unsigned long nTot_Line = dataSorter->GetnElemGlobal(LINE),
                 nTot_Tria = dataSorter->GetnElemGlobal(TRIANGLE),
                 nTot_Quad = dataSorter->GetnElemGlobal(QUADRILATERAL),
@@ -134,6 +133,8 @@ void CTecplotBinaryFileWriter::Write_Data(){
   }
 
 #ifdef HAVE_MPI
+
+  unsigned long nParallel_Line = dataSorter->GetnElem(LINE);
 
   unsigned short iVar;
   NodePartitioner node_partitioner(num_nodes, size);

--- a/SU2_CFD/src/solvers/CEulerSolver.cpp
+++ b/SU2_CFD/src/solvers/CEulerSolver.cpp
@@ -175,21 +175,16 @@ CEulerSolver::CEulerSolver(CGeometry *geometry, CConfig *config,
 
   /*--- Allocates a 2D array with variable "outer" sizes and init to 0. ---*/
 
-  auto Alloc2D = [](unsigned long M, const unsigned long* N, su2double**& X) {
-    X = new su2double* [M];
-    for(unsigned long i = 0; i < M; ++i)
-      X[i] = new su2double [N[i]] ();
+  auto Alloc2D = [](unsigned long M, const unsigned long* N, vector<vector<su2double> >& X) {
+    X.resize(M);
+    for(unsigned long i = 0; i < M; ++i) X[i].resize(N[i], 0.0);
   };
 
   /*--- Allocates a 3D array with variable "middle" sizes and init to 0. ---*/
 
-  auto Alloc3D = [](unsigned long M, const unsigned long* N, unsigned long P, su2double***& X) {
-    X = new su2double** [M];
-    for(unsigned long i = 0; i < M; ++i) {
-      X[i] = new su2double* [N[i]];
-      for(unsigned long j = 0; j < N[i]; ++j)
-        X[i][j] = new su2double [P] ();
-    }
+  auto Alloc3D = [](unsigned long M, const unsigned long* N, unsigned long P, vector<su2activematrix>& X) {
+    X.resize(M);
+    for(unsigned long i = 0; i < M; ++i) X[i].resize(N[i],P) = su2double(0.0);
   };
 
   /*--- Store the value of the primitive variables + 2 turb variables at the boundaries,
@@ -199,10 +194,9 @@ CEulerSolver::CEulerSolver(CGeometry *geometry, CConfig *config,
 
   /*--- Store the value of the characteristic primitive variables index at the boundaries ---*/
 
-  DonorGlobalIndex = new unsigned long* [nMarker];
-  for (iMarker = 0; iMarker < nMarker; iMarker++) {
-    DonorGlobalIndex[iMarker] = new unsigned long [nVertex[iMarker]]();
-  }
+  DonorGlobalIndex.resize(nMarker);
+  for (iMarker = 0; iMarker < nMarker; iMarker++)
+    DonorGlobalIndex[iMarker].resize(nVertex[iMarker],0);
 
   /*--- Actuator Disk Radius allocation ---*/
   ActDisk_R.resize(nMarker);
@@ -229,19 +223,19 @@ CEulerSolver::CEulerSolver(CGeometry *geometry, CConfig *config,
 
   /*--- Supersonic coefficients ---*/
 
-  CEquivArea_Inv = new su2double[nMarker];
+  CEquivArea_Inv.resize(nMarker);
 
   /*--- Engine simulation ---*/
 
-  Inflow_MassFlow = new su2double[nMarker];
-  Inflow_Pressure = new su2double[nMarker];
-  Inflow_Mach = new su2double[nMarker];
-  Inflow_Area = new su2double[nMarker];
+  Inflow_MassFlow.resize(nMarker);
+  Inflow_Pressure.resize(nMarker);
+  Inflow_Mach.resize(nMarker);
+  Inflow_Area.resize(nMarker);
 
-  Exhaust_Temperature = new su2double[nMarker];
-  Exhaust_MassFlow = new su2double[nMarker];
-  Exhaust_Pressure = new su2double[nMarker];
-  Exhaust_Area = new su2double[nMarker];
+  Exhaust_Temperature.resize(nMarker);
+  Exhaust_MassFlow.resize(nMarker);
+  Exhaust_Pressure.resize(nMarker);
+  Exhaust_Area.resize(nMarker);
 
   /*--- Read farfield conditions from config ---*/
 
@@ -357,73 +351,10 @@ CEulerSolver::CEulerSolver(CGeometry *geometry, CConfig *config,
 
 CEulerSolver::~CEulerSolver(void) {
 
-  unsigned short iMarker, iSpan;
-  unsigned long iVertex;
+  unsigned short iSpan;
+  unsigned long iMarker;
 
   /*--- Array deallocation ---*/
-
-  delete [] CEquivArea_Inv;
-
-  delete [] Inflow_MassFlow;
-  delete [] Exhaust_MassFlow;
-  delete [] Exhaust_Area;
-  delete [] Inflow_Pressure;
-  delete [] Inflow_Mach;
-  delete [] Inflow_Area;
-
-  delete [] Exhaust_Pressure;
-  delete [] Exhaust_Temperature;
-
-  if (DonorPrimVar != nullptr) {
-    for (iMarker = 0; iMarker < nMarker; iMarker++) {
-      for (iVertex = 0; iVertex < nVertex[iMarker]; iVertex++)
-        delete [] DonorPrimVar[iMarker][iVertex];
-      delete [] DonorPrimVar[iMarker];
-    }
-    delete [] DonorPrimVar;
-  }
-
-  if (DonorGlobalIndex != nullptr) {
-    for (iMarker = 0; iMarker < nMarker; iMarker++)
-      delete [] DonorGlobalIndex[iMarker];
-    delete [] DonorGlobalIndex;
-  }
-
-  if (ActDisk_Fa != nullptr) {
-    for (iMarker = 0; iMarker < nMarker; iMarker++)
-      delete [] ActDisk_Fa[iMarker];
-    delete [] ActDisk_Fa;
-  }
-
-  if (ActDisk_Fx != nullptr) {
-    for (iMarker = 0; iMarker < nMarker; iMarker++)
-      delete [] ActDisk_Fx[iMarker];
-    delete [] ActDisk_Fx;
-  }
-
-  if (ActDisk_Fy != nullptr) {
-    for (iMarker = 0; iMarker < nMarker; iMarker++)
-      delete [] ActDisk_Fy[iMarker];
-    delete [] ActDisk_Fy;
-  }
-
-  if (ActDisk_Fz != nullptr) {
-    for (iMarker = 0; iMarker < nMarker; iMarker++)
-      delete [] ActDisk_Fz[iMarker];
-    delete [] ActDisk_Fz;
-  }
-
-  if (ActDisk_DeltaP != nullptr) {
-    for (iMarker = 0; iMarker < nMarker; iMarker++)
-      delete [] ActDisk_DeltaP[iMarker];
-    delete [] ActDisk_DeltaP;
-  }
-
-  if (ActDisk_DeltaT != nullptr) {
-    for (iMarker = 0; iMarker < nMarker; iMarker++)
-      delete [] ActDisk_DeltaT[iMarker];
-    delete [] ActDisk_DeltaT;
-  }
 
   for(auto& model : FluidModel) delete model;
 
@@ -816,7 +747,6 @@ void CEulerSolver::InitTurboContainers(CGeometry *geometry, CConfig *config){
       }
     }
   }
-
 
 }
 

--- a/SU2_CFD/src/solvers/CFEM_DG_EulerSolver.cpp
+++ b/SU2_CFD/src/solvers/CFEM_DG_EulerSolver.cpp
@@ -1749,8 +1749,7 @@ void CFEM_DG_EulerSolver::MetaDataJacobianComputation(const CMeshFEM    *FEMGeom
     for(int j=0; j<sizeMess; ++j) {
       const unsigned long jj = recvBuf[j] - nDOFsPerRank[rank];
       if(jj >= nDOFsLocOwned) {
-        cout << "This DOF should be owned, but it is not. This should not happen." << endl;
-        exit(1);
+        SU2_MPI::Error("This DOF should be owned, but it is not. This should not happen.",CURRENT_FUNCTION);
       }
       sendReturnBuf[i][j] = colorLocalDOFs[jj];
     }

--- a/SU2_CFD/src/solvers/CNEMONSSolver.cpp
+++ b/SU2_CFD/src/solvers/CNEMONSSolver.cpp
@@ -52,16 +52,6 @@ CNEMONSSolver::CNEMONSSolver(CGeometry *geometry, CConfig *config, unsigned shor
       break;
   }
 
-  /* Auxiliary vector for storing primitives for gradient computation in viscous flow */
-  /* V = [Y1, ... , Yn, T, Tve, ... ] */
-  primitives_aux = new su2double[nPrimVar];
-
-}
-
-CNEMONSSolver::~CNEMONSSolver(void) {
-
-  if (primitives_aux != nullptr) delete [] primitives_aux;
-
 }
 
 void CNEMONSSolver::Preprocessing(CGeometry *geometry, CSolver **solver_container, CConfig *config, unsigned short iMesh,
@@ -150,10 +140,10 @@ void CNEMONSSolver::SetPrimitive_Gradient_GG(CGeometry *geometry, const CConfig 
 
   /*--- Modify species density to mass concentration ---*/
   for ( iPoint = 0; iPoint < nPoint; iPoint++){
-    for( iVar = 0; iVar < nPrimVar; iVar++) {
+    su2double primitives_aux[MAXNVAR] = {0.0};
+    for( iVar = 0; iVar < nPrimVar; iVar++)
       primitives_aux[iVar] = nodes->GetPrimitive(iPoint, iVar);
-    }
-    for (iSpecies = 0; iSpecies < nSpecies; iSpecies++)
+    for ( iSpecies = 0; iSpecies < nSpecies; iSpecies++)
       primitives_aux[RHOS_INDEX+iSpecies] = primitives_aux[RHOS_INDEX+iSpecies]/primitives_aux[RHO_INDEX];
     for( iVar = 0; iVar < nPrimVar; iVar++)
       nodes->SetPrimitive_Aux(iPoint, iVar, primitives_aux[iVar] );

--- a/SU2_CFD/src/solvers/CTurbSASolver.cpp
+++ b/SU2_CFD/src/solvers/CTurbSASolver.cpp
@@ -160,35 +160,22 @@ CTurbSASolver::CTurbSASolver(CGeometry *geometry, CConfig *config, unsigned shor
 
   /*--- Initializate quantities for SlidingMesh Interface ---*/
 
-  unsigned long iMarker;
+  SlidingState.resize(nMarker);
+  SlidingStateNodes.resize(nMarker);
 
-  SlidingState       = new su2double*** [nMarker] ();
-  SlidingStateNodes  = new int*         [nMarker] ();
-
-  for (iMarker = 0; iMarker < nMarker; iMarker++){
-
-    if (config->GetMarker_All_KindBC(iMarker) == FLUID_INTERFACE){
-
-      SlidingState[iMarker]       = new su2double**[geometry->GetnVertex(iMarker)] ();
-      SlidingStateNodes[iMarker]  = new int        [geometry->GetnVertex(iMarker)] ();
-
-      for (iPoint = 0; iPoint < geometry->GetnVertex(iMarker); iPoint++)
-        SlidingState[iMarker][iPoint] = new su2double*[nPrimVar+1] ();
+  for (unsigned long iMarker = 0; iMarker < nMarker; iMarker++) {
+    if (config->GetMarker_All_KindBC(iMarker) == FLUID_INTERFACE) {
+      SlidingState[iMarker].resize(nVertex[iMarker], nPrimVar+1) = nullptr;
+      SlidingStateNodes[iMarker].resize(nVertex[iMarker],0);
     }
-
   }
 
   /*-- Allocation of inlets has to happen in derived classes (not CTurbSolver),
    * due to arbitrary number of turbulence variables ---*/
 
-  Inlet_TurbVars = new su2double**[nMarker];
-  for (unsigned long iMarker = 0; iMarker < nMarker; iMarker++) {
-    Inlet_TurbVars[iMarker] = new su2double*[nVertex[iMarker]];
-    for(unsigned long iVertex=0; iVertex < nVertex[iMarker]; iVertex++){
-      Inlet_TurbVars[iMarker][iVertex] = new su2double[nVar] ();
-      Inlet_TurbVars[iMarker][iVertex][0] = nu_tilde_Inf;
-    }
-  }
+  Inlet_TurbVars.resize(nMarker);
+  for (unsigned long iMarker = 0; iMarker < nMarker; iMarker++)
+    Inlet_TurbVars[iMarker].resize(nVertex[iMarker],nVar) = nu_tilde_Inf;
 
   /*--- The turbulence models are always solved implicitly, so set the
    implicit flag in case we have periodic BCs. ---*/
@@ -207,36 +194,6 @@ CTurbSASolver::CTurbSASolver(CGeometry *geometry, CConfig *config, unsigned shor
 
   /*--- Add the solver name (max 8 characters) ---*/
   SolverName = "SA";
-
-}
-
-CTurbSASolver::~CTurbSASolver(void) {
-
-  unsigned long iMarker, iVertex;
-  unsigned short iVar;
-
-  if ( SlidingState != nullptr ) {
-    for (iMarker = 0; iMarker < nMarker; iMarker++) {
-      if ( SlidingState[iMarker] != nullptr ) {
-        for (iVertex = 0; iVertex < nVertex[iMarker]; iVertex++)
-          if ( SlidingState[iMarker][iVertex] != nullptr ){
-            for (iVar = 0; iVar < nPrimVar+1; iVar++)
-              delete [] SlidingState[iMarker][iVertex][iVar];
-            delete [] SlidingState[iMarker][iVertex];
-          }
-        delete [] SlidingState[iMarker];
-      }
-    }
-    delete [] SlidingState;
-  }
-
-  if ( SlidingStateNodes != nullptr ){
-    for (iMarker = 0; iMarker < nMarker; iMarker++){
-      if (SlidingStateNodes[iMarker] != nullptr)
-        delete [] SlidingStateNodes[iMarker];
-    }
-    delete [] SlidingStateNodes;
-  }
 
 }
 

--- a/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
+++ b/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
@@ -159,33 +159,25 @@ CTurbSSTSolver::CTurbSSTSolver(CGeometry *geometry, CConfig *config, unsigned sh
 
   /*--- Initializate quantities for SlidingMesh Interface ---*/
 
-  unsigned long iMarker;
+  SlidingState.resize(nMarker);
+  SlidingStateNodes.resize(nMarker);
 
-  SlidingState       = new su2double*** [nMarker]();
-  SlidingStateNodes  = new int*         [nMarker]();
-
-  for (iMarker = 0; iMarker < nMarker; iMarker++){
-
-    if (config->GetMarker_All_KindBC(iMarker) == FLUID_INTERFACE){
-
-      SlidingState[iMarker]       = new su2double**[geometry->GetnVertex(iMarker)]();
-      SlidingStateNodes[iMarker]  = new int        [geometry->GetnVertex(iMarker)]();
-
-      for (iPoint = 0; iPoint < geometry->GetnVertex(iMarker); iPoint++)
-        SlidingState[iMarker][iPoint] = new su2double*[nPrimVar+1]();
+  for (unsigned long iMarker = 0; iMarker < nMarker; iMarker++) {
+    if (config->GetMarker_All_KindBC(iMarker) == FLUID_INTERFACE) {
+      SlidingState[iMarker].resize(nVertex[iMarker], nPrimVar+1) = nullptr;
+      SlidingStateNodes[iMarker].resize(nVertex[iMarker],0);
     }
   }
 
   /*-- Allocation of inlets has to happen in derived classes (not CTurbSolver),
     due to arbitrary number of turbulence variables ---*/
 
-  Inlet_TurbVars = new su2double**[nMarker];
+  Inlet_TurbVars.resize(nMarker);
   for (unsigned long iMarker = 0; iMarker < nMarker; iMarker++) {
-    Inlet_TurbVars[iMarker] = new su2double*[nVertex[iMarker]];
-    for(unsigned long iVertex=0; iVertex < nVertex[iMarker]; iVertex++){
-      Inlet_TurbVars[iMarker][iVertex] = new su2double[nVar];
-      Inlet_TurbVars[iMarker][iVertex][0] = kine_Inf;
-      Inlet_TurbVars[iMarker][iVertex][1] = omega_Inf;
+    Inlet_TurbVars[iMarker].resize(nVertex[iMarker],nVar);
+    for (unsigned long iVertex = 0; iVertex < nVertex[iMarker]; ++iVertex) {
+      Inlet_TurbVars[iMarker](iVertex,0) = kine_Inf;
+      Inlet_TurbVars[iMarker](iVertex,1) = omega_Inf;
     }
   }
 
@@ -206,36 +198,6 @@ CTurbSSTSolver::CTurbSSTSolver(CGeometry *geometry, CConfig *config, unsigned sh
 
   /*--- Add the solver name (max 8 characters) ---*/
   SolverName = "K-W SST";
-
-}
-
-CTurbSSTSolver::~CTurbSSTSolver(void) {
-
-  unsigned long iMarker, iVertex;
-  unsigned short iVar;
-
-  if ( SlidingState != nullptr ) {
-    for (iMarker = 0; iMarker < nMarker; iMarker++) {
-      if ( SlidingState[iMarker] != nullptr ) {
-        for (iVertex = 0; iVertex < nVertex[iMarker]; iVertex++)
-          if ( SlidingState[iMarker][iVertex] != nullptr ){
-            for (iVar = 0; iVar < nPrimVar+1; iVar++)
-              delete [] SlidingState[iMarker][iVertex][iVar];
-            delete [] SlidingState[iMarker][iVertex];
-          }
-        delete [] SlidingState[iMarker];
-      }
-    }
-    delete [] SlidingState;
-  }
-
-  if ( SlidingStateNodes != nullptr ){
-    for (iMarker = 0; iMarker < nMarker; iMarker++){
-        if (SlidingStateNodes[iMarker] != nullptr)
-            delete [] SlidingStateNodes[iMarker];
-    }
-    delete [] SlidingStateNodes;
-  }
 
 }
 
@@ -322,7 +284,7 @@ void CTurbSSTSolver::Postprocessing(CGeometry *geometry, CSolver **solver_contai
 
 void CTurbSSTSolver::Source_Residual(CGeometry *geometry, CSolver **solver_container,
                                      CNumerics **numerics_container, CConfig *config, unsigned short iMesh) {
-                                       
+
   bool axisymmetric = config->GetAxisymmetric();
 
   CVariable* flowNodes = solver_container[FLOW_SOL]->GetNodes();
@@ -378,7 +340,7 @@ void CTurbSSTSolver::Source_Residual(CGeometry *geometry, CSolver **solver_conta
       /*--- Set y coordinate ---*/
       numerics->SetCoord(geometry->nodes->GetCoord(iPoint), geometry->nodes->GetCoord(iPoint));
     }
-    
+
     /*--- Compute the source term ---*/
 
     auto residual = numerics->ComputeResidual(config);

--- a/SU2_CFD/src/solvers/CTurbSolver.cpp
+++ b/SU2_CFD/src/solvers/CTurbSolver.cpp
@@ -75,16 +75,8 @@ CTurbSolver::CTurbSolver(CGeometry* geometry, CConfig *config) : CSolver() {
 
 CTurbSolver::~CTurbSolver(void) {
 
-  if (Inlet_TurbVars != nullptr) {
-    for (unsigned short iMarker = 0; iMarker < nMarker; iMarker++) {
-      if (Inlet_TurbVars[iMarker] != nullptr) {
-        for (unsigned long iVertex = 0; iVertex < nVertex[iMarker]; iVertex++) {
-          delete [] Inlet_TurbVars[iMarker][iVertex];
-        }
-        delete [] Inlet_TurbVars[iMarker];
-      }
-    }
-    delete [] Inlet_TurbVars;
+  for (auto& mat : SlidingState) {
+    for (auto ptr : mat) delete [] ptr;
   }
 
   delete nodes;

--- a/UnitTests/SU2_CFD/numerics/CNumerics_tests.cpp
+++ b/UnitTests/SU2_CFD/numerics/CNumerics_tests.cpp
@@ -39,8 +39,6 @@ TEST_CASE("NTS blending has a minimum of 0.05", "[Upwind/central blending]") {
   
   /*--- Setup ---*/
 
-  const unsigned short nDim = 3;
-
   CConfig* config = new CConfig(config_options, SU2_CFD, false);
 
   const su2double dissipation_i = 0;

--- a/UnitTests/test_driver.cpp
+++ b/UnitTests/test_driver.cpp
@@ -43,7 +43,6 @@ int main(int argc, char *argv[]) {
 #else
   SU2_MPI::Init(&argc, &argv);
 #endif
-  SU2_MPI::Comm MPICommunicator = SU2_MPI::GetComm();
 
   /*--- Run the test driver supplied by Catch ---*/
   int result = Catch::Session().run(argc, argv);

--- a/externals/cgns/meson.build
+++ b/externals/cgns/meson.build
@@ -1,7 +1,12 @@
 if build_machine.system() == 'windows' or meson.get_compiler('cpp').get_id() == 'intel'
   cgns_default_warnings = []
 else
-  cgns_default_warnings = ['-Wno-unused-result']
+  cgns_default_warnings = ['-Wno-unused-result',
+                           '-Wno-unused-parameter',
+                           '-Wno-unused-variable',
+                           '-Wno-unused-but-set-variable',
+                           '-Wno-sign-compare',
+                           '-Wno-pedantic']
 endif
 
 cgns_include = include_directories('adf', './')

--- a/externals/metis/meson.build
+++ b/externals/metis/meson.build
@@ -4,7 +4,18 @@ metis_default_warnings = []
 if build_machine.system() != 'windows'
   metis_default_warnings += ['-Wno-implicit-function-declaration']
   if meson.get_compiler('cpp').get_id() != 'intel'
-    metis_default_warnings += ['-Wno-unused-result', '-Wno-macro-redefined']
+    metis_default_warnings += ['-Wno-unused-result',
+                               '-Wno-unused-parameter',
+                               '-Wno-unused-variable',
+                               '-Wno-unused-but-set-variable',
+                               '-Wno-macro-redefined',
+                               '-Wno-unknown-pragmas',
+                               '-Wno-sign-compare',
+                               '-Wno-clobbered',
+                               '-Wno-empty-body',
+                               '-Wno-unused-label',
+                               '-Wno-misleading-indentation',
+                               '-Wno-pedantic']
   endif
 endif
 

--- a/externals/metis/meson.build
+++ b/externals/metis/meson.build
@@ -15,6 +15,7 @@ if build_machine.system() != 'windows'
                                '-Wno-empty-body',
                                '-Wno-unused-label',
                                '-Wno-misleading-indentation',
+                               '-Wno-maybe-uninitialized',
                                '-Wno-pedantic']
   endif
 endif

--- a/externals/parmetis/meson.build
+++ b/externals/parmetis/meson.build
@@ -41,6 +41,6 @@ parmetis = static_library('parmetis',
            'libparmetis/match.c',
            'libparmetis/mmetis.c',
            install : false, include_directories: parmetis_include,
-	   dependencies: [mpi_dep, metis_dep], c_args: parmetis_c_args)
+	   dependencies: [mpi_dep, metis_dep], c_args: parmetis_c_args + metis_default_warnings)
 
 parmetis_dep = declare_dependency(link_with: parmetis, include_directories: parmetis_include)

--- a/externals/tecio/teciompisrc/meson.build
+++ b/externals/tecio/teciompisrc/meson.build
@@ -12,6 +12,15 @@ if (host_machine.system() == 'windows')
   tec_cxx_flags += ['-DMSWIN']
 endif
 
+if build_machine.system() != 'windows'
+  if meson.get_compiler('cpp').get_id() != 'intel'
+    tec_cxx_flags += ['-Wno-misleading-indentation',
+                      '-Wno-uninitialized',
+                      '-Wno-placement-new',
+                      '-Wno-pedantic']
+  endif
+endif
+
 
 teciompi_include = include_directories(['../', './'])
 

--- a/externals/tecio/teciosrc/meson.build
+++ b/externals/tecio/teciosrc/meson.build
@@ -12,6 +12,15 @@ if (host_machine.system() == 'windows')
   tecio_cpp_flags += ['-DMSWIN']
 endif
 
+if build_machine.system() != 'windows'
+  if meson.get_compiler('cpp').get_id() != 'intel'
+    tecio_cpp_flags += ['-Wno-misleading-indentation',
+                        '-Wno-uninitialized',
+                        '-Wno-placement-new',
+                        '-Wno-pedantic']
+  endif
+endif
+
 tecio_include = include_directories('../', './')
 tecio = static_library('tecio',
            'ClassicZoneWriterAbstract.cpp',

--- a/meson.build
+++ b/meson.build
@@ -18,9 +18,11 @@ if build_machine.system() != 'windows'
     default_warning_flags += ['-Wno-empty-body']
   endif
   default_warning_flags += ['-Wno-unused-parameter',
-                            '-Wno-format-security',
-                            '-Wno-deprecated-declarations',
-                            '-Wno-non-virtual-dtor']
+                            '-Wno-deprecated-declarations']
+
+  if get_option('enable-autodiff') or get_option('enable-directdiff')
+    default_warning_flags += ['-Wno-non-virtual-dtor']
+  endif
 endif
 
 # meson script path


### PR DESCRIPTION
## Proposed Changes
Regression tests will fail (code will not compile) on pedantic warnings, i.e. -Wall -Wextra -Wpedantic -Werror
For external libraries many warnings were manually disabled, because I don't know a better way of not having -Werror defined for them via meson.

## PR Checklist
- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags, or simply --warnlevel=2 when using meson).
- [X] My contribution is commented and consistent with SU2 style.
- [X] I have added a test case that demonstrates my contribution, if necessary.
- [X] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
