### PR TITLE
Treat SU2_CFD library similar to Common in meson build process

### DIFF
--- a/SU2_DEF/src/meson.build
+++ b/SU2_DEF/src/meson.build
@@ -1,39 +1,9 @@
 su2_def_src = ['SU2_DEF.cpp']
 if get_option('enable-normal')
 
-  su2_cfd_obj = su2_cfd_lib.extract_objects(['solvers/CSolver.cpp',
-                                        'solvers/CBaselineSolver.cpp',
-                                        'CMarkerProfileReaderFVM.cpp',
-                                        'output/COutput.cpp',
-                                        'output/tools/CWindowingTools.cpp',
-                                        'output/CMeshOutput.cpp',
-                                        'output/output_structure_legacy.cpp',
-                                        'variables/CBaselineVariable.cpp',
-                                        'variables/CVariable.cpp',
-                                        'output/filewriter/CParallelDataSorter.cpp',
-                                        'output/filewriter/CFVMDataSorter.cpp',
-                                        'output/filewriter/CFEMDataSorter.cpp',
-                                        'output/filewriter/CSurfaceFEMDataSorter.cpp',
-                                        'output/filewriter/CSurfaceFVMDataSorter.cpp',
-                                        'output/filewriter/CParallelFileWriter.cpp',
-                                        'output/filewriter/CParaviewFileWriter.cpp',
-                                        'output/filewriter/CParaviewBinaryFileWriter.cpp',
-                                        'output/filewriter/CTecplotFileWriter.cpp',
-                                        'output/filewriter/CTecplotBinaryFileWriter.cpp',
-                                        'output/filewriter/CCSVFileWriter.cpp',
-                                        'output/filewriter/CSTLFileWriter.cpp',
-                                        'output/filewriter/CSU2FileWriter.cpp',
-                                        'output/filewriter/CSU2BinaryFileWriter.cpp',
-                                        'output/filewriter/CParaviewXMLFileWriter.cpp',
-                                        'output/filewriter/CParaviewVTMFileWriter.cpp',
-                                        'output/filewriter/CSU2MeshFileWriter.cpp',
-                                        'output/filewriter/CCGNSFileWriter.cpp',
-                                        'limiters/CLimiterDetails.cpp'])
-
   su2_def = executable('SU2_DEF',
-                        su2_def_src, 
+                        su2_def_src,
                         install: true,
-                        dependencies: [su2_deps, common_dep], 
-                        objects : su2_cfd_obj,
+                        dependencies: [su2_deps, common_dep, su2_cfd_dep],
                         cpp_args :[default_warning_flags, su2_cpp_args])
 endif

--- a/SU2_DOT/src/meson.build
+++ b/SU2_DOT/src/meson.build
@@ -1,78 +1,21 @@
 su2_dot_src = ['SU2_DOT.cpp']
 
 if get_option('enable-normal')
-  su2_cfd_obj = su2_cfd_lib.extract_objects(['solvers/CSolver.cpp',
-                                             'solvers/CBaselineSolver.cpp',
-                                             'CMarkerProfileReaderFVM.cpp',
-                                             'output/COutput.cpp',
-                                             'output/tools/CWindowingTools.cpp',
-                                             'output/output_structure_legacy.cpp',
-                                             'output/CBaselineOutput.cpp',
-                                             'output/filewriter/CParallelDataSorter.cpp',
-                                             'output/filewriter/CParallelFileWriter.cpp',
-                                             'output/filewriter/CFEMDataSorter.cpp',
-                                             'output/filewriter/CSurfaceFEMDataSorter.cpp',
-                                             'output/filewriter/CFVMDataSorter.cpp',
-                                             'output/filewriter/CSurfaceFVMDataSorter.cpp',
-                                             'output/filewriter/CCSVFileWriter.cpp',
-                                             'output/filewriter/CSTLFileWriter.cpp',
-                                             'output/filewriter/CTecplotFileWriter.cpp',
-                                             'output/filewriter/CTecplotBinaryFileWriter.cpp',
-                                             'output/filewriter/CParaviewFileWriter.cpp',
-                                             'output/filewriter/CParaviewBinaryFileWriter.cpp',
-                                             'output/filewriter/CSU2FileWriter.cpp',
-                                             'output/filewriter/CSU2BinaryFileWriter.cpp',
-                                             'output/filewriter/CSU2MeshFileWriter.cpp',
-                                             'output/filewriter/CParaviewXMLFileWriter.cpp',
-                                             'output/filewriter/CParaviewVTMFileWriter.cpp',
-                                             'output/filewriter/CCGNSFileWriter.cpp',
-                                             'variables/CBaselineVariable.cpp',
-                                             'variables/CVariable.cpp',
-                                             'limiters/CLimiterDetails.cpp'])
+
   su2_dot = executable('SU2_DOT',
-                      su2_dot_src, 
+                      su2_dot_src,
                       install: true,
-                      dependencies: [su2_deps, common_dep], 
-                      objects : su2_cfd_obj,
+                      dependencies: [su2_deps, common_dep, su2_cfd_dep],
                       cpp_args :[default_warning_flags, su2_cpp_args])
 
 endif
 
 if get_option('enable-autodiff')
-  su2_cfd_obj_ad = su2_cfd_lib_ad.extract_objects(['solvers/CSolver.cpp',
-                                                   'solvers/CBaselineSolver.cpp',
-                                                   'CMarkerProfileReaderFVM.cpp',
-                                                   'output/COutput.cpp',
-                                                   'output/tools/CWindowingTools.cpp',
-                                                   'output/output_structure_legacy.cpp',
-                                                   'output/CBaselineOutput.cpp',
-                                                   'output/filewriter/CParallelDataSorter.cpp',
-                                                   'output/filewriter/CParallelFileWriter.cpp',
-                                                   'output/filewriter/CFEMDataSorter.cpp',
-                                                   'output/filewriter/CSurfaceFEMDataSorter.cpp',
-                                                   'output/filewriter/CFVMDataSorter.cpp',
-                                                   'output/filewriter/CSurfaceFVMDataSorter.cpp',
-                                                   'output/filewriter/CCSVFileWriter.cpp',
-                                                   'output/filewriter/CSTLFileWriter.cpp',
-                                                   'output/filewriter/CTecplotFileWriter.cpp',
-                                                   'output/filewriter/CTecplotBinaryFileWriter.cpp',
-                                                   'output/filewriter/CParaviewFileWriter.cpp',
-                                                   'output/filewriter/CParaviewBinaryFileWriter.cpp',
-                                                   'output/filewriter/CSU2FileWriter.cpp',
-                                                   'output/filewriter/CSU2BinaryFileWriter.cpp',
-                                                   'output/filewriter/CSU2MeshFileWriter.cpp',
-                                                   'output/filewriter/CParaviewXMLFileWriter.cpp',
-                                                   'output/filewriter/CParaviewVTMFileWriter.cpp',
-                                                   'output/filewriter/CCGNSFileWriter.cpp',
-                                                   'variables/CBaselineVariable.cpp',
-                                                   'variables/CVariable.cpp',
-                                                   'limiters/CLimiterDetails.cpp'])
 
   su2_dot_ad = executable('SU2_DOT_AD',
                           su2_dot_src,
                           install: true,
-                          dependencies: [su2_deps, codi_dep, commonAD_dep], 
-		                      objects : su2_cfd_obj_ad,
-		                      cpp_args : [default_warning_flags, su2_cpp_args, codi_rev_args])
+                          dependencies: [su2_deps, codi_dep, commonAD_dep, su2_cfd_dep_ad],
+                          cpp_args : [default_warning_flags, su2_cpp_args, codi_rev_args])
 
 endif

--- a/SU2_GEO/src/meson.build
+++ b/SU2_GEO/src/meson.build
@@ -2,7 +2,7 @@ su2_geo_src = ['SU2_GEO.cpp']
 
 if get_option('enable-normal')
   su2_geo = executable('SU2_GEO',
-                       su2_geo_src, 
+                       su2_geo_src,
                        install: true,
 		       dependencies: [su2_deps, common_dep], 
 		       cpp_args : [default_warning_flags, su2_cpp_args])

--- a/SU2_SOL/src/meson.build
+++ b/SU2_SOL/src/meson.build
@@ -1,41 +1,10 @@
 su2_sol_src = ['SU2_SOL.cpp']
 if get_option('enable-normal')
-  su2_cfd_obj = su2_cfd_lib.extract_objects(['solvers/CSolver.cpp',
-                                        'solvers/CBaselineSolver.cpp',
-                                        'solvers/CBaselineSolver_FEM.cpp',
-                                        'CMarkerProfileReaderFVM.cpp',
-                                        'output/COutput.cpp',
-                                        'output/output_structure_legacy.cpp',
-                                        'output/tools/CWindowingTools.cpp',
-                                        'output/CBaselineOutput.cpp',
-                                        'output/filewriter/CParallelDataSorter.cpp',
-                                        'output/filewriter/CParallelFileWriter.cpp',
-                                        'output/filewriter/CFEMDataSorter.cpp',
-                                        'output/filewriter/CSurfaceFEMDataSorter.cpp',
-                                        'output/filewriter/CFVMDataSorter.cpp',
-                                        'output/filewriter/CSurfaceFVMDataSorter.cpp',
-                                        'output/filewriter/CCSVFileWriter.cpp',
-                                        'output/filewriter/CSTLFileWriter.cpp',
-                                        'output/filewriter/CTecplotFileWriter.cpp',
-                                        'output/filewriter/CTecplotBinaryFileWriter.cpp',
-                                        'output/filewriter/CParaviewFileWriter.cpp',
-                                        'output/filewriter/CParaviewBinaryFileWriter.cpp',
-                                        'output/filewriter/CSU2FileWriter.cpp',
-                                        'output/filewriter/CSU2BinaryFileWriter.cpp',
-                                        'output/filewriter/CSU2MeshFileWriter.cpp',
-                                        'output/filewriter/CParaviewXMLFileWriter.cpp',
-                                        'output/filewriter/CParaviewVTMFileWriter.cpp',
-                                        'output/filewriter/CCGNSFileWriter.cpp',
-                                        'variables/CBaselineVariable.cpp',
-                                        'variables/CVariable.cpp',
-                                        'limiters/CLimiterDetails.cpp'])
 
   su2_sol = executable('SU2_SOL',
-                      su2_sol_src, 
+                      su2_sol_src,
                       install: true,
-                      dependencies: [su2_deps, common_dep], 
-                      objects : su2_cfd_obj,
+                      dependencies: [su2_deps, common_dep, su2_cfd_dep],
                       cpp_args :[default_warning_flags, su2_cpp_args])
-
 
 endif


### PR DESCRIPTION
## Proposed Changes

In the last developer meeting, there were some mentions of changing the meson build process for some of the executables. 

The idea is to use the static libraries su2_cfd_lib and su2_cfd_lib_ad for linking when building SU2_DEF, SU2_DOT, SU2_SOL. This way it is no longer necessary to extract the needed sources for building the executables by hand in the meson.build files of each subdirectory. The linking process should ensure that only the necessary sources are linked and the size of the executables does not change too much.

Please feel free to comment on this pull request, whether you think it is a good change to the build process? 

- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags, or simply --warnlevel=2 when using meson).
- [X] My contribution is commented and consistent with SU2 style.
- [X] I have added a test case that demonstrates my contribution, if necessary.
- [X] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
