### PR TITLE
Inform user of possible CGNS memory usage issue

### DIFF
--- a/Common/src/geometry/meshreader/CCGNSMeshReaderFVM.cpp
+++ b/Common/src/geometry/meshreader/CCGNSMeshReaderFVM.cpp
@@ -89,6 +89,7 @@ void CCGNSMeshReaderFVM::OpenCGNSFile(string val_filename) {
   /*--- Check whether the supplied file is truly a CGNS file. ---*/
 
   int file_type;
+  float file_version;
   if (cg_is_cgns(val_filename.c_str(), &file_type) != CG_OK) {
     SU2_MPI::Error(val_filename +
                    string(" was not found or is not a properly formatted") +
@@ -107,7 +108,13 @@ void CCGNSMeshReaderFVM::OpenCGNSFile(string val_filename) {
     cout << "Reading the CGNS file: ";
     cout << val_filename.c_str() << "." << endl;
   }
-
+  if (cg_version(cgnsFileID, &file_version))
+    cg_error_exit();
+  if (rank == MASTER_NODE) {
+    if (file_version < 4.0) {
+      cout << "The file version is too old, please update it with the cgnsupdate tool." << endl;
+    }
+  }
 }
 
 void CCGNSMeshReaderFVM::ReadCGNSDatabaseMetadata() {

--- a/Common/src/geometry/meshreader/CCGNSMeshReaderFVM.cpp
+++ b/Common/src/geometry/meshreader/CCGNSMeshReaderFVM.cpp
@@ -112,7 +112,7 @@ void CCGNSMeshReaderFVM::OpenCGNSFile(string val_filename) {
     cg_error_exit();
   if (rank == MASTER_NODE) {
     if (file_version < 4.0) {
-      cout << "The file version is too old, please update it with the cgnsupdate tool." << endl;
+      cout << "WARNING: The CGNS file version (" << file_version << ")  is old and may cause high memory usage issues, consider updating the file with the cgnsupdate tool.\n";
     }
   }
 }


### PR DESCRIPTION
CGNS file older than 4.0 release have a high ram memory usage

## Proposed Changes

Add a small message to help users understand that SU2 is eating their RAM with old CGNS files.
 
## Related Work

See: #1378 


## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags, or simply --warnlevel=2 when using meson).
- [x] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
