### PR TITLE
Fix memory leaks in CHeatSolver

### DIFF
--- a/Common/include/containers/C2DContainer.hpp
+++ b/Common/include/containers/C2DContainer.hpp
@@ -624,39 +624,3 @@ using su2activematrix = su2matrix<su2double>;
 using su2passivevector = su2vector<passivedouble>;
 using su2passivematrix = su2matrix<passivedouble>;
 
-/*--- Functions to allocate 2D/3D data. ---*/
-
-namespace container_helpers {
-
-/*!
- * \brief Allocate a vector of varying-size vectors and initialize with some value.
- * \param[in] M - the first index is >=0 and < M
- * \param[in] N - the second index is >=0 and < N[first index]
- * \param[in,out] X - the vector of vectors
- * \param[in] val - the value for initialization, default is 0
- * \tparam T - type of an element
- */
-template<typename T>
-inline void Alloc2D(unsigned long M, const std::vector<unsigned long>& N, std::vector<std::vector<T> >& X, T val = 0) {
-  X.resize(M);
-  for(unsigned long i = 0; i < M; ++i){
-    X[i].resize(N[i], val);
-  }
-}
-
-/*!
- * \brief Allocate a vector of matrices with varying row count, and initialize with some value.
- * \param[in] M - the first index is >=0 and < M
- * \param[in] N - the second index is >=0 and < N[first index]
- * \param[in] P - the third index is >=0 and < P
- * \param[in,out] X - the vector of matrices
- * \param[in] val - the value for initialization, default is 0
- */
-inline void Alloc3D(unsigned long M, const std::vector<unsigned long>& N, unsigned long P, std::vector<su2activematrix>& X, su2double val=0) {
-  X.resize(M);
-  for(unsigned long i = 0; i < M; ++i){
-    X[i].resize(N[i],P) = su2double(val);
-  }
-}
-
-}

--- a/Common/include/containers/C2DContainer.hpp
+++ b/Common/include/containers/C2DContainer.hpp
@@ -33,6 +33,7 @@
 
 #include <utility>
 #include <type_traits>
+#include <vector>
 
 /*!
  * \enum StorageType
@@ -348,6 +349,7 @@ public:
 #undef MATRIX_ACCESSORS
 #undef VECTOR_ACCESSORS
 #undef UNIV_ACCESSORS
+
 }
 
 /*!
@@ -621,3 +623,40 @@ using su2activematrix = su2matrix<su2double>;
 
 using su2passivevector = su2vector<passivedouble>;
 using su2passivematrix = su2matrix<passivedouble>;
+
+/*--- Functions to allocate 2D/3D data. ---*/
+
+namespace container_helpers {
+
+/*!
+ * \brief Allocate a vector of varying-size vectors and initialize with some value.
+ * \param[in] M - the first index is >=0 and < M
+ * \param[in] N - the second index is >=0 and < N[first index]
+ * \param[in,out] X - the vector of vectors
+ * \param[in] val - the value for initialization, default is 0
+ * \tparam T - type of an element
+ */
+template<typename T>
+inline void Alloc2D(unsigned long M, const std::vector<unsigned long>& N, std::vector<std::vector<T> >& X, T val = 0) {
+  X.resize(M);
+  for(unsigned long i = 0; i < M; ++i){
+    X[i].resize(N[i], val);
+  }
+}
+
+/*!
+ * \brief Allocate a vector of matrices with varying row count, and initialize with some value.
+ * \param[in] M - the first index is >=0 and < M
+ * \param[in] N - the second index is >=0 and < N[first index]
+ * \param[in] P - the third index is >=0 and < P
+ * \param[in,out] X - the vector of matrices
+ * \param[in] val - the value for initialization, default is 0
+ */
+inline void Alloc3D(unsigned long M, const std::vector<unsigned long>& N, unsigned long P, std::vector<su2activematrix>& X, su2double val=0) {
+  X.resize(M);
+  for(unsigned long i = 0; i < M; ++i){
+    X[i].resize(N[i],P) = su2double(val);
+  }
+};
+
+}

--- a/Common/include/containers/C2DContainer.hpp
+++ b/Common/include/containers/C2DContainer.hpp
@@ -33,7 +33,6 @@
 
 #include <utility>
 #include <type_traits>
-#include <vector>
 
 /*!
  * \enum StorageType
@@ -51,7 +50,7 @@ enum SizeType : size_t {DynamicSize=0};
 
 /*--- Namespace to "hide" helper classes and
  functions used by the container class. ---*/
-namespace container_helpers
+namespace container_details
 {
 /*!
  * \class AccessorImpl
@@ -148,7 +147,9 @@ public:
   bool empty() const noexcept {return size()==0;}                       \
   Scalar_t* data() noexcept {return m_data;}                            \
   const Scalar_t* data() const noexcept {return m_data;}                \
+  Scalar_t* begin() noexcept {return data();}                           \
   const Scalar_t* begin() const noexcept {return data();}               \
+  Scalar_t* end() noexcept {return data()+size();}                      \
   const Scalar_t* end() const noexcept {return data()+size();}
 
   /*!
@@ -360,7 +361,6 @@ public:
 #undef MATRIX_ACCESSORS
 #undef VECTOR_ACCESSORS
 #undef UNIV_ACCESSORS
-
 }
 
 /*!
@@ -385,12 +385,12 @@ public:
  */
 template<typename Index_t, class Scalar_t, StorageType Store, size_t AlignSize, size_t StaticRows, size_t StaticCols>
 class C2DContainer :
-  public container_helpers::AccessorImpl<Index_t,Scalar_t,Store,AlignSize,StaticRows,StaticCols>
+  public container_details::AccessorImpl<Index_t,Scalar_t,Store,AlignSize,StaticRows,StaticCols>
 {
   static_assert(std::is_integral<Index_t>::value,"");
 
 private:
-  using Base = container_helpers::AccessorImpl<Index_t,Scalar_t,Store,AlignSize,StaticRows,StaticCols>;
+  using Base = container_details::AccessorImpl<Index_t,Scalar_t,Store,AlignSize,StaticRows,StaticCols>;
   using Base::m_data;
   using Base::m_allocate;
   using Base::m_destroy;
@@ -635,4 +635,3 @@ using su2activematrix = su2matrix<su2double>;
 
 using su2passivevector = su2vector<passivedouble>;
 using su2passivematrix = su2matrix<passivedouble>;
-

--- a/Common/include/containers/C2DContainer.hpp
+++ b/Common/include/containers/C2DContainer.hpp
@@ -657,6 +657,6 @@ inline void Alloc3D(unsigned long M, const std::vector<unsigned long>& N, unsign
   for(unsigned long i = 0; i < M; ++i){
     X[i].resize(N[i],P) = su2double(val);
   }
-};
+}
 
 }

--- a/Common/include/containers/container_decorators.hpp
+++ b/Common/include/containers/container_decorators.hpp
@@ -227,7 +227,7 @@ inline void AllocVectorOfVectors(size_t M, const IndexVector& N, VectorOfVector&
 }
 
 /*!
- * \overload Derive outer size from index vector.
+ * \overload Deduce outer size from index vector.
  */
 template<class IndexVector, class VectorOfVector, class Scalar = int>
 inline void AllocVectorOfVectors(const IndexVector& N, VectorOfVector& X, Scalar val = 0) {
@@ -255,7 +255,7 @@ inline void AllocVectorOfMatrices(size_t M, const IndexVector& N, size_t P, Vect
 }
 
 /*!
- * \overload Derive outer size from index vector.
+ * \overload Deduce outer size from index vector.
  */
 template<class IndexVector, class VectorOfMatrix, class Scalar = int>
 inline void AllocVectorOfMatrices(const IndexVector& N, size_t P, VectorOfMatrix& X, Scalar val=0) {

--- a/Common/include/containers/container_decorators.hpp
+++ b/Common/include/containers/container_decorators.hpp
@@ -205,3 +205,66 @@ struct C3DDummyMiddleView
     return data(i,k);
   }
 };
+
+/*--- Functions to allocate 2D/3D data. ---*/
+
+/*!
+ * \brief Allocate a vector of varying-size vectors and initialize with some value.
+ * \param[in] M - the first index is >=0 and < M
+ * \param[in] N - the second index is >=0 and < N[first index]
+ * \param[in,out] X - the vector of vectors
+ * \param[in] val - the value for initialization, default is 0
+ * \tparam Scalar - type of an element
+ * \tparam IndexVector - type of N
+ */
+template<typename Scalar, typename IndexVector>
+inline void Alloc2D(unsigned long M, const IndexVector& N, std::vector<std::vector<Scalar> >& X, Scalar val = 0) {
+  X.resize(M);
+  for(unsigned long i = 0; i < M; ++i){
+    X[i].resize(N[i], val);
+  }
+}
+/*!
+ * \brief Allocate a vector of varying-size vectors and initialize with some value.
+ * \param[in] N - Vector of ranges of the second index. Its size determines the range of the first index.
+ * \param[in,out] X - the vector of vectors
+ * \param[in] val - the value for initialization, default is 0
+ * \tparam Scalar - type of an element
+ */
+template<typename Scalar>
+inline void Alloc2D(const std::vector<unsigned long>& N, std::vector<std::vector<Scalar> >& X, Scalar val = 0) {
+  unsigned long M = N.size();
+  Alloc2D(M, N, X, val);
+}
+
+/*!
+ * \brief Allocate a vector of matrices with varying row count, and initialize with some value.
+ * \param[in] M - the first index is >=0 and < M
+ * \param[in] N - the second index is >=0 and < N[first index]
+ * \param[in] P - the third index is >=0 and < P
+ * \param[in,out] X - the vector of matrices
+ * \param[in] val - the value for initialization, default is 0
+ * \tparam Matrix - type of a matrix, scalar type is Matrix::Scalar
+ * \tparam IndexVector - type of N
+ */
+template<typename Matrix, typename IndexVector>
+inline void Alloc3D(unsigned long M, const IndexVector& N, unsigned long P, std::vector<Matrix>& X, typename Matrix::Scalar val=0) {
+  X.resize(M);
+  for(unsigned long i = 0; i < M; ++i){
+    X[i].resize(N[i],P) = val;
+  }
+}
+
+/*!
+ * \brief Allocate a vector of matrices with varying row count, and initialize with some value.
+ * \param[in] N - Vector of ranges of the second index. Its size determines the range of the first index.
+ * \param[in] P - the third index is >=0 and < P
+ * \param[in,out] X - the vector of matrices
+ * \param[in] val - the value for initialization, default is 0
+ * \tparam Matrix - type of a matrix, scalar type is Matrix::Scalar
+ */
+template<typename Matrix>
+inline void Alloc3D(const std::vector<unsigned long>& N, unsigned long P, std::vector<Matrix>& X, typename Matrix::Scalar val=0) {
+  unsigned long M = N.size();
+  Alloc3D(M, N, P, X, val);
+}

--- a/Common/include/containers/container_decorators.hpp
+++ b/Common/include/containers/container_decorators.hpp
@@ -206,7 +206,7 @@ struct C3DDummyMiddleView
   }
 };
 
-/*--- Functions to allocate 2D/3D data. ---*/
+/*--- Helper functions to allocate containers of containers. ---*/
 
 /*!
  * \brief Allocate a vector of varying-size vectors and initialize with some value.
@@ -214,26 +214,24 @@ struct C3DDummyMiddleView
  * \param[in] N - the second index is >=0 and < N[first index]
  * \param[in,out] X - the vector of vectors
  * \param[in] val - the value for initialization, default is 0
- * \tparam Scalar - type of an element
  * \tparam IndexVector - type of N
+ * \tparam VectorOfVector - type of X
  */
-template<typename Scalar, typename IndexVector>
-inline void AllocVectorOfVectors(unsigned long M, const IndexVector& N, std::vector<std::vector<Scalar> >& X, Scalar val = 0) {
+template<class IndexVector, class VectorOfVector, class Scalar = int>
+inline void AllocVectorOfVectors(size_t M, const IndexVector& N, VectorOfVector& X, Scalar val = 0) {
   X.resize(M);
-  for(unsigned long i = 0; i < M; ++i){
-    X[i].resize(N[i], val);
+  for(size_t i = 0; i < M; ++i){
+    X[i].resize(N[i]);
+    for (auto& x : X[i]) x = val;
   }
 }
+
 /*!
- * \brief Allocate a vector of varying-size vectors and initialize with some value.
- * \param[in] N - Vector of ranges of the second index. Its size determines the range of the first index.
- * \param[in,out] X - the vector of vectors
- * \param[in] val - the value for initialization, default is 0
- * \tparam Scalar - type of an element
+ * \overload Derive outer size from index vector.
  */
-template<typename Scalar>
-inline void AllocVectorOfVectors(const std::vector<unsigned long>& N, std::vector<std::vector<Scalar> >& X, Scalar val = 0) {
-  unsigned long M = N.size();
+template<class IndexVector, class VectorOfVector, class Scalar = int>
+inline void AllocVectorOfVectors(const IndexVector& N, VectorOfVector& X, Scalar val = 0) {
+  auto M = N.size();
   AllocVectorOfVectors(M, N, X, val);
 }
 
@@ -244,27 +242,23 @@ inline void AllocVectorOfVectors(const std::vector<unsigned long>& N, std::vecto
  * \param[in] P - the third index is >=0 and < P
  * \param[in,out] X - the vector of matrices
  * \param[in] val - the value for initialization, default is 0
- * \tparam Matrix - type of a matrix, scalar type is Matrix::Scalar
  * \tparam IndexVector - type of N
+ * \tparam VectorOfMatrix - type of X
  */
-template<typename Matrix, typename IndexVector>
-inline void AllocVectorOfMatrices(unsigned long M, const IndexVector& N, unsigned long P, std::vector<Matrix>& X, typename Matrix::Scalar val=0) {
+template<class IndexVector, class VectorOfMatrix, class Scalar = int>
+inline void AllocVectorOfMatrices(size_t M, const IndexVector& N, size_t P, VectorOfMatrix& X, Scalar val=0) {
   X.resize(M);
-  for(unsigned long i = 0; i < M; ++i){
-    X[i].resize(N[i],P) = val;
+  for(size_t i = 0; i < M; ++i){
+    X[i].resize(N[i],P);
+    for (auto& x : X[i]) x = val;
   }
 }
 
 /*!
- * \brief Allocate a vector of matrices with varying row count, and initialize with some value.
- * \param[in] N - Vector of ranges of the second index. Its size determines the range of the first index.
- * \param[in] P - the third index is >=0 and < P
- * \param[in,out] X - the vector of matrices
- * \param[in] val - the value for initialization, default is 0
- * \tparam Matrix - type of a matrix, scalar type is Matrix::Scalar
+ * \overload Derive outer size from index vector.
  */
-template<typename Matrix>
-inline void AllocVectorOfMatrices(const std::vector<unsigned long>& N, unsigned long P, std::vector<Matrix>& X, typename Matrix::Scalar val=0) {
-  unsigned long M = N.size();
+template<class IndexVector, class VectorOfMatrix, class Scalar = int>
+inline void AllocVectorOfMatrices(const IndexVector& N, size_t P, VectorOfMatrix& X, Scalar val=0) {
+  auto M = N.size();
   AllocVectorOfMatrices(M, N, P, X, val);
 }

--- a/Common/include/containers/container_decorators.hpp
+++ b/Common/include/containers/container_decorators.hpp
@@ -218,7 +218,7 @@ struct C3DDummyMiddleView
  * \tparam IndexVector - type of N
  */
 template<typename Scalar, typename IndexVector>
-inline void Alloc2D(unsigned long M, const IndexVector& N, std::vector<std::vector<Scalar> >& X, Scalar val = 0) {
+inline void AllocVectorOfVectors(unsigned long M, const IndexVector& N, std::vector<std::vector<Scalar> >& X, Scalar val = 0) {
   X.resize(M);
   for(unsigned long i = 0; i < M; ++i){
     X[i].resize(N[i], val);
@@ -232,9 +232,9 @@ inline void Alloc2D(unsigned long M, const IndexVector& N, std::vector<std::vect
  * \tparam Scalar - type of an element
  */
 template<typename Scalar>
-inline void Alloc2D(const std::vector<unsigned long>& N, std::vector<std::vector<Scalar> >& X, Scalar val = 0) {
+inline void AllocVectorOfVectors(const std::vector<unsigned long>& N, std::vector<std::vector<Scalar> >& X, Scalar val = 0) {
   unsigned long M = N.size();
-  Alloc2D(M, N, X, val);
+  AllocVectorOfVectors(M, N, X, val);
 }
 
 /*!
@@ -248,7 +248,7 @@ inline void Alloc2D(const std::vector<unsigned long>& N, std::vector<std::vector
  * \tparam IndexVector - type of N
  */
 template<typename Matrix, typename IndexVector>
-inline void Alloc3D(unsigned long M, const IndexVector& N, unsigned long P, std::vector<Matrix>& X, typename Matrix::Scalar val=0) {
+inline void AllocVectorOfMatrices(unsigned long M, const IndexVector& N, unsigned long P, std::vector<Matrix>& X, typename Matrix::Scalar val=0) {
   X.resize(M);
   for(unsigned long i = 0; i < M; ++i){
     X[i].resize(N[i],P) = val;
@@ -264,7 +264,7 @@ inline void Alloc3D(unsigned long M, const IndexVector& N, unsigned long P, std:
  * \tparam Matrix - type of a matrix, scalar type is Matrix::Scalar
  */
 template<typename Matrix>
-inline void Alloc3D(const std::vector<unsigned long>& N, unsigned long P, std::vector<Matrix>& X, typename Matrix::Scalar val=0) {
+inline void AllocVectorOfMatrices(const std::vector<unsigned long>& N, unsigned long P, std::vector<Matrix>& X, typename Matrix::Scalar val=0) {
   unsigned long M = N.size();
-  Alloc3D(M, N, P, X, val);
+  AllocVectorOfMatrices(M, N, P, X, val);
 }

--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -7472,6 +7472,7 @@ CConfig::~CConfig(void) {
   delete[] Marker_Analyze;
   delete[] Marker_WallFunctions;
   delete[] Marker_ZoneInterface;
+  delete[] Marker_CHTInterface;
   delete [] Marker_PyCustom;
   delete[] Marker_All_SendRecv;
 

--- a/SU2_CFD/include/solvers/CFVMFlowSolverBase.inl
+++ b/SU2_CFD/include/solvers/CFVMFlowSolverBase.inl
@@ -108,40 +108,26 @@ void CFVMFlowSolverBase<V, R>::Allocate(const CConfig& config) {
   /*--- LinSysSol will always be init to 0. ---*/
   System.SetxIsZero(true);
 
-  /*--- Allocates a 2D array with variable "outer" sizes and init to 0. ---*/
-
-  auto Alloc2D = [](unsigned long M, const vector<unsigned long>& N, vector<vector<su2double> >& X) {
-    X.resize(M);
-    for (unsigned long i = 0; i < M; ++i) X[i].resize(N[i],0.0);
-  };
-
-  /*--- Allocates a 3D array with variable "middle" sizes and init to 0. ---*/
-
-  auto Alloc3D = [](unsigned long M, const vector<unsigned long>& N, unsigned long P, vector<su2activematrix>& X) {
-    X.resize(M);
-    for (unsigned long i = 0; i < M; ++i) X[i].resize(N[i],P) = su2double(0.0);
-  };
-
   /*--- Store the value of the characteristic primitive variables at the boundaries ---*/
 
-  Alloc3D(nMarker, nVertex, nPrimVar, CharacPrimVar);
+  AllocVectorOfMatrices(nVertex, nPrimVar, CharacPrimVar);
 
   /*--- Store the value of the Total Pressure at the inlet BC ---*/
 
-  Alloc2D(nMarker, nVertex, Inlet_Ttotal);
+  AllocVectorOfVectors(nVertex, Inlet_Ttotal);
 
   /*--- Store the value of the Total Temperature at the inlet BC ---*/
 
-  Alloc2D(nMarker, nVertex, Inlet_Ptotal);
+  AllocVectorOfVectors(nVertex, Inlet_Ptotal);
 
   /*--- Store the value of the Flow direction at the inlet BC ---*/
 
-  Alloc3D(nMarker, nVertex, nDim, Inlet_FlowDir);
+  AllocVectorOfMatrices(nVertex, nDim, Inlet_FlowDir);
 
   /*--- Force definition and coefficient arrays for all of the markers ---*/
 
-  Alloc2D(nMarker, nVertex, CPressure);
-  Alloc2D(nMarker, nVertex, CPressureTarget);
+  AllocVectorOfVectors(nVertex, CPressure);
+  AllocVectorOfVectors(nVertex, CPressureTarget);
 
   /*--- Non dimensional aerodynamic coefficients ---*/
 
@@ -179,26 +165,26 @@ void CFVMFlowSolverBase<V, R>::Allocate(const CConfig& config) {
 
   /*--- Heat flux in all the markers ---*/
 
-  Alloc2D(nMarker, nVertex, HeatFlux);
-  Alloc2D(nMarker, nVertex, HeatFluxTarget);
+  AllocVectorOfVectors(nVertex, HeatFlux);
+  AllocVectorOfVectors(nVertex, HeatFluxTarget);
 
   /*--- Y plus in all the markers ---*/
 
-  Alloc2D(nMarker, nVertex, YPlus);
+  AllocVectorOfVectors(nVertex, YPlus);
 
   /*--- Skin friction in all the markers ---*/
 
-  Alloc3D(nMarker, nVertex, nDim, CSkinFriction);
+  AllocVectorOfMatrices(nVertex, nDim, CSkinFriction);
 
   /*--- Wall Shear Stress in all the markers ---*/
 
-  Alloc2D(nMarker, nVertex, WallShearStress);
+  AllocVectorOfVectors(nVertex, WallShearStress);
 
   /*--- Store the values of the temperature and the heat flux density at the boundaries,
    used for coupling with a solid donor cell ---*/
   constexpr auto nHeatConjugateVar = 4u;
 
-  Alloc3D(nMarker, nVertex, nHeatConjugateVar, HeatConjugateVar);
+  AllocVectorOfMatrices(nVertex, nHeatConjugateVar, HeatConjugateVar);
   for (auto& x : HeatConjugateVar) x = config.GetTemperature_FreeStreamND();
 
   if (MGLevel == MESH_0) {

--- a/SU2_CFD/include/solvers/CFVMFlowSolverBase.inl
+++ b/SU2_CFD/include/solvers/CFVMFlowSolverBase.inl
@@ -183,24 +183,17 @@ void CFVMFlowSolverBase<V, R>::Allocate(const CConfig& config) {
   /*--- Store the values of the temperature and the heat flux density at the boundaries,
    used for coupling with a solid donor cell ---*/
   constexpr auto nHeatConjugateVar = 4u;
-
-  AllocVectorOfMatrices(nVertex, nHeatConjugateVar, HeatConjugateVar);
-  for (auto& x : HeatConjugateVar) x = config.GetTemperature_FreeStreamND();
+  AllocVectorOfMatrices(nVertex, nHeatConjugateVar, HeatConjugateVar, config.GetTemperature_FreeStreamND());
 
   if (MGLevel == MESH_0) {
-    VertexTraction.resize(nMarker);
-    for (unsigned long iMarker = 0; iMarker < nMarker; iMarker++) {
-      if (config.GetSolid_Wall(iMarker))
-        VertexTraction[iMarker].resize(nVertex[iMarker], nDim) = su2double(0.0);
-    }
+    auto nSolidVertex = nVertex;
+    for (unsigned long iMarker = 0; iMarker < nMarker; iMarker++)
+      if (!config.GetSolid_Wall(iMarker))
+        nSolidVertex[iMarker] = 0;
 
-    if (config.GetDiscrete_Adjoint()) {
-      VertexTractionAdjoint.resize(nMarker);
-      for (unsigned long iMarker = 0; iMarker < nMarker; iMarker++) {
-        if (config.GetSolid_Wall(iMarker))
-          VertexTractionAdjoint[iMarker].resize(nVertex[iMarker], nDim) = su2double(0.0);
-      }
-    }
+    AllocVectorOfMatrices(nSolidVertex, nDim, VertexTraction);
+
+    if (config.GetDiscrete_Adjoint()) AllocVectorOfMatrices(nSolidVertex, nDim, VertexTractionAdjoint);
   }
 
   /*--- Initialize the BGS residuals in FSI problems. ---*/

--- a/SU2_CFD/include/solvers/CHeatSolver.hpp
+++ b/SU2_CFD/include/solvers/CHeatSolver.hpp
@@ -38,12 +38,23 @@
  */
 class CHeatSolver final : public CSolver {
 protected:
+  static constexpr size_t MAXNDIM = 3; /*!< \brief Max number of space dimensions, used in some static arrays. */
+  static constexpr size_t MAXNVAR = 1; /*!< \brief Max number of variables, for static arrays. */
+
   unsigned short nVarFlow, nMarker, CurrentMesh;
-  su2double **HeatFlux, *HeatFlux_per_Marker, *Surface_HF, Total_HeatFlux, AllBound_HeatFlux,
-            *AverageT_per_Marker, Total_AverageT, AllBound_AverageT,
-            *Primitive, *Primitive_Flow_i, *Primitive_Flow_j,
-            *Surface_Areas, Total_HeatFlux_Areas, Total_HeatFlux_Areas_Monitor;
-  su2double ***ConjugateVar, ***InterfaceVar;
+  vector<vector<su2double> > HeatFlux;
+  vector<su2double> HeatFlux_per_Marker;
+  su2double Total_HeatFlux;
+  su2double AllBound_HeatFlux;
+  vector<su2double> AverageT_per_Marker;
+  su2double Total_AverageT;
+  su2double AllBound_AverageT;
+  vector<su2double>  Primitive_Flow_i;
+  vector<su2double> Primitive_Flow_j;
+  vector<su2double> Surface_Areas;
+  su2double Total_HeatFlux_Areas;
+  su2double Total_HeatFlux_Areas_Monitor;
+  vector<su2activematrix> ConjugateVar;
 
   CHeatVariable* nodes = nullptr;  /*!< \brief The highest level in the variable hierarchy this solver can safely use. */
 

--- a/SU2_CFD/src/solvers/CEulerSolver.cpp
+++ b/SU2_CFD/src/solvers/CEulerSolver.cpp
@@ -176,7 +176,7 @@ CEulerSolver::CEulerSolver(CGeometry *geometry, CConfig *config,
   /*--- Store the value of the primitive variables + 2 turb variables at the boundaries,
    used for IO with a donor cell ---*/
 
-  Alloc3D(nVertex, (rans? nPrimVar+2 : nPrimVar), DonorPrimVar);
+  AllocVectorOfMatrices(nVertex, (rans? nPrimVar+2 : nPrimVar), DonorPrimVar);
 
   /*--- Store the value of the characteristic primitive variables index at the boundaries ---*/
 
@@ -194,18 +194,18 @@ CEulerSolver::CEulerSolver(CGeometry *geometry, CConfig *config,
   ActDisk_Axis.resize(nMarker, MAXNDIM);
 
   /*--- Actuator Disk Fa, Fx, Fy and Fz allocations ---*/
-  Alloc2D(nVertex, ActDisk_Fa);
-  Alloc2D(nVertex, ActDisk_Fx);
-  Alloc2D(nVertex, ActDisk_Fy);
-  Alloc2D(nVertex, ActDisk_Fz);
+  AllocVectorOfVectors(nVertex, ActDisk_Fa);
+  AllocVectorOfVectors(nVertex, ActDisk_Fx);
+  AllocVectorOfVectors(nVertex, ActDisk_Fy);
+  AllocVectorOfVectors(nVertex, ActDisk_Fz);
 
   /*--- Store the value of the Delta P at the Actuator Disk ---*/
 
-  Alloc2D(nVertex, ActDisk_DeltaP);
+  AllocVectorOfVectors(nVertex, ActDisk_DeltaP);
 
   /*--- Store the value of the Delta T at the Actuator Disk ---*/
 
-  Alloc2D(nVertex, ActDisk_DeltaT);
+  AllocVectorOfVectors(nVertex, ActDisk_DeltaT);
 
   /*--- Supersonic coefficients ---*/
 

--- a/SU2_CFD/src/solvers/CEulerSolver.cpp
+++ b/SU2_CFD/src/solvers/CEulerSolver.cpp
@@ -173,19 +173,8 @@ CEulerSolver::CEulerSolver(CGeometry *geometry, CConfig *config,
       cout << "Explicit scheme. No Jacobian structure (" << description << "). MG level: " << iMesh <<"." << endl;
   }
 
-  /*--- Allocates a 2D array with variable "outer" sizes and init to 0. ---*/
-
-  auto Alloc2D = [](unsigned long M, const vector<unsigned long>& N, vector<vector<su2double> >& X) {
-    X.resize(M);
-    for(unsigned long i = 0; i < M; ++i) X[i].resize(N[i], 0.0);
-  };
-
-  /*--- Allocates a 3D array with variable "middle" sizes and init to 0. ---*/
-
-  auto Alloc3D = [](unsigned long M, const vector<unsigned long>& N, unsigned long P, vector<su2activematrix>& X) {
-    X.resize(M);
-    for(unsigned long i = 0; i < M; ++i) X[i].resize(N[i],P) = su2double(0.0);
-  };
+  using container_helpers::Alloc2D;
+  using container_helpers::Alloc3D;
 
   /*--- Store the value of the primitive variables + 2 turb variables at the boundaries,
    used for IO with a donor cell ---*/

--- a/SU2_CFD/src/solvers/CEulerSolver.cpp
+++ b/SU2_CFD/src/solvers/CEulerSolver.cpp
@@ -173,13 +173,10 @@ CEulerSolver::CEulerSolver(CGeometry *geometry, CConfig *config,
       cout << "Explicit scheme. No Jacobian structure (" << description << "). MG level: " << iMesh <<"." << endl;
   }
 
-  using container_helpers::Alloc2D;
-  using container_helpers::Alloc3D;
-
   /*--- Store the value of the primitive variables + 2 turb variables at the boundaries,
    used for IO with a donor cell ---*/
 
-  Alloc3D(nMarker, nVertex, (rans? nPrimVar+2 : nPrimVar), DonorPrimVar);
+  Alloc3D(nVertex, (rans? nPrimVar+2 : nPrimVar), DonorPrimVar);
 
   /*--- Store the value of the characteristic primitive variables index at the boundaries ---*/
 
@@ -197,18 +194,18 @@ CEulerSolver::CEulerSolver(CGeometry *geometry, CConfig *config,
   ActDisk_Axis.resize(nMarker, MAXNDIM);
 
   /*--- Actuator Disk Fa, Fx, Fy and Fz allocations ---*/
-  Alloc2D(nMarker, nVertex, ActDisk_Fa);
-  Alloc2D(nMarker, nVertex, ActDisk_Fx);
-  Alloc2D(nMarker, nVertex, ActDisk_Fy);
-  Alloc2D(nMarker, nVertex, ActDisk_Fz);
+  Alloc2D(nVertex, ActDisk_Fa);
+  Alloc2D(nVertex, ActDisk_Fx);
+  Alloc2D(nVertex, ActDisk_Fy);
+  Alloc2D(nVertex, ActDisk_Fz);
 
   /*--- Store the value of the Delta P at the Actuator Disk ---*/
 
-  Alloc2D(nMarker, nVertex, ActDisk_DeltaP);
+  Alloc2D(nVertex, ActDisk_DeltaP);
 
   /*--- Store the value of the Delta T at the Actuator Disk ---*/
 
-  Alloc2D(nMarker, nVertex, ActDisk_DeltaT);
+  Alloc2D(nVertex, ActDisk_DeltaT);
 
   /*--- Supersonic coefficients ---*/
 

--- a/SU2_CFD/src/solvers/CHeatSolver.cpp
+++ b/SU2_CFD/src/solvers/CHeatSolver.cpp
@@ -72,20 +72,6 @@ CHeatSolver::CHeatSolver(CGeometry *geometry, CConfig *config, unsigned short iM
   for (iMarker = 0; iMarker < nMarker; iMarker++)
     nVertex[iMarker] = geometry->nVertex[iMarker];
 
-  /*--- Allocates a 2D array with variable "outer" sizes and init to 0. ---*/
-
-  auto Alloc2D = [](unsigned long M, const vector<unsigned long>& N, vector<vector<su2double> >& X) {
-    X.resize(M);
-    for(unsigned long i = 0; i < M; ++i) X[i].resize(N[i], 0.0);
-  };
-
-  /*--- Allocates a 3D array with variable "middle" sizes and init to 0. ---*/
-
-  auto Alloc3D = [](unsigned long M, const vector<unsigned long>& N, unsigned long P, vector<su2activematrix>& X) {
-    X.resize(M);
-    for(unsigned long i = 0; i < M; ++i) X[i].resize(N[i],P) = su2double(0.0);
-  };
-
   /*--- Define some auxiliar vector related with the residual ---*/
 
   Residual      = new su2double[nVar];  for (iVar = 0; iVar < nVar; iVar++) Residual[iVar]      = 0.0;
@@ -191,7 +177,7 @@ CHeatSolver::CHeatSolver(CGeometry *geometry, CConfig *config, unsigned short iM
 
   unsigned short nConjVariables = 4;
 
-  Alloc3D(nMarker, nVertex, nConjVariables, ConjugateVar);
+  container_helpers::Alloc3D(nMarker, nVertex, nConjVariables, ConjugateVar);
   for (iMarker = 0; iMarker < nMarker; iMarker++) {
     for (iVertex = 0; iVertex < geometry->nVertex[iMarker]; iVertex++) {
       ConjugateVar[iMarker][iVertex][0] = config->GetTemperature_FreeStreamND();
@@ -200,7 +186,7 @@ CHeatSolver::CHeatSolver(CGeometry *geometry, CConfig *config, unsigned short iM
 
   /*--- Heat flux in all the markers ---*/
 
-  Alloc2D(nMarker, nVertex, HeatFlux);
+  container_helpers::Alloc2D(nMarker, nVertex, HeatFlux);
 
   if (multizone){
     /*--- Initialize the BGS residuals. ---*/

--- a/SU2_CFD/src/solvers/CHeatSolver.cpp
+++ b/SU2_CFD/src/solvers/CHeatSolver.cpp
@@ -33,7 +33,6 @@ CHeatSolver::CHeatSolver(void) : CSolver() { }
 CHeatSolver::CHeatSolver(CGeometry *geometry, CConfig *config, unsigned short iMesh) : CSolver() {
 
   unsigned short iVar, iDim, nLineLets, iMarker;
-  unsigned long iVertex;
 
   bool multizone = config->GetMultizone_Problem();
 
@@ -176,13 +175,7 @@ CHeatSolver::CHeatSolver(CGeometry *geometry, CConfig *config, unsigned short iM
    used for communications with donor cells ---*/
 
   unsigned short nConjVariables = 4;
-
-  AllocVectorOfMatrices(nVertex, nConjVariables, ConjugateVar);
-  for (iMarker = 0; iMarker < nMarker; iMarker++) {
-    for (iVertex = 0; iVertex < geometry->nVertex[iMarker]; iVertex++) {
-      ConjugateVar[iMarker][iVertex][0] = config->GetTemperature_FreeStreamND();
-    }
-  }
+  AllocVectorOfMatrices(nVertex, nConjVariables, ConjugateVar, config->GetTemperature_FreeStreamND());
 
   /*--- Heat flux in all the markers ---*/
 

--- a/SU2_CFD/src/solvers/CHeatSolver.cpp
+++ b/SU2_CFD/src/solvers/CHeatSolver.cpp
@@ -28,11 +28,7 @@
 #include "../../include/solvers/CHeatSolver.hpp"
 #include "../../../Common/include/toolboxes/geometry_toolbox.hpp"
 
-CHeatSolver::CHeatSolver(void) : CSolver() {
-
-  ConjugateVar = nullptr;
-  HeatFlux     = nullptr;
-}
+CHeatSolver::CHeatSolver(void) : CSolver() { }
 
 CHeatSolver::CHeatSolver(CGeometry *geometry, CConfig *config, unsigned short iMesh) : CSolver() {
 
@@ -69,6 +65,27 @@ CHeatSolver::CHeatSolver(CGeometry *geometry, CConfig *config, unsigned short iM
   nMarker = config->GetnMarker_All();
 
   CurrentMesh = iMesh;
+
+  /*--- Store the number of vertices on each marker for deallocation later ---*/
+
+  nVertex.resize(nMarker);
+  for (iMarker = 0; iMarker < nMarker; iMarker++)
+    nVertex[iMarker] = geometry->nVertex[iMarker];
+
+  /*--- Allocates a 2D array with variable "outer" sizes and init to 0. ---*/
+
+  auto Alloc2D = [](unsigned long M, const vector<unsigned long>& N, vector<vector<su2double> >& X) {
+    X.resize(M);
+    for(unsigned long i = 0; i < M; ++i) X[i].resize(N[i], 0.0);
+  };
+
+  /*--- Allocates a 3D array with variable "middle" sizes and init to 0. ---*/
+
+  auto Alloc3D = [](unsigned long M, const vector<unsigned long>& N, unsigned long P, vector<su2activematrix>& X) {
+    X.resize(M);
+    for(unsigned long i = 0; i < M; ++i) X[i].resize(N[i],P) = su2double(0.0);
+  };
+
   /*--- Define some auxiliar vector related with the residual ---*/
 
   Residual      = new su2double[nVar];  for (iVar = 0; iVar < nVar; iVar++) Residual[iVar]      = 0.0;
@@ -97,8 +114,8 @@ CHeatSolver::CHeatSolver(CGeometry *geometry, CConfig *config, unsigned short iM
 
   /*--- Define some auxiliary vectors related to the primitive flow solution ---*/
 
-  Primitive_Flow_i = new su2double[nDim+1]; for (iVar = 0; iVar < nDim+1; iVar++) Primitive_Flow_i[iVar] = 0.0;
-  Primitive_Flow_j = new su2double[nDim+1]; for (iVar = 0; iVar < nDim+1; iVar++) Primitive_Flow_j[iVar] = 0.0;
+  Primitive_Flow_i.resize(nDim+1, 0.0);
+  Primitive_Flow_j.resize(nDim+1, 0.0);
 
   /*--- Jacobians and vector structures for implicit computations ---*/
 
@@ -129,17 +146,9 @@ CHeatSolver::CHeatSolver(CGeometry *geometry, CConfig *config, unsigned short iM
     OutputHeadingNames = new string[nOutputVariables];
   }
 
-  HeatFlux_per_Marker = new su2double[nMarker];
-  AverageT_per_Marker = new su2double[nMarker];
-  Surface_Areas       = new su2double[config->GetnMarker_HeatFlux()];
-
-  for(iMarker = 0; iMarker < nMarker; iMarker++) {
-    HeatFlux_per_Marker[iMarker]        = 0.0;
-    AverageT_per_Marker[iMarker]  = 0.0;
-  }
-  for(iMarker = 0; iMarker < config->GetnMarker_HeatFlux(); iMarker++) {
-    Surface_Areas[iMarker] = 0.0;
-  }
+  HeatFlux_per_Marker.resize(nMarker, 0.0);
+  AverageT_per_Marker.resize(nMarker, 0.0);
+  Surface_Areas.resize(config->GetnMarker_HeatFlux(), 0.0);
 
   Set_Heatflux_Areas(geometry, config);
 
@@ -182,28 +191,16 @@ CHeatSolver::CHeatSolver(CGeometry *geometry, CConfig *config, unsigned short iM
 
   unsigned short nConjVariables = 4;
 
-  ConjugateVar = new su2double** [nMarker];
+  Alloc3D(nMarker, nVertex, nConjVariables, ConjugateVar);
   for (iMarker = 0; iMarker < nMarker; iMarker++) {
-    ConjugateVar[iMarker] = new su2double* [geometry->nVertex[iMarker]];
     for (iVertex = 0; iVertex < geometry->nVertex[iMarker]; iVertex++) {
-
-      ConjugateVar[iMarker][iVertex] = new su2double [nConjVariables];
-      for (iVar = 0; iVar < nConjVariables ; iVar++) {
-        ConjugateVar[iMarker][iVertex][iVar] = 0.0;
-      }
       ConjugateVar[iMarker][iVertex][0] = config->GetTemperature_FreeStreamND();
     }
   }
 
   /*--- Heat flux in all the markers ---*/
 
-  HeatFlux = new su2double* [nMarker];
-  for (iMarker = 0; iMarker < nMarker; iMarker++) {
-    HeatFlux[iMarker] = new su2double [geometry->nVertex[iMarker]];
-    for (iVertex = 0; iVertex < geometry->nVertex[iMarker]; iVertex++) {
-      HeatFlux[iMarker][iVertex] = 0.0;
-    }
-  }
+  Alloc2D(nMarker, nVertex, HeatFlux);
 
   if (multizone){
     /*--- Initialize the BGS residuals. ---*/
@@ -230,15 +227,6 @@ CHeatSolver::CHeatSolver(CGeometry *geometry, CConfig *config, unsigned short iM
 }
 
 CHeatSolver::~CHeatSolver(void) {
-
-  unsigned short iMarker;
-
-  if (HeatFlux != nullptr) {
-    for (iMarker = 0; iMarker < nMarker; iMarker++) {
-      delete [] HeatFlux[iMarker];
-    }
-    delete [] HeatFlux;
-  }
 
   delete nodes;
 }
@@ -292,13 +280,9 @@ void CHeatSolver::LoadRestart(CGeometry **geometry, CSolver ***solver, CConfig *
   bool heat_equation = ((config->GetKind_Solver() == HEAT_EQUATION) ||
                         (config->GetKind_Solver() == DISC_ADJ_HEAT));
 
-  su2double Area_Children, Area_Parent, *Coord, *Solution_Fine;
+  su2double Area_Children, Area_Parent, *Solution_Fine;
 
   string restart_filename = config->GetFilename(config->GetSolution_FileName(), "", val_iter);
-
-  Coord = new su2double [nDim];
-  for (iDim = 0; iDim < nDim; iDim++)
-    Coord[iDim] = 0.0;
 
   int counter = 0;
   long iPoint_Local = 0; unsigned long iPoint_Global = 0;
@@ -393,8 +377,6 @@ void CHeatSolver::LoadRestart(CGeometry **geometry, CSolver ***solver, CConfig *
     solver[iMesh][HEAT_SOL]->CompleteComms(geometry[iMesh], config, SOLUTION);
     solver[iMesh][HEAT_SOL]->Preprocessing(geometry[iMesh], solver[iMesh], config, iMesh, NO_RK_ITER, RUNTIME_HEAT_SYS, false);
   }
-
-  delete [] Coord;
 
   /*--- Delete the class memory that is used to load the restart. ---*/
 
@@ -526,7 +508,7 @@ void CHeatSolver::Upwind_Residual(CGeometry *geometry, CSolver **solver_containe
         Temp_i_Corrected = Temp_i + Project_Temp_i_Grad;
         Temp_j_Corrected = Temp_j + Project_Temp_j_Grad;
 
-        numerics->SetPrimitive(Primitive_Flow_i, Primitive_Flow_j);
+        numerics->SetPrimitive(Primitive_Flow_i.data(), Primitive_Flow_j.data());
         numerics->SetTemperature(Temp_i_Corrected, Temp_j_Corrected);
       }
 
@@ -667,7 +649,7 @@ void CHeatSolver::Set_Heatflux_Areas(CGeometry *geometry, CConfig *config) {
     }
   }
 
-  SU2_MPI::Allreduce(Local_Surface_Areas, Surface_Areas, config->GetnMarker_HeatFlux(), MPI_DOUBLE, MPI_SUM, SU2_MPI::GetComm());
+  SU2_MPI::Allreduce(Local_Surface_Areas, Surface_Areas.data(), config->GetnMarker_HeatFlux(), MPI_DOUBLE, MPI_SUM, SU2_MPI::GetComm());
   SU2_MPI::Allreduce(&Local_HeatFlux_Areas_Monitor, &Total_HeatFlux_Areas_Monitor, 1, MPI_DOUBLE, MPI_SUM, SU2_MPI::GetComm());
 
   Total_HeatFlux_Areas = 0.0;
@@ -807,7 +789,7 @@ void CHeatSolver::BC_Inlet(CGeometry *geometry, CSolver **solver_container,
   bool implicit             = (config->GetKind_TimeIntScheme_Flow() == EULER_IMPLICIT);
   string Marker_Tag         = config->GetMarker_All_TagBound(val_marker);
 
-  su2double *Normal = new su2double[nDim];
+  su2double Normal[MAXNDIM];
 
   su2double *Coord_i, *Coord_j, Area, dist_ij, laminar_viscosity, thermal_diffusivity, Twall, dTdn, Prandtl_Lam;
   //su2double Prandtl_Turb;
@@ -902,9 +884,6 @@ void CHeatSolver::BC_Inlet(CGeometry *geometry, CSolver **solver_container,
     }
   }
 
-  /*--- Free locally allocated memory ---*/
-  delete [] Normal;
-
 }
 
 void CHeatSolver::BC_Outlet(CGeometry *geometry, CSolver **solver_container,
@@ -920,7 +899,7 @@ void CHeatSolver::BC_Outlet(CGeometry *geometry, CSolver **solver_container,
                || (config->GetKind_Solver() == DISC_ADJ_INC_RANS));
   bool implicit             = (config->GetKind_TimeIntScheme_Flow() == EULER_IMPLICIT);
 
-  su2double *Normal = new su2double[nDim];
+  su2double Normal[MAXNDIM];
 
   for (iVertex = 0; iVertex < geometry->nVertex[val_marker]; iVertex++) {
 
@@ -971,9 +950,6 @@ void CHeatSolver::BC_Outlet(CGeometry *geometry, CSolver **solver_container,
     }
   }
 
-  /*--- Free locally allocated memory ---*/
-  delete [] Normal;
-
 }
 
 void CHeatSolver::BC_ConjugateHeat_Interface(CGeometry *geometry, CSolver **solver_container, CNumerics *numerics, CConfig *config, unsigned short val_marker) {
@@ -989,7 +965,7 @@ void CHeatSolver::BC_ConjugateHeat_Interface(CGeometry *geometry, CSolver **solv
                || (config->GetKind_Solver() == DISC_ADJ_INC_NAVIER_STOKES)
                || (config->GetKind_Solver() == DISC_ADJ_INC_RANS));
 
-  su2double *Normal = new su2double[nDim];
+  su2double* Normal = nullptr;
 
   Temperature_Ref       = config->GetTemperature_Ref();
   rho_cp_solid          = config->GetDensity_Solid()*config->GetSpecific_Heat_Cp();
@@ -1565,7 +1541,7 @@ void CHeatSolver::SetInitialCondition(CGeometry **geometry, CSolver ***solver_co
 
   if (restart && (TimeIter == 0)) {
 
-    Solution = new su2double[nVar];
+    su2double Solution[MAXNVAR];
     for (iMesh = 1; iMesh <= config->GetnMGLevels(); iMesh++) {
       for (iPoint = 0; iPoint < geometry[iMesh]->GetnPoint(); iPoint++) {
         Area_Parent = geometry[iMesh]->nodes->GetVolume(iPoint);
@@ -1583,7 +1559,6 @@ void CHeatSolver::SetInitialCondition(CGeometry **geometry, CSolver ***solver_co
       solver_container[iMesh][HEAT_SOL]->InitiateComms(geometry[iMesh], config, SOLUTION);
       solver_container[iMesh][HEAT_SOL]->CompleteComms(geometry[iMesh], config, SOLUTION);
     }
-    delete [] Solution;
   }
 
   /*--- The value of the solution for the first iteration of the dual time ---*/

--- a/SU2_CFD/src/solvers/CHeatSolver.cpp
+++ b/SU2_CFD/src/solvers/CHeatSolver.cpp
@@ -177,7 +177,7 @@ CHeatSolver::CHeatSolver(CGeometry *geometry, CConfig *config, unsigned short iM
 
   unsigned short nConjVariables = 4;
 
-  container_helpers::Alloc3D(nMarker, nVertex, nConjVariables, ConjugateVar);
+  Alloc3D(nVertex, nConjVariables, ConjugateVar);
   for (iMarker = 0; iMarker < nMarker; iMarker++) {
     for (iVertex = 0; iVertex < geometry->nVertex[iMarker]; iVertex++) {
       ConjugateVar[iMarker][iVertex][0] = config->GetTemperature_FreeStreamND();
@@ -186,7 +186,7 @@ CHeatSolver::CHeatSolver(CGeometry *geometry, CConfig *config, unsigned short iM
 
   /*--- Heat flux in all the markers ---*/
 
-  container_helpers::Alloc2D(nMarker, nVertex, HeatFlux);
+  Alloc2D(nVertex, HeatFlux);
 
   if (multizone){
     /*--- Initialize the BGS residuals. ---*/
@@ -635,7 +635,7 @@ void CHeatSolver::Set_Heatflux_Areas(CGeometry *geometry, CConfig *config) {
     }
   }
 
-  SU2_MPI::Allreduce(Local_Surface_Areas, Surface_Areas.data(), config->GetnMarker_HeatFlux(), MPI_DOUBLE, MPI_SUM, SU2_MPI::GetComm());
+  SU2_MPI::Allreduce(Local_Surface_Areas, Surface_Areas.data(), Surface_Areas.size(), MPI_DOUBLE, MPI_SUM, SU2_MPI::GetComm());
   SU2_MPI::Allreduce(&Local_HeatFlux_Areas_Monitor, &Total_HeatFlux_Areas_Monitor, 1, MPI_DOUBLE, MPI_SUM, SU2_MPI::GetComm());
 
   Total_HeatFlux_Areas = 0.0;
@@ -962,7 +962,7 @@ void CHeatSolver::BC_ConjugateHeat_Interface(CGeometry *geometry, CSolver **solv
 
       if (geometry->nodes->GetDomain(iPoint)) {
 
-        su2double const* Normal = geometry->vertex[val_marker][iVertex]->GetNormal();
+        const su2double* Normal = geometry->vertex[val_marker][iVertex]->GetNormal();
         Area = GeometryToolbox::Norm(nDim, Normal);
 
         T_Conjugate = GetConjugateHeatVariable(val_marker, iVertex, 0)/Temperature_Ref;

--- a/SU2_CFD/src/solvers/CHeatSolver.cpp
+++ b/SU2_CFD/src/solvers/CHeatSolver.cpp
@@ -177,7 +177,7 @@ CHeatSolver::CHeatSolver(CGeometry *geometry, CConfig *config, unsigned short iM
 
   unsigned short nConjVariables = 4;
 
-  Alloc3D(nVertex, nConjVariables, ConjugateVar);
+  AllocVectorOfMatrices(nVertex, nConjVariables, ConjugateVar);
   for (iMarker = 0; iMarker < nMarker; iMarker++) {
     for (iVertex = 0; iVertex < geometry->nVertex[iMarker]; iVertex++) {
       ConjugateVar[iMarker][iVertex][0] = config->GetTemperature_FreeStreamND();
@@ -186,7 +186,7 @@ CHeatSolver::CHeatSolver(CGeometry *geometry, CConfig *config, unsigned short iM
 
   /*--- Heat flux in all the markers ---*/
 
-  Alloc2D(nVertex, HeatFlux);
+  AllocVectorOfVectors(nVertex, HeatFlux);
 
   if (multizone){
     /*--- Initialize the BGS residuals. ---*/

--- a/SU2_CFD/src/solvers/CHeatSolver.cpp
+++ b/SU2_CFD/src/solvers/CHeatSolver.cpp
@@ -269,7 +269,7 @@ void CHeatSolver::LoadRestart(CGeometry **geometry, CSolver ***solver, CConfig *
 
   /*--- Restart the solution from file information ---*/
 
-  unsigned short iDim, iVar, iMesh;
+  unsigned short iVar, iMesh;
   unsigned long iPoint, index, iChildren, Point_Fine;
 
   bool flow = ((config->GetKind_Solver() == INC_NAVIER_STOKES)
@@ -1530,7 +1530,7 @@ void CHeatSolver::SetInitialCondition(CGeometry **geometry, CSolver ***solver_co
 
   unsigned long iPoint, Point_Fine;
   unsigned short iMesh, iChildren, iVar;
-  su2double Area_Children, Area_Parent, *Solution_Fine, *Solution;
+  su2double Area_Children, Area_Parent, *Solution_Fine;
 
   bool restart   = (config->GetRestart() || config->GetRestart_Flow());
   bool dual_time = ((config->GetTime_Marching() == DT_STEPPING_1ST) ||

--- a/SU2_CFD/src/solvers/CHeatSolver.cpp
+++ b/SU2_CFD/src/solvers/CHeatSolver.cpp
@@ -965,8 +965,6 @@ void CHeatSolver::BC_ConjugateHeat_Interface(CGeometry *geometry, CSolver **solv
                || (config->GetKind_Solver() == DISC_ADJ_INC_NAVIER_STOKES)
                || (config->GetKind_Solver() == DISC_ADJ_INC_RANS));
 
-  su2double* Normal = nullptr;
-
   Temperature_Ref       = config->GetTemperature_Ref();
   rho_cp_solid          = config->GetDensity_Solid()*config->GetSpecific_Heat_Cp();
 
@@ -978,7 +976,7 @@ void CHeatSolver::BC_ConjugateHeat_Interface(CGeometry *geometry, CSolver **solv
 
       if (geometry->nodes->GetDomain(iPoint)) {
 
-        Normal = geometry->vertex[val_marker][iVertex]->GetNormal();
+        su2double const* Normal = geometry->vertex[val_marker][iVertex]->GetNormal();
         Area = GeometryToolbox::Norm(nDim, Normal);
 
         T_Conjugate = GetConjugateHeatVariable(val_marker, iVertex, 0)/Temperature_Ref;
@@ -999,7 +997,7 @@ void CHeatSolver::BC_ConjugateHeat_Interface(CGeometry *geometry, CSolver **solv
 
       if (geometry->nodes->GetDomain(iPoint)) {
 
-        Normal = geometry->vertex[val_marker][iVertex]->GetNormal();
+        su2double const* Normal = geometry->vertex[val_marker][iVertex]->GetNormal();
         Area = GeometryToolbox::Norm(nDim, Normal);
 
         thermal_diffusivity = GetConjugateHeatVariable(val_marker, iVertex, 2)/rho_cp_solid;


### PR DESCRIPTION
## Proposed Changes
The following members of `CHeatSolver` were allocated but never freed: `Primitive_Flow_i`, `Primitive_Flow_j`, `HeatFlux_per_Marker`, `AverageT_per_Marker`, `Surface_Areas`, `ConjugateVar`.

I propose to correct this in the spirit of #1225, using containers (`std::vector`) instead of pointers. There is a bit of additional cleanup.


## Related Work
#1225 

## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [X ] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags, or simply --warnlevel=2 when using meson).
- [x] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
