### PR TITLE
Removed CSolver::Convective_Residual

### DIFF
--- a/SU2_CFD/include/drivers/CDriver.hpp
+++ b/SU2_CFD/include/drivers/CDriver.hpp
@@ -745,7 +745,7 @@ class CFluidDriver : public CDriver {
 protected:
    unsigned long Max_Iter;
 
-public:
+protected:
 
   /*!
    * \brief Constructor of the class.
@@ -758,6 +758,7 @@ public:
                unsigned short val_nZone,
                SU2_Comm MPICommunicator);
 
+public:
   /*!
    * \brief Destructor of the class.
    */

--- a/SU2_CFD/include/solvers/CSolver.hpp
+++ b/SU2_CFD/include/solvers/CSolver.hpp
@@ -785,22 +785,6 @@ public:
    * \brief A virtual member.
    * \param[in] geometry - Geometrical definition of the problem.
    * \param[in] solver_container - Container vector with all the solutions.
-   * \param[in] numerics - Description of the numerical method.
-   * \param[in] config - Definition of the particular problem.
-   * \param[in] iMesh - Index of the mesh in multigrid computations.
-   * \param[in] iRKStep - Current step of the Runge-Kutta iteration.
-   */
-  inline virtual void Convective_Residual(CGeometry *geometry,
-                                          CSolver **solver_container,
-                                          CNumerics *numerics,
-                                          CConfig *config,
-                                          unsigned short iMesh,
-                                          unsigned short iRKStep) { }
-
-  /*!
-   * \brief A virtual member.
-   * \param[in] geometry - Geometrical definition of the problem.
-   * \param[in] solver_container - Container vector with all the solutions.
    * \param[in] config - Definition of the particular problem.
    * \param[in] iRKStep - Current step of the Runge-Kutta iteration.
    * \param[in] RunTime_EqSystem - System of equations which is going to be solved.

--- a/SU2_CFD/src/SU2_CFD.cpp
+++ b/SU2_CFD/src/SU2_CFD.cpp
@@ -143,13 +143,7 @@ int main(int argc, char *argv[]) {
     /*--- Turbomachinery problem. ---*/
     driver = new CTurbomachineryDriver(config_file_name, nZone, MPICommunicator);
 
-  }
-  else {
-
-    /*--- Instantiate the class for external aerodynamics by default. ---*/
-    driver = new CFluidDriver(config_file_name, nZone, MPICommunicator);
-
-  }
+  } /*--- These are all the possible cases ---*/
 
   delete config;
   config = nullptr;

--- a/SU2_CFD/src/integration/CIntegration.cpp
+++ b/SU2_CFD/src/integration/CIntegration.cpp
@@ -58,9 +58,6 @@ void CIntegration::Space_Integration(CGeometry *geometry,
     case SPACE_UPWIND:
       solver_container[MainSolver]->Upwind_Residual(geometry, solver_container, numerics, config, iMesh);
       break;
-    case FINITE_ELEMENT:
-      SU2_MPI::Error("Computation of FEM convective flux in non-FEM integration attempted.", CURRENT_FUNCTION);
-      break;
   }
 
   /*--- Compute viscous residuals ---*/

--- a/SU2_CFD/src/integration/CIntegration.cpp
+++ b/SU2_CFD/src/integration/CIntegration.cpp
@@ -59,7 +59,7 @@ void CIntegration::Space_Integration(CGeometry *geometry,
       solver_container[MainSolver]->Upwind_Residual(geometry, solver_container, numerics, config, iMesh);
       break;
     case FINITE_ELEMENT:
-      solver_container[MainSolver]->Convective_Residual(geometry, solver_container, numerics[CONV_TERM], config, iMesh, iRKStep);
+      SU2_MPI::Error("Computation of FEM convective flux in non-FEM integration attempted.", CURRENT_FUNCTION);
       break;
   }
 


### PR DESCRIPTION
## Proposed Changes
Remove `CSolver::Convective_Residual`, as it does nothing and no derived class overrides it. There is one call in `CIntegration.cpp`, which I would like to replace by an error message. 

Note that in the present version, usage of `numerics[CONV_TERM]` would not be thread-safe, it should be `numerics[CONV_TERM + omp_get_thread_num()*MAX_TERMS]` (see also #1214).

## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [X] I am submitting my contribution to the develop branch.
- [ ] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags, or simply --warnlevel=2 when using meson).
- [ ] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
