### PR TITLE
Use latest build-su2-cross Docker image for `release-management` Github Actions workflow

### DIFF
--- a/.github/workflows/release-management.yml
+++ b/.github/workflows/release-management.yml
@@ -35,7 +35,7 @@ jobs:
           key: ${{ matrix.os_bin }}-${{ github.sha }}
           restore-keys: ${{ matrix.os_bin }}
       - name: Build
-        uses: docker://ghcr.io/su2code/su2/build-su2-cross:220630-1237
+        uses: docker://ghcr.io/su2code/su2/build-su2-cross:220716-1459
         with:
           args: -b ${{ github.sha }} -f "${{matrix.flags}}"
       - name: Create Archive

--- a/.github/workflows/release-management.yml
+++ b/.github/workflows/release-management.yml
@@ -35,7 +35,7 @@ jobs:
           key: ${{ matrix.os_bin }}-${{ github.sha }}
           restore-keys: ${{ matrix.os_bin }}
       - name: Build
-        uses: docker://su2code/build-su2-cross:latest
+        uses: docker://ghcr.io/su2code/su2/build-su2-cross:220630-1237
         with:
           args: -b ${{ github.sha }} -f "${{matrix.flags}}"
       - name: Create Archive


### PR DESCRIPTION
## Proposed Changes

build-su2-cross should extend from build-su2 Docker image to use the same GCC version. 

Failed build: https://github.com/su2code/SU2/runs/7125551739?check_suite_focus=true

The PR is draft because it depends on the build of https://github.com/su2code/Docker-Builds/pull/7

## Related Work

https://github.com/su2code/SU2/pull/1619 - Updates Ubuntu to 20.04 and GCC from 7.x to 9.x. 

## PR Checklist

- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with the '-Wall -Wextra -Wno-unused-parameter -Wno-empty-body' compiler flags, or simply --warnlevel=2 when using meson).
- [X] My contribution is commented and consistent with SU2 style.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp) , if necessary.
