### PR TITLE
Wrap MPI_Allgatherv for NdFlattener

### DIFF
--- a/Common/include/parallelization/mpi_structure.cpp
+++ b/Common/include/parallelization/mpi_structure.cpp
@@ -119,9 +119,9 @@ void CBaseMPIWrapper::CopyData(const void* sendbuf, void* recvbuf, int size, Dat
   } else {
     int scalarsize;
     MPI_Type_size(datatype, &scalarsize);
-    const char* src = static_cast<const char*>(sendbuf) + sendshift*scalarsize;
-    char* dest = static_cast<char*>(recvbuf) + recvshift*scalarsize;
-    std::memcpy(static_cast<void*>(dest), static_cast<const void*>(src), size*scalarsize);
+    const char* src = static_cast<const char*>(sendbuf) + sendshift*static_cast<size_t>(scalarsize);
+    char* dest = static_cast<char*>(recvbuf) + recvshift*static_cast<size_t>(scalarsize);
+    std::memcpy(static_cast<void*>(dest), static_cast<const void*>(src), size*static_cast<size_t>(scalarsize));
   }
 }
 #else // HAVE_MPI

--- a/Common/include/parallelization/mpi_structure.cpp
+++ b/Common/include/parallelization/mpi_structure.cpp
@@ -26,6 +26,7 @@
  */
 
 #include "mpi_structure.hpp"
+#include <cstring> // memcpy
 
 
 /* Initialise the MPI Communicator Rank and Size */
@@ -108,6 +109,20 @@ void CBaseMPIWrapper::Error(std::string ErrorMsg, std::string FunctionName){
     std::cout << std::endl << std::endl;
   }
   Abort(currentComm, EXIT_FAILURE);
+}
+
+void CBaseMPIWrapper::CopyData(const void* sendbuf, void* recvbuf, int size, Datatype datatype, int recvshift, int sendshift) {
+  if(datatype==MPI_DOUBLE) {
+    for (int i = 0; i < size; i++) {
+      static_cast<su2double*>(recvbuf)[i+recvshift] = static_cast<const su2double*>(sendbuf)[i+sendshift];
+    }
+  } else {
+    int scalarsize;
+    MPI_Type_size(datatype, &scalarsize);
+    const char* src = static_cast<const char*>(sendbuf) + sendshift*scalarsize;
+    char* dest = static_cast<char*>(recvbuf) + recvshift*scalarsize;
+    std::memcpy(static_cast<void*>(dest), static_cast<const void*>(src), size*scalarsize);
+  }
 }
 #else // HAVE_MPI
 

--- a/Common/include/parallelization/mpi_structure.hpp
+++ b/Common/include/parallelization/mpi_structure.hpp
@@ -105,6 +105,8 @@ class CBaseMPIWrapper {
   static Win winMinRankError;
 
  public:
+  static void CopyData(const void* sendbuf, void* recvbuf, int size, Datatype datatype, int recvshift=0, int sendshift=0);
+
   static void Error(std::string ErrorMsg, std::string FunctionName);
 
   static inline int GetRank() { return Rank; }
@@ -503,9 +505,9 @@ class CBaseMPIWrapper {
   static int Rank, Size;
   static Comm currentComm;
 
+ public:
   static void CopyData(const void* sendbuf, void* recvbuf, int size, Datatype datatype, int recvshift=0, int sendshift=0);
 
- public:
   static void Error(std::string ErrorMsg, std::string FunctionName);
 
   static inline int GetRank() { return Rank; }

--- a/Common/include/toolboxes/ndflattener.hpp
+++ b/Common/include/toolboxes/ndflattener.hpp
@@ -210,12 +210,12 @@ class NdFlattener;
 /*! Allgatherv wrapper defaulting to a copy operation if there is only a single MPI rank.
  *
  *  Introducing this was necessary because MPICH's Allgatherv behaved unexpectedly if there
- *  is only one MPI rank.
+ *  is only one MPI rank (seemingly ignoring displs[0] != 0).
  */
 static inline void SU2_MPI_Allgatherv_safe(const void* sendbuf, int sendcount, SU2_MPI::Datatype sendtype, void* recvbuf,
                               const int* recvcounts, const int* displs, SU2_MPI::Datatype recvtype, SU2_MPI::Comm comm) {
-  if(SU2_MPI::GetSize()==1){
-    SU2_MPI::CopyData(sendbuf,recvbuf,sendcount,sendtype,displs[0]);
+  if (SU2_MPI::GetSize() == 1) {
+    SU2_MPI::CopyData(sendbuf, recvbuf, sendcount, sendtype, displs[0]);
   } else {
     SU2_MPI::Allgatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm);
   }

--- a/Common/include/toolboxes/ndflattener.hpp
+++ b/Common/include/toolboxes/ndflattener.hpp
@@ -207,6 +207,20 @@
 template <size_t K, typename Data_t_ = su2double, typename Index_t_ = unsigned long>
 class NdFlattener;
 
+/*! Allgatherv wrapper defaulting to a copy operation if there is only a single MPI rank.
+ *
+ *  Introducing this was necessary because MPICH's Allgatherv behaved unexpectedly if there
+ *  is only one MPI rank.
+ */
+static inline void SU2_MPI_Allgatherv_safe(const void* sendbuf, int sendcount, SU2_MPI::Datatype sendtype, void* recvbuf,
+                              const int* recvcounts, const int* displs, SU2_MPI::Datatype recvtype, SU2_MPI::Comm comm) {
+  if(SU2_MPI::GetSize()==1){
+    SU2_MPI::CopyData(sendbuf,recvbuf,sendcount,sendtype,displs[0]);
+  } else {
+    SU2_MPI::Allgatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm);
+  }
+}
+
 /*! \struct Nd_MPI_Environment
  * \brief Contains information for the collective communication of NdFlatteners.
  *
@@ -232,7 +246,7 @@ struct Nd_MPI_Environment {
                      MPI_Datatype_t mpi_index = MPI_UNSIGNED_LONG,
                      MPI_Communicator_t comm = SU2_MPI::GetComm(),
                      MPI_Allgather_t MPI_Allgather_fun = &(SU2_MPI::Allgather),
-                     MPI_Allgatherv_t MPI_Allgatherv_fun = &(SU2_MPI::Allgatherv))
+                     MPI_Allgatherv_t MPI_Allgatherv_fun = &(SU2_MPI_Allgatherv_safe))
       : mpi_data(mpi_data),
         mpi_index(mpi_index),
         comm(comm),


### PR DESCRIPTION
## Proposed Changes
Let NdFlattener use a wrapped [MPI_Allgatherv](https://www.mpich.org/static/docs/v3.2/www3/MPI_Allgatherv.html) function which checks the number of participating MPI ranks. If there is only one, perform a simple copy operation instead.

I hope that this fixes #1893, which I believe to be the result of a bug in MPICH. In my Ubuntu MPICH container, the `[NdFlattener]` test succeeds with these changes. 

## Related Work
#1893 



## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [X] I am submitting my contribution to the develop branch.
- [ ] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [ ] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
