### PR TITLE
Fixes #1568 - Prefer loading zlib and szip libraries dynamically

### DIFF
--- a/externals/cgns/hdf5/meson.build
+++ b/externals/cgns/hdf5/meson.build
@@ -25,8 +25,8 @@ hdf5_conf_data.set('version', '1.12.1')
 ext_deps = []
 
 
-opt_zlib = dependency('zlib', required: false, static: true)
-opt_szip = dependency('szip', required: false, static: true)
+opt_zlib = dependency('zlib', required: false, static: false)
+opt_szip = dependency('szip', required: false, static: false)
 
 if opt_zlib.found() and cc.has_header('zlib.h')
   if cc.has_function('inflate', dependencies: opt_zlib, prefix: '#include <zlib.h>')


### PR DESCRIPTION
## Proposed Changes

Changes the loading of zlib and szip libraries from static (.a) to dynamic (.so).
 Suggested by @aa-g at https://github.com/su2code/SU2/issues/1568#issuecomment-1083104460.


## Related Work

None.

## PR Checklist

- [ ] I am submitting my contribution to the develop branch.
- [ ] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags, or simply --warnlevel=2 when using meson).
- [ ] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
