### PR TITLE
Quick fix to a bug in CFlowOutput.cpp that crashes the FEM-DG solver

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -126,6 +126,7 @@ TobiKattmann
 Trent Lukaczyk
 VivaanKhatri
 Wally Maier
+Zan Xu
 aaronyicongfu
 aeroamit
 anilvar

--- a/SU2_CFD/src/output/CFlowCompFEMOutput.cpp
+++ b/SU2_CFD/src/output/CFlowCompFEMOutput.cpp
@@ -257,12 +257,9 @@ void CFlowCompFEMOutput::LoadHistoryData(CConfig *config, CGeometry *geometry, C
 
   /*--- Set the analyse surface history values --- */
 
-  for (unsigned short iMarker = 0; iMarker < config->GetnMarker_All(); iMarker++) {
-    if (config->GetMarker_All_Analyze(iMarker) == YES) {
-      SU2_MPI::Error("SetAnalyzeSurface is not implemented for FEM-DG solver.", CURRENT_FUNCTION);
-    }
+  if (config->GetnMarker_Analyze() > 0) {
+    SU2_MPI::Error("SetAnalyzeSurface is not implemented for FEM-DG solver.", CURRENT_FUNCTION);
   }
-  // SetAnalyzeSurface(solver, geometry, config, false);
 
   /*--- Set aeroydnamic coefficients --- */
 

--- a/SU2_CFD/src/output/CFlowCompFEMOutput.cpp
+++ b/SU2_CFD/src/output/CFlowCompFEMOutput.cpp
@@ -255,8 +255,6 @@ void CFlowCompFEMOutput::LoadHistoryData(CConfig *config, CGeometry *geometry, C
   SetHistoryOutputValue("AOA", config->GetAoA());
   SetHistoryOutputValue("CFL_NUMBER", config->GetCFL(MESH_0));
 
-  /*--- Set the analyse surface history values --- */
-
   if (config->GetnMarker_Analyze() > 0) {
     SU2_MPI::Error("SetAnalyzeSurface is not implemented for FEM-DG solver.", CURRENT_FUNCTION);
   }

--- a/SU2_CFD/src/output/CFlowCompFEMOutput.cpp
+++ b/SU2_CFD/src/output/CFlowCompFEMOutput.cpp
@@ -257,7 +257,12 @@ void CFlowCompFEMOutput::LoadHistoryData(CConfig *config, CGeometry *geometry, C
 
   /*--- Set the analyse surface history values --- */
 
-  SetAnalyzeSurface(solver, geometry, config, false);
+  for (unsigned short iMarker = 0; iMarker < config->GetnMarker_All(); iMarker++) {
+    if (config->GetMarker_All_Analyze(iMarker) == YES) {
+      SU2_MPI::Error("SetAnalyzeSurface is not implemented for FEM-DG solver.", CURRENT_FUNCTION);
+    }
+  }
+  // SetAnalyzeSurface(solver, geometry, config, false);
 
   /*--- Set aeroydnamic coefficients --- */
 

--- a/SU2_CFD/src/output/CFlowOutput.cpp
+++ b/SU2_CFD/src/output/CFlowOutput.cpp
@@ -155,7 +155,10 @@ void CFlowOutput::SetAnalyzeSurface(const CSolver* const*solver, const CGeometry
   const bool axisymmetric               = config->GetAxisymmetric();
   const unsigned short nMarker_Analyze  = config->GetnMarker_Analyze();
 
-  const auto flow_nodes = solver[FLOW_SOL]->GetNodes();
+  const auto flow_nodes = (config->GetKind_Solver() == MAIN_SOLVER::FEM_EULER               ||
+                           config->GetKind_Solver() == MAIN_SOLVER::FEM_NAVIER_STOKES       ||
+                           config->GetKind_Solver() == MAIN_SOLVER::FEM_RANS                ||
+                           config->GetKind_Solver() == MAIN_SOLVER::FEM_LES                 ) ? nullptr : solver[FLOW_SOL]->GetNodes();
   const CVariable* species_nodes = species ? solver[SPECIES_SOL]->GetNodes() : nullptr;
 
   vector<su2double> Surface_MassFlow          (nMarker,0.0);

--- a/SU2_CFD/src/output/CFlowOutput.cpp
+++ b/SU2_CFD/src/output/CFlowOutput.cpp
@@ -155,10 +155,7 @@ void CFlowOutput::SetAnalyzeSurface(const CSolver* const*solver, const CGeometry
   const bool axisymmetric               = config->GetAxisymmetric();
   const unsigned short nMarker_Analyze  = config->GetnMarker_Analyze();
 
-  const auto flow_nodes = (config->GetKind_Solver() == MAIN_SOLVER::FEM_EULER               ||
-                           config->GetKind_Solver() == MAIN_SOLVER::FEM_NAVIER_STOKES       ||
-                           config->GetKind_Solver() == MAIN_SOLVER::FEM_RANS                ||
-                           config->GetKind_Solver() == MAIN_SOLVER::FEM_LES                 ) ? nullptr : solver[FLOW_SOL]->GetNodes();
+  const auto flow_nodes = solver[FLOW_SOL]->GetNodes();
   const CVariable* species_nodes = species ? solver[SPECIES_SOL]->GetNodes() : nullptr;
 
   vector<su2double> Surface_MassFlow          (nMarker,0.0);


### PR DESCRIPTION
## Proposed Changes
This is a tiny PR to add a conditional operator in CFlowOutput.cpp to avoid calling to GetNodes() function if the solver is a FEM/DG solver.

In one of the early commits (34b0464e898dd167d8a865f47aa630019a5978ac), a call to GetNodes() was added in `CFlowOutput::SetAnalyzeSurface` which calls the function `GetNodes()`

```const auto flow_nodes = solver[FLOW_SOL]->GetNodes();```

There is an assertion in `GetNodes()` that further mandates the `CVariable` `base_nodes` to be set properly. However, in the FEM/DG solver, the `base_nodes` is defaulted to `nullptr` and we have workarounds in the FEM/DG sovler that does not require a call to `GetNodes()` in other parts of the code (we use elements instead of nodes, so the concept of nodes is not really well-defined in the FEM/DG solver). 

At the moment, the develop branch will fail at this line if anyone attempts to use the FEM/DG solver. 

E.g., Taking the `hom_euler/NACA0012_5thOrder` test case in the repo gives the following error message:
```SU2_CFD: ../SU2_CFD/src/output/../../include/solvers/CSolver.hpp:230: const CVariable* CSolver::GetNodes() const: Assertion `base_nodes!=nullptr && "CSolver::base_nodes was not set properly, see brief for CSolver::SetBaseClassPointerToNodes()"' failed.``` at the pre-processing stage before any computation is done.

Hence, a conditional operator is added to avoid this call for DG solvers.

## Related Work
*Resolve any issues (bug fix or feature request), note any related PRs, or mention interactions with the work of others, if any.*
@vdweide and I are working on a new version of the DG solver that needs this workaround anyway. This is just added for now in case anyone else wants to work on the current version of DG solver available.


## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [x] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
