### PR TITLE
Fix heat-only primal restarts in adjoint

### DIFF
--- a/SU2_CFD/include/iteration/CDiscAdjHeatIteration.hpp
+++ b/SU2_CFD/include/iteration/CDiscAdjHeatIteration.hpp
@@ -149,6 +149,18 @@ class CDiscAdjHeatIteration final : public CIteration {
                       unsigned short iZone, unsigned short iInst) override;
 
   /*!
+   * \brief Record a single iteration of the direct FEM system.
+   * \param[in] solver - Container vector with all the solutions.
+   * \param[in] geometry - Geometrical definition of the problem.
+   * \param[in] config - Definition of the particular problem.
+   * \param[in] iZone - Index of the zone.
+   * \param[in] iInst - Index of the instance.
+   * \param[in] kind_recording - The kind of recording (geometry or flow).
+   */
+  void SetRecording(CSolver***** solver, CGeometry**** geometry, CConfig** config,
+                    unsigned short iZone, unsigned short iInst, RECORDING kind_recording) override;
+
+  /*!
    * \brief Compute necessary variables that depend on the conservative variables or the mesh node positions
    * (e.g. turbulent variables, normals, volumes).
    * \param[in] solver - Container vector with all the solutions.

--- a/SU2_CFD/src/drivers/CDriver.cpp
+++ b/SU2_CFD/src/drivers/CDriver.cpp
@@ -2675,6 +2675,7 @@ void CDriver::Print_DirectResidual(RECORDING kind_recording) {
 
   const unsigned short fieldWidth = 15;
   PrintingToolbox::CTablePrinter RMSTable(&std::cout);
+  RMSTable.SetPrecision(config_container[ZONE_0]->GetOutput_Precision());
 
   /*--- The CTablePrinter requires two sweeps:
     *--- 0. Add the colum names (addVals=0=false) plus CTablePrinter.PrintHeader()

--- a/SU2_CFD/src/iteration/CDiscAdjHeatIteration.cpp
+++ b/SU2_CFD/src/iteration/CDiscAdjHeatIteration.cpp
@@ -200,6 +200,12 @@ void CDiscAdjHeatIteration::RegisterInput(CSolver***** solver, CGeometry**** geo
   }
 }
 
+void CDiscAdjHeatIteration::SetRecording(CSolver***** solver, CGeometry**** geometry, CConfig** config,
+                                         unsigned short iZone, unsigned short iInst, RECORDING kind_recording) {
+  /*--- Prepare for recording by resetting the solution to the initial converged solution ---*/
+  solver[iZone][iInst][MESH_0][ADJHEAT_SOL]->SetRecording(geometry[iZone][iInst][MESH_0], config[iZone]);
+}
+
 void CDiscAdjHeatIteration::SetDependencies(CSolver***** solver, CGeometry**** geometry, CNumerics****** numerics,
                                             CConfig** config, unsigned short iZone, unsigned short iInst,
                                             RECORDING kind_recording) {


### PR DESCRIPTION
## Proposed Changes
Hi, 

A small one: For 1 zone heat equation, the primal restart for the adjoint run was missing the solution reset after the CLEAR_INDICES run.

Additionally I added a output_precision to the primal Residual Table for the adjoint. My recommendation is to set OUTPUT_PRECISION= 12 (because that is the fixed field Width of the table) and compare those screen residuals to the history output of the comparing primal simulations.

I noticed this problem while looking at non-perfect restarts for CHT cases, which I am currently still debugging. I will make an issue for that soon. Note though that the discrepancies seem subtle and a gradient comparison with FD shows and showed good agreement in the past.


## PR Checklist

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags, or simply --warnlevel=2 when using meson).
- [x] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
