### PR TITLE
Fix #1667 Potential crash for the OpenMP multi-thread running.

### DIFF
--- a/Common/src/linear_algebra/CSysMatrix.cpp
+++ b/Common/src/linear_algebra/CSysMatrix.cpp
@@ -205,12 +205,10 @@ void CSysMatrix<ScalarType>::Initialize(unsigned long npoint, unsigned long npoi
   }
 
   for (unsigned long thread = 0; thread < omp_num_parts; ++thread) {
-    const unsigned long begin = omp_partitions[thread];
-    const unsigned long end = omp_partitions[thread + 1];
-    if (begin > end) {
-      SU2_MPI::Error("Invalid nodes are distributed in the thread " + to_string(thread) + ".", CURRENT_FUNCTION);
-    } else if (begin == end) {
-      cout << "WARNING: Redundent thread has been detected. Performance could be impacted." << endl;
+    const auto begin = omp_partitions[thread];
+    const auto end = omp_partitions[thread + 1];
+    if (begin == end) {
+      cout << "WARNING: Redundant thread has been detected. Performance could be impacted due to low number of nodes per thread." << endl;
       break;
     }
   }

--- a/Common/src/linear_algebra/CSysMatrix.cpp
+++ b/Common/src/linear_algebra/CSysMatrix.cpp
@@ -190,6 +190,7 @@ void CSysMatrix<ScalarType>::Initialize(unsigned long npoint, unsigned long npoi
 
   /*--- This is akin to the row_ptr. ---*/
   omp_partitions = new unsigned long [omp_num_parts+1];
+  for (unsigned long i = 0; i <= omp_num_parts; ++i) omp_partitions[i] = nPointDomain;
 
   /*--- Work estimate based on non-zeros to produce balanced partitions. ---*/
 
@@ -202,7 +203,17 @@ void CSysMatrix<ScalarType>::Initialize(unsigned long npoint, unsigned long npoi
     if (row_ptr_prec[iPoint] >= part*nnz_per_part)
       omp_partitions[part++] = iPoint;
   }
-  omp_partitions[omp_num_parts] = nPointDomain;
+
+  for (unsigned long thread = 0; thread < omp_num_parts; ++thread) {
+    const unsigned long begin = omp_partitions[thread];
+    const unsigned long end = omp_partitions[thread + 1];
+    if (begin > end) {
+      SU2_MPI::Error("Invalid nodes are distributed in the thread " + to_string(thread) + ".", CURRENT_FUNCTION);
+    } else if (begin == end) {
+      cout << "WARNING: Redundent thread has been detected. Performance could be impacted." << endl;
+      break;
+    }
+  }
 
   /*--- Generate MKL Kernels ---*/
 
@@ -707,6 +718,7 @@ void CSysMatrix<ScalarType>::BuildILUPreconditioner() {
   {
     const auto begin = omp_partitions[thread];
     const auto end = omp_partitions[thread+1];
+    if (begin == end) continue;
 
     /*--- Each thread will work on the submatrix defined from row/col "begin"
      *    to row/col "end-1" (i.e. the range [begin,end[). Which is exactly
@@ -784,6 +796,7 @@ void CSysMatrix<ScalarType>::ComputeILUPreconditioner(const CSysVector<ScalarTyp
   {
     const auto begin = omp_partitions[thread];
     const auto end = omp_partitions[thread+1];
+    if (begin == end) continue;
 
     ScalarType aux_vec[MAXNVAR];
 
@@ -846,6 +859,7 @@ void CSysMatrix<ScalarType>::ComputeLU_SGSPreconditioner(const CSysVector<Scalar
   {
     const auto begin = omp_partitions[thread];
     const auto end = omp_partitions[thread+1];
+    if (begin == end) continue;
 
     /*--- Each thread will work on the submatrix defined from row/col "begin"
      *    to row/col "end-1", except the last thread that also considers halos.
@@ -876,6 +890,8 @@ void CSysMatrix<ScalarType>::ComputeLU_SGSPreconditioner(const CSysVector<Scalar
   {
     const auto begin = omp_partitions[thread];
     const auto row_end = omp_partitions[thread+1];
+    if (begin == row_end) continue;
+
     /*--- On the last thread partition the upper
      *    product should consider halo columns. ---*/
     const auto col_end = (row_end==nPointDomain)? nPoint : row_end;


### PR DESCRIPTION
## Proposed Changes
Initialize the omp_partitions vector with the number of points, skip the for loop if the last partition has been calculated. A light-weight checker is added also to verify the partition vector, promote a warning or error message if necessary.
 

## Related Work
Fix #1667 Potential crash for the OpenMP multi-thread running.


## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags, or simply --warnlevel=2 when using meson).
- [x] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
