### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -10,8 +10,13 @@ on:
       - 'develop'
       - 'master'
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: none
     name: Build SU2
     strategy:
       fail-fast: false
@@ -54,6 +59,8 @@ jobs:
           name: ${{ matrix.config_set }}
           path: install/bin
   regression_tests:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     name: Regression Tests
     needs: build
@@ -94,6 +101,8 @@ jobs:
           # -t <Tutorials-branch> -c <Testcases-branch>
           args: -b ${{github.ref}} -t develop -c develop -s ${{matrix.testscript}}
   unit_tests:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     name: Unit Tests
     needs: build


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
