### PR TITLE
[WIP] Fix NEMO super-catalytic isothermal wall boundary

### DIFF
--- a/SU2_CFD/src/solvers/CNEMONSSolver.cpp
+++ b/SU2_CFD/src/solvers/CNEMONSSolver.cpp
@@ -809,8 +809,15 @@ void CNEMONSSolver::BC_IsothermalCatalytic_Wall(CGeometry *geometry,
       dTvedU = nodes->GetdTvedU(iPoint);
 
       /*--- Calculate normal derivative of mass fraction ---*/
-      for (iSpecies = 0; iSpecies < nSpecies; iSpecies++)
-        dYdn[iSpecies] = (Yst[iSpecies]-Yj[iSpecies])/dij;
+      for (iSpecies = 0; iSpecies < nSpecies; iSpecies++) {
+        if (iSpecies == 0) {
+          dYdn[iSpecies] = (0.999-Yj[iSpecies])/dij;
+        } else if (iSpecies == 1) {
+          dYdn[iSpecies] = (0.001-Yj[iSpecies])/dij;
+        } else {
+          dYdn[iSpecies] = (0-Yj[iSpecies])/dij;
+        }
+      }
 
       /*--- Calculate supplementary quantities ---*/
       SdYdn = 0.0;


### PR DESCRIPTION
## Proposed Changes
-This PR addresses re-activating the super-catalytic wall boundary, which enforces full recombination of monatomic species to their free-stream concentrations.
-This work is conducted as part of a larger effort to implement more complex gas-surface interaction boundary conditions in NEMO.
 


## Related Work
*Resolve any issues (bug fix or feature request), note any related PRs, or mention interactions with the work of others, if any.*



## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags, or simply --warnlevel=2 when using meson).
- [x] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
