### PR TITLE
Try to detect wrong meson being used to configure SU2

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,9 @@ project('SU2', 'c', 'cpp',
                           'c_std=c99',
                           'cpp_std=c++11'])
 
+if meson.version() != '0.61.1'
+  error('SU2 must be configured with the extended Meson script (./meson.py) in the SU2 root directory.')
+endif
 
 pymod = import('python')
 python = pymod.find_installation()


### PR DESCRIPTION
Many issues caused by users doing `meson build` instead of `./meson.py build`, maybe this will make it less likely... In hindsight we should not have called it `meson.py`