### PR TITLE
Specify C standard

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,6 +3,7 @@ project('SU2', 'c', 'cpp',
         license: 'LGPL2',
         default_options: ['buildtype=release',
                           'warning_level=0',
+                          'c_std=c99',
                           'cpp_std=c++11'])
 
 


### PR DESCRIPTION
## Proposed Changes
In `SU2/meson.build`, specify the version of the C standard used when compiling SU2, as C99. It must be at least C99 because of the for loop initial declarations in `externals/cgns/cgnslib.c`. (One could probably use a newer C standard as well.)

This change was necessary to compile SU2 on a system where `cc` is the GCC 4.8.5 (from 2015), which used `-std=gnu89` by default.

## Related Work
The change was not necessary in v7.1.0. I suppose it has something to do with the recent CGNS updates (#1500, #1507, ...).

## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [X] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags, or simply --warnlevel=2 when using meson).
- [ ] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
