### PR TITLE
Fix possible segfault using SetConsVarGradient

### DIFF
--- a/SU2_CFD/src/solvers/CNEMOEulerSolver.cpp
+++ b/SU2_CFD/src/solvers/CNEMOEulerSolver.cpp
@@ -1591,8 +1591,6 @@ void CNEMOEulerSolver::BC_Far_Field(CGeometry *geometry, CSolver **solver_contai
         /*--- Primitive variables, and gradient ---*/
         visc_numerics->SetConservative(nodes->GetSolution(iPoint),
                                        node_infty->GetSolution(0) );
-        visc_numerics->SetConsVarGradient(nodes->GetGradient(iPoint),
-                                          node_infty->GetGradient(0) );
         visc_numerics->SetPrimitive(nodes->GetPrimitive(iPoint),
                                     node_infty->GetPrimitive(0) );
         visc_numerics->SetPrimVarGradient(nodes->GetGradient_Primitive(iPoint),
@@ -2119,8 +2117,6 @@ void CNEMOEulerSolver::BC_Outlet(CGeometry *geometry, CSolver **solver_container
 
 //        /*--- Conservative variables, and gradient ---*/
 //        visc_numerics->SetConservative(U_domain, U_outlet);
-//        visc_numerics->SetConsVarGradient(nodes->GetGradient(), node_infty->GetGradient() );
-
 
 //        /*--- Pass supplementary information to CNumerics ---*/
 //        visc_numerics->SetdPdU(nodes->GetdPdU(), node_infty->GetdPdU());

--- a/SU2_CFD/src/solvers/CNEMONSSolver.cpp
+++ b/SU2_CFD/src/solvers/CNEMONSSolver.cpp
@@ -191,8 +191,6 @@ void CNEMONSSolver::Viscous_Residual(CGeometry *geometry,
     /*--- Primitive variables, and gradient ---*/
     numerics->SetConservative   (nodes->GetSolution(iPoint),
                                  nodes->GetSolution(jPoint) );
-    numerics->SetConsVarGradient(nodes->GetGradient(iPoint),
-                                 nodes->GetGradient(jPoint) );
     numerics->SetPrimitive      (nodes->GetPrimitive(iPoint),
                                  nodes->GetPrimitive(jPoint) );
     numerics->SetPrimVarGradient(nodes->GetGradient_Primitive(iPoint),


### PR DESCRIPTION
## Proposed Changes
I removed the calls to SetConsVarGradient in NEMO.  It was causing a segfault locally when running any viscous case, though I couldn't produce the issue on other machines.  If anyone has an explanation, I'm all ears!   These seem to be superfluous anyway.


## Related Work
This is a continuation of PR #1375


## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags, or simply --warnlevel=2 when using meson).
- [x] My contribution is commented and consistent with SU2 style.
- [x] I have added a test case that demonstrates my contribution, if necessary.
- [x] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
