### PR TITLE
Changed the registration of AD input variables in CDiscAdjFluidIteration

### DIFF
--- a/Common/include/CConfig.hpp
+++ b/Common/include/CConfig.hpp
@@ -4246,7 +4246,7 @@ public:
   unsigned short GetRef_Inc_NonDim(void) const { return Ref_Inc_NonDim; }
 
   /*!
-   * \brief Get the kind of SU2 software component.
+   * \brief Set the kind of SU2 software component.
    * \return Kind of the SU2 software component.
    */
   void SetKind_SU2(SU2_COMPONENT val_kind_su2) { Kind_SU2 = val_kind_su2 ; }

--- a/SU2_CFD/src/drivers/CDiscAdjSinglezoneDriver.cpp
+++ b/SU2_CFD/src/drivers/CDiscAdjSinglezoneDriver.cpp
@@ -434,9 +434,8 @@ void CDiscAdjSinglezoneDriver::DirectRun(RECORDING kind_recording){
 }
 
 void CDiscAdjSinglezoneDriver::MainRecording(){
-
-  /*--- SetRecording stores the computational graph on one iteration of the direct problem. Calling it with NONE
-   *    as argument ensures that all information from a previous recording is removed. ---*/
+  /*--- SetRecording stores the computational graph on one iteration of the direct problem. Calling it with
+   *    RECORDING::CLEAR_INDICES as argument ensures that all information from a previous recording is removed. ---*/
 
   SetRecording(RECORDING::CLEAR_INDICES);
 
@@ -447,9 +446,8 @@ void CDiscAdjSinglezoneDriver::MainRecording(){
 }
 
 void CDiscAdjSinglezoneDriver::SecondaryRecording(){
-
-  /*--- SetRecording stores the computational graph on one iteration of the direct problem. Calling it with NONE
-   *    as argument ensures that all information from a previous recording is removed. ---*/
+  /*--- SetRecording stores the computational graph on one iteration of the direct problem. Calling it with
+   *    RECORDING::CLEAR_INDICES as argument ensures that all information from a previous recording is removed. ---*/
 
   SetRecording(RECORDING::CLEAR_INDICES);
 

--- a/SU2_CFD/src/iteration/CDiscAdjFluidIteration.cpp
+++ b/SU2_CFD/src/iteration/CDiscAdjFluidIteration.cpp
@@ -507,7 +507,7 @@ void CDiscAdjFluidIteration::RegisterInput(CSolver***** solver, CGeometry**** ge
     }
   }
 
-  if (kind_recording == RECORDING::MESH_COORDS) {
+  if (kind_recording == RECORDING::MESH_COORDS || kind_recording == RECORDING::SOLUTION_AND_MESH) {
     /*--- Register node coordinates as input ---*/
 
     geometry[iZone][iInst][MESH_0]->RegisterCoordinates();


### PR DESCRIPTION
This is a small issue I noticed when I worked on some features for the discrete adjoint driver.
In CDiscAdjFluidIteration::RegisterInput the inputs for the AD tape are registered.
At the moment if kind_recording == RECORDING::SOLUTION_AND_MESH is set it only registers the flow variables and has no difference to RECORDING::SOLUTION_VARIABLES. If I understand the logic for this enum option correctly, it should register the flow variables and the mesh coordinates from geometry. I.e. if you want to add unctions to the driver, which can evaluate derivatives w.r.t. flow and geometry in one tape evaluation, you should use this option.

In addition, I change an out-of-date comment.

## Proposed Changes
Register the geometry variables as inputs in the discrete adjoint flow iteration if 'kind_recording == RECORDING::SOLUTION_AND_MESH'.

## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags, or simply --warnlevel=2 when using meson).
- [X] My contribution is commented and consistent with SU2 style.
- [X] I have added a test case that demonstrates my contribution, if necessary.
- [X] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
