### PR TITLE
[WIP] Fixes to axi nemo set functions and auxvargrad in source residual

### DIFF
--- a/SU2_CFD/src/numerics/NEMO/NEMO_sources.cpp
+++ b/SU2_CFD/src/numerics/NEMO/NEMO_sources.cpp
@@ -376,7 +376,7 @@ CNumerics::ResidualType<> CSource_NEMO::ComputeAxisymmetric(const CConfig *confi
                                                      +v*TWO3*(2*PrimVar_Grad_i[nSpecies+2][1]-PrimVar_Grad_i[nSpecies+2][0]
                                                      -v*yinv+rho*turb_ke_i))
                                                      -total_conductivity_i*PrimVar_Grad_i[nSpecies][1])
-                                                     -TWO3*(AuxVar_Grad_i[1][1]+AuxVar_Grad_i[2][1]));
+                                                     -TWO3*(AuxVar_Grad_i[1][1]+AuxVar_Grad_i[2][0]));
     residual[nSpecies+3] -= Volume*(yinv*(sumJeve_y -qy_ve));
   }
 

--- a/SU2_CFD/src/numerics/NEMO/NEMO_sources.cpp
+++ b/SU2_CFD/src/numerics/NEMO/NEMO_sources.cpp
@@ -372,12 +372,12 @@ CNumerics::ResidualType<> CSource_NEMO::ComputeAxisymmetric(const CConfig *confi
                                                                     -TWO3*AuxVar_Grad_i[0][0]);
     residual[nSpecies+1] -= Volume*(yinv*total_viscosity_i*2*(PrimVar_Grad_i[nSpecies+3][1]-v*yinv)
                                                                     -TWO3*AuxVar_Grad_i[0][1]);
-    residual[nSpecies+2] -= Volume*(yinv*(sumJhs_y + total_viscosity_i*(u*(PrimVar_Grad_i[nSpecies+3][0]+PrimVar_Grad_i[nSpecies+2][1])
+    residual[nSpecies+2] -= Volume*(yinv*(-sumJhs_y + total_viscosity_i*(u*(PrimVar_Grad_i[nSpecies+3][0]+PrimVar_Grad_i[nSpecies+2][1])
                                                      +v*TWO3*(2*PrimVar_Grad_i[nSpecies+2][1]-PrimVar_Grad_i[nSpecies+2][0]
                                                      -v*yinv+rho*turb_ke_i))
                                                      -total_conductivity_i*PrimVar_Grad_i[nSpecies][1])
                                                      -TWO3*(AuxVar_Grad_i[1][1]+AuxVar_Grad_i[2][0]));
-    residual[nSpecies+3] -= Volume*(yinv*(sumJeve_y -qy_ve));
+    residual[nSpecies+3] -= Volume*(yinv*(-sumJeve_y -qy_ve));
   }
 
 //  if (implicit) {

--- a/SU2_CFD/src/solvers/CNEMOEulerSolver.cpp
+++ b/SU2_CFD/src/solvers/CNEMOEulerSolver.cpp
@@ -938,6 +938,21 @@ void CNEMOEulerSolver::Source_Residual(CGeometry *geometry, CSolver **solver_con
         /*--- If necessary, set variables needed for viscous computation ---*/
         if (viscous) {
 
+          // TODO: NOTE: Some of these are set above. They need to be set here as well, otherwise they are passed in incorrectly.
+          // Do not remove.
+          
+          /*--- Set volume ---*/
+          numerics->SetVolume(geometry->nodes->GetVolume(iPoint));
+
+          /*--- Set coords ---*/
+          numerics->SetCoord(geometry->nodes->GetCoord(iPoint), geometry->nodes->GetCoord(iPoint));
+
+          /*--- Set conservative vars ---*/
+          numerics->SetConservative(nodes->GetSolution(iPoint),   nodes->GetSolution(iPoint));
+
+          /*--- Set primitive vars ---*/
+          numerics->SetPrimitive   (nodes->GetPrimitive(iPoint),  nodes->GetPrimitive(iPoint) );
+
           /*--- Set gradient of primitive variables ---*/
           numerics->SetPrimVarGradient(nodes->GetGradient_Primitive(iPoint), nodes->GetGradient_Primitive(iPoint));
 

--- a/SU2_CFD/src/solvers/CNEMOEulerSolver.cpp
+++ b/SU2_CFD/src/solvers/CNEMOEulerSolver.cpp
@@ -1321,8 +1321,8 @@ void CNEMOEulerSolver::SetNondimensionalization(CConfig *config, unsigned short 
     ModelTableOut <<"-- Models:"<< endl;
 
     ModelTable.AddColumn("Mixture", 25);
-    ModelTable.AddColumn("Transport Model", 25);
     ModelTable.AddColumn("Fluid Model", 25);
+    ModelTable.AddColumn("Transport Model", 25);
     ModelTable.SetAlign(PrintingToolbox::CTablePrinter::RIGHT);
     ModelTable.PrintHeader();
 


### PR DESCRIPTION
fixed set functions for NEMO axisymmetric, implemented auxvargrad correction in nemo axisymmetric source residual, fixed fluid model/transport model print statement

Signed-off-by: jtneedels <jneedels@stanford.edu>

## Proposed Changes
This PR addresses an issue found with not setting primitive and conservative variables in computing the axisymmetric source residual, as well as implementing the auxvargrad indexing correction applied in the standard air axisymmetric source residual and fixing an issue with printing the fluid and transport models. 


## Related Work
This PR is related to #1192 and #1162.


## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags, or simply --warnlevel=2 when using meson).
- [x] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
