### PR TITLE
Su2 hdf5 cross compile add missing meson keyword

### DIFF
--- a/externals/cgns/hdf5/meson.build
+++ b/externals/cgns/hdf5/meson.build
@@ -1165,10 +1165,12 @@ if cc_can_run
   gen_SRCS = [ H5lib_settings_c, H5Tinit_c ]
 else
   configure_file(input: 'H5T_init.cross',
-                 output: 'H5T_init.c')
+                 output: 'H5T_init.c',
+                 copy: true)
 
   configure_file(input: 'H5lib_settings.cross',
-                  output: 'H5lib_settings.c')
+                 output: 'H5lib_settings.c',
+                 copy: true)
 
   gen_SRCS = ['H5T_init.c', 'H5lib_settings.c']
 endif


### PR DESCRIPTION
## Proposed Changes
*Give a brief overview of your contribution here in a few sentences.*
 


## Related Work
*Resolve any issues (bug fix or feature request), note any related PRs, or mention interactions with the work of others, if any.*



## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [ ] I am submitting my contribution to the develop branch.
- [ ] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags, or simply --warnlevel=2 when using meson).
- [ ] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
