### PR TITLE
SU2-NEMO - Optimize initialization time

### DIFF
--- a/SU2_CFD/include/variables/CNEMOEulerVariable.hpp
+++ b/SU2_CFD/include/variables/CNEMOEulerVariable.hpp
@@ -29,6 +29,7 @@
 
 #include "CVariable.hpp"
 #include "../fluid/CNEMOGas.hpp"
+#include "../../Common/include/toolboxes/geometry_toolbox.hpp"
 
 /*!
  * \class CNEMOEulerVariable

--- a/SU2_CFD/src/solvers/CNEMOEulerSolver.cpp
+++ b/SU2_CFD/src/solvers/CNEMOEulerSolver.cpp
@@ -256,7 +256,7 @@ void CNEMOEulerSolver::CommonPreprocessing(CGeometry *geometry, CSolver **solver
       config->SetNonphysical_Points(ErrorCounter);
       
       if ((rank == MASTER_NODE) && (ErrorCounter != 0))
-        cout << "Warning. The original solution contains "<< ErrorCounter << " points that are not physical." << endl;
+        cout << "Warning. The initial solution contains "<< ErrorCounter << " points that are not physical." << endl;
   }
 
   /*--- Artificial dissipation ---*/

--- a/SU2_CFD/src/solvers/CNEMOEulerSolver.cpp
+++ b/SU2_CFD/src/solvers/CNEMOEulerSolver.cpp
@@ -46,11 +46,9 @@ CNEMOEulerSolver::CNEMOEulerSolver(CGeometry *geometry, CConfig *config,
     description = "Euler";
   }
 
-  vector<su2double> Energies_Inf;
-  unsigned long iPoint, counter_local, counter_global = 0;
-  unsigned short iDim, iMarker, iSpecies, nLineLets;
+  unsigned short iMarker, nLineLets;
   unsigned short nZone = geometry->GetnZone();
-  su2double *Mvec_Inf, Alpha, Beta, Soundspeed_Inf, sqvel;
+  su2double *Mvec_Inf, Alpha, Beta;
   bool restart   = (config->GetRestart() || config->GetRestart_Flow());
   unsigned short direct_diff = config->GetDirectDiff();
   int Unst_RestartIter = 0;
@@ -59,10 +57,6 @@ CNEMOEulerSolver::CNEMOEulerSolver(CGeometry *geometry, CConfig *config,
   bool time_stepping = config->GetTime_Marching() == TIME_MARCHING::TIME_STEPPING;
   bool adjoint = config->GetDiscrete_Adjoint();
   string filename_ = "flow";
-
-  bool nonPhys;
-
-  Energies_Inf.resize(2);
 
   /*--- Store the multigrid level. ---*/
   MGLevel = iMesh;

--- a/SU2_CFD/src/solvers/CSolverFactory.cpp
+++ b/SU2_CFD/src/solvers/CSolverFactory.cpp
@@ -429,7 +429,6 @@ CSolver* CSolverFactory::CreateFlowSolver(SUB_SOLVER_TYPE kindFlowSolver, CSolve
       break;
     case SUB_SOLVER_TYPE::NEMO_EULER:
       flowSolver = new CNEMOEulerSolver(geometry, config, iMGLevel);
-      //flowSolver->Preprocessing(geometry, solver, config, iMGLevel, NO_RK_ITER, RUNTIME_FLOW_SYS, false);
       break;
     case SUB_SOLVER_TYPE::NEMO_NAVIER_STOKES:
       flowSolver = new CNEMONSSolver(geometry, config, iMGLevel);

--- a/SU2_CFD/src/solvers/CSolverFactory.cpp
+++ b/SU2_CFD/src/solvers/CSolverFactory.cpp
@@ -429,7 +429,7 @@ CSolver* CSolverFactory::CreateFlowSolver(SUB_SOLVER_TYPE kindFlowSolver, CSolve
       break;
     case SUB_SOLVER_TYPE::NEMO_EULER:
       flowSolver = new CNEMOEulerSolver(geometry, config, iMGLevel);
-      flowSolver->Preprocessing(geometry, solver, config, iMGLevel, NO_RK_ITER, RUNTIME_FLOW_SYS, false);
+      //flowSolver->Preprocessing(geometry, solver, config, iMGLevel, NO_RK_ITER, RUNTIME_FLOW_SYS, false);
       break;
     case SUB_SOLVER_TYPE::NEMO_NAVIER_STOKES:
       flowSolver = new CNEMONSSolver(geometry, config, iMGLevel);

--- a/SU2_CFD/src/variables/CNEMOEulerVariable.cpp
+++ b/SU2_CFD/src/variables/CNEMOEulerVariable.cpp
@@ -45,10 +45,7 @@ CNEMOEulerVariable::CNEMOEulerVariable(su2double val_pressure,
                                                                          config ),
                                        Gradient_Reconstruction(config->GetReconstructionGradientRequired() ? Gradient_Aux : Gradient_Primitive) {
 
-  vector<su2double> energies;
   unsigned short iDim, iSpecies;
-  su2double soundspeed, rho;
-  su2double sqvel = 0.0;
 
   /*--- Setting variable amounts ---*/
   nDim            = ndim;
@@ -148,12 +145,10 @@ CNEMOEulerVariable::CNEMOEulerVariable(su2double val_pressure,
   fluidmodel->SetTDStatePTTv(val_pressure, val_massfrac, val_temperature, val_temperature_ve);
 
   /*--- Compute necessary quantities ---*/
-  rho = fluidmodel->GetDensity();
-  soundspeed = fluidmodel->ComputeSoundSpeed();
-  for (iDim = 0; iDim < nDim; iDim++){
-    sqvel += val_mach[iDim]*soundspeed * val_mach[iDim]*soundspeed;
-  }
-  energies = fluidmodel->ComputeMixtureEnergies();
+  const su2double rho = fluidmodel->GetDensity();
+  const su2double soundspeed = fluidmodel->ComputeSoundSpeed();
+  const su2double sqvel = GeometryToolbox::SquaredNorm(nDim, val_mach) * pow(soundspeed,2);
+  const auto& energies = fluidmodel->ComputeMixtureEnergies();
   
   /*--- Loop over all points --*/
   for(unsigned long iPoint = 0; iPoint < nPoint; ++iPoint){

--- a/SU2_CFD/src/variables/CNEMOEulerVariable.cpp
+++ b/SU2_CFD/src/variables/CNEMOEulerVariable.cpp
@@ -47,7 +47,8 @@ CNEMOEulerVariable::CNEMOEulerVariable(su2double val_pressure,
 
   vector<su2double> energies;
   unsigned short iDim, iSpecies;
-  su2double soundspeed, sqvel, rho;
+  su2double soundspeed, rho;
+  su2double sqvel = 0.0;
 
   /*--- Setting variable amounts ---*/
   nDim            = ndim;
@@ -143,22 +144,19 @@ CNEMOEulerVariable::CNEMOEulerVariable(su2double val_pressure,
   UnderRelaxation.resize(nPoint) = su2double(1.0);
   LocalCFL.resize(nPoint) = su2double(0.0);
 
+  /*--- Set mixture state ---*/
+  fluidmodel->SetTDStatePTTv(val_pressure, val_massfrac, val_temperature, val_temperature_ve);
+
+  /*--- Compute necessary quantities ---*/
+  rho = fluidmodel->GetDensity();
+  soundspeed = fluidmodel->ComputeSoundSpeed();
+  for (iDim = 0; iDim < nDim; iDim++){
+    sqvel += val_mach[iDim]*soundspeed * val_mach[iDim]*soundspeed;
+  }
+  energies = fluidmodel->ComputeMixtureEnergies();
+  
   /*--- Loop over all points --*/
   for(unsigned long iPoint = 0; iPoint < nPoint; ++iPoint){
-
-    /*--- Reset velocity^2 [m2/s2] to zero ---*/
-    sqvel = 0.0;
-
-    /*--- Set mixture state ---*/
-    fluidmodel->SetTDStatePTTv(val_pressure, val_massfrac, val_temperature, val_temperature_ve);
-
-    /*--- Compute necessary quantities ---*/
-    rho = fluidmodel->GetDensity();
-    soundspeed = fluidmodel->ComputeSoundSpeed();
-    for (iDim = 0; iDim < nDim; iDim++){
-      sqvel += val_mach[iDim]*soundspeed * val_mach[iDim]*soundspeed;
-    }
-    energies = fluidmodel->ComputeMixtureEnergies();
 
     /*--- Initialize Solution & Solution_Old vectors ---*/
     for (iSpecies = 0; iSpecies < nSpecies; iSpecies++)
@@ -168,14 +166,9 @@ CNEMOEulerVariable::CNEMOEulerVariable(su2double val_pressure,
 
     Solution(iPoint,nSpecies+nDim)       = rho*(energies[0]+0.5*sqvel);
     Solution(iPoint,nSpecies+nDim+1)     = rho*(energies[1]);
-
-    Solution_Old = Solution;
-
-    /*--- Assign primitive variables ---*/
-    Primitive(iPoint,T_INDEX)   = val_temperature;
-    Primitive(iPoint,TVE_INDEX) = val_temperature_ve;
-    Primitive(iPoint,P_INDEX)   = val_pressure;
   }
+
+  Solution_Old = Solution;
 }
 
 void CNEMOEulerVariable::SetVelocity2(unsigned long iPoint) {


### PR DESCRIPTION
## Proposed Changes

Optimize the SU2-NEMO solver initialization time 

## Related Work
None that I remember

## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [ X] I am submitting my contribution to the develop branch.
- [ X ] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags, or simply --warnlevel=2 when using meson).
- [ X ] My contribution is commented and consistent with SU2 style.
- [ X ] I have added a test case that demonstrates my contribution, if necessary.
- [ X ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.

## Work Overview

I have optimized the initialization time of SU2-NEMO. You can check the time comparison between the old and new version at the table below.

![image](https://user-images.githubusercontent.com/29612207/127698090-e4924a77-a5f0-40fc-90eb-ce218c413aaf.png)


Some steps that I have done:
### CNEMOEulerVariable.cpp 
* Removed constant calculations inside a for loop
* Passed the Solution_Old = Solution to outside the loop

### CNEMOEulerSolver.cpp
* Removed the "for" loop that fills the Nodes Primitive Fields (already done in the Preprocessing phase)
* Removed the error counter (already done in the Preprocessing phase)

### CSolverFactory.cpp
* Removed the Preprocessing step after the CNEMOEulerSolver instantiation (**This is done before the start of the iterative process, regardless. Additionally, the Navier-Stokes do not have any preprocess phase after the instantiation, why is that ?** )

The residuals may slightly different, because of the removal of the for loop inside CNEMOEulerSolver.cpp. Notice that inside that for loop, the soundspeed is obtained using the function FluidModel->GetSoundSpeed(), which gives a slight different value than the one calculated inside CNEMOEulerVariable.cpp using FluidModel->ComputeSoundSpeed(). This means that the regression tests may fail.
