### PR TITLE
Fix LUT and species clipping

### DIFF
--- a/Common/include/linear_algebra/CSysVector.hpp
+++ b/Common/include/linear_algebra/CSysVector.hpp
@@ -353,6 +353,15 @@ class CSysVector : public VecExpr::CVecExpr<CSysVector<ScalarType>, ScalarType> 
   }
 
   /*!
+   * \brief Set the value of one variable to zero for one block.
+   * \param[in] iPoint - Index of the block being set to zero.
+   * \param[in] iVar - Index of the variable being set to zero.
+   */
+  inline void SetBlock_Zero(unsigned long iPoint, unsigned long iVar) {
+    vec_val[iPoint * nVar + iVar] = 0.0;
+  }
+  
+  /*!
    * \brief Set "block" to the vector.
    * \note Template param Overwrite can be set to false to update existing values.
    * \param[in] iPoint - index of the point where set the residual.

--- a/Common/include/linear_algebra/CSysVector.hpp
+++ b/Common/include/linear_algebra/CSysVector.hpp
@@ -353,15 +353,6 @@ class CSysVector : public VecExpr::CVecExpr<CSysVector<ScalarType>, ScalarType> 
   }
 
   /*!
-   * \brief Set the value of one variable to zero for one block.
-   * \param[in] iPoint - Index of the block being set to zero.
-   * \param[in] iVar - Index of the variable being set to zero.
-   */
-  inline void SetBlock_Zero(unsigned long iPoint, unsigned long iVar) {
-    vec_val[iPoint * nVar + iVar] = 0.0;
-  }
-  
-  /*!
    * \brief Set "block" to the vector.
    * \note Template param Overwrite can be set to false to update existing values.
    * \param[in] iPoint - index of the point where set the residual.

--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -5357,8 +5357,9 @@ void CConfig::SetPostprocessing(SU2_COMPONENT val_software, unsigned short val_i
       SU2_MPI::Error("Only TIME_DISCRE_TURB = EULER_IMPLICIT, EULER_EXPLICIT have been implemented in the scalar solver.", CURRENT_FUNCTION);
     }
 
+
     /*--- If Species clipping is on, make sure bounds are given by the user. ---*/
-    if (OptionIsSet("SPECIES_CLIPPING"))
+    if (Species_Clipping)
       if (!(OptionIsSet("SPECIES_CLIPPING_MIN") && OptionIsSet("SPECIES_CLIPPING_MAX")))
         SU2_MPI::Error("SPECIES_CLIPPING= YES requires the options SPECIES_CLIPPING_MIN/MAX to set the clipping values.", CURRENT_FUNCTION);
 

--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -5357,7 +5357,6 @@ void CConfig::SetPostprocessing(SU2_COMPONENT val_software, unsigned short val_i
       SU2_MPI::Error("Only TIME_DISCRE_TURB = EULER_IMPLICIT, EULER_EXPLICIT have been implemented in the scalar solver.", CURRENT_FUNCTION);
     }
 
-
     /*--- If Species clipping is on, make sure bounds are given by the user. ---*/
     if (Species_Clipping)
       if (!(OptionIsSet("SPECIES_CLIPPING_MIN") && OptionIsSet("SPECIES_CLIPPING_MAX")))

--- a/Common/src/containers/CTrapezoidalMap.cpp
+++ b/Common/src/containers/CTrapezoidalMap.cpp
@@ -142,14 +142,14 @@ unsigned long CTrapezoidalMap::GetTriangle(su2double val_x, su2double val_y) {
   /* within that band, find edges which enclose the (val_x, val_y) point */
   pair<unsigned long, unsigned long> edges = GetEdges(band, val_x, val_y);
 
-  /* identify the triangle using the two edges */
-  std::array<unsigned long, 3> triangles_edge_low;
+
+  std::array<unsigned long, 2> triangles_edge_low;
   
-  for (int i=0;i<3;i++)
+  for (int i=0;i<2;i++)
    triangles_edge_low[i] = edge_to_triangle[edges.first][i];
    
-  std::array<unsigned long, 3> triangles_edge_up;
-  for (int i=0;i<3;i++)
+  std::array<unsigned long, 2> triangles_edge_up;
+  for (int i=0;i<2;i++)
    triangles_edge_up[i] = edge_to_triangle[edges.second][i];
 
   sort(triangles_edge_low.begin(), triangles_edge_low.end());

--- a/Common/src/containers/CTrapezoidalMap.cpp
+++ b/Common/src/containers/CTrapezoidalMap.cpp
@@ -142,7 +142,7 @@ unsigned long CTrapezoidalMap::GetTriangle(su2double val_x, su2double val_y) {
   /* within that band, find edges which enclose the (val_x, val_y) point */
   pair<unsigned long, unsigned long> edges = GetEdges(band, val_x, val_y);
 
-
+  /* identify the triangle using the two edges */
   std::array<unsigned long, 2> triangles_edge_low;
   
   for (int i=0;i<2;i++)

--- a/SU2_CFD/src/fluid/CFluidScalar.cpp
+++ b/SU2_CFD/src/fluid/CFluidScalar.cpp
@@ -1,5 +1,5 @@
 /*!
- * \file CFluidScalar.hpp
+ * \file CFluidScalar.cpp
  * \brief Defines the multicomponent incompressible Ideal Gas model for mixtures.
  * \author T. Economon, Mark Heimgartner, Cristopher Morales Ubal
  * \version 7.4.0 "Blackbird"


### PR DESCRIPTION
## Proposed Changes
*Give a brief overview of your contribution here in a few sentences.*
 1. arrays in gettriangle need to be size 2 instead of 3
 2. error message that checks species clipping only checks if the keyword is present, not if clipping is on
 3. added setblock_zero "per-species" to CSysVector (added here to reduce the mega-PR for the flamelet model)
 4. fix speling eror

## Related Work
*Resolve any issues (bug fix or feature request), note any related PRs, or mention interactions with the work of others, if any.*

## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [X] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
