### PR TITLE
Fixed an error for the Coupled RHT-CFD Adjoint test in serial_regression_AD.py

### DIFF
--- a/TestCases/serial_regression_AD.py
+++ b/TestCases/serial_regression_AD.py
@@ -248,21 +248,6 @@ def main():
     test_list.append(discadj_heat)
 
     ###################################
-    ### Coupled RHT-CFD Adjoint     ###
-    ###################################
-
-    # Coupled discrete adjoint for radiative heat transfer in heated cylinder
-    discadj_rht                = TestCase('discadj_rht')
-    discadj_rht.cfg_dir        = "radiation/p1adjoint"
-    discadj_rht.cfg_file       = "configp1adjoint.cfg"
-    discadj_rht.test_iter      = 10
-    discadj_rht.su2_exec       = "discrete_adjoint.py -f"
-    discadj_rht.timeout        = 1600
-    discadj_rht.reference_file = "of_grad_cd.csv.ref"
-    discadj_rht.test_file      = "of_grad_cd.csv"
-    test_list.append(discadj_rht)
-
-    ###################################
     ### Coupled FSI Adjoint         ###
     ###################################
    
@@ -298,6 +283,22 @@ def main():
 
     pass_list = [ test.run_test() for test in test_list ]
     
+    ###################################
+    ### Coupled RHT-CFD Adjoint     ###
+    ###################################
+
+    # Coupled discrete adjoint for radiative heat transfer in heated cylinder
+    discadj_rht                = TestCase('discadj_rht')
+    discadj_rht.cfg_dir        = "radiation/p1adjoint"
+    discadj_rht.cfg_file       = "configp1adjoint.cfg"
+    discadj_rht.test_iter      = 10
+    discadj_rht.su2_exec       = "discrete_adjoint.py -f"
+    discadj_rht.timeout        = 1600
+    discadj_rht.reference_file = "of_grad_cd.csv.ref"
+    discadj_rht.test_file      = "of_grad_cd.csv"
+    pass_list.append(discadj_rht.run_filediff())
+    test_list.append(discadj_rht)
+
     ######################################
     ### RUN PYTHON TESTS               ###
     ######################################


### PR DESCRIPTION
The Coupled RHT-CFD Adjoint did not compare the computed gradient file to the reference file. Instead, the test case passed without file comparison.

## Proposed Changes
Added a call to run_filediff to ensure the test is run.
Moved the Coupled RHT-CFD Adjoint test in serial_regression_AD.py down to the file difference test.

## Related Work
This fixes the related issue #1431 
The reference gradient file in the test case repo needs a small modification. See su2code/TestCases/pull/84

## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [X] I am submitting my contribution to the develop branch.
- [ ] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags, or simply --warnlevel=2 when using meson).
- [X] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
