### PR TITLE
fix logo path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 <p align="center">
-<img width="250" height="154" src="Common/doc/logoSU2small.png">
+<img width="250" height="154" src="Docs/logoSU2small.png">
 </p>
-
 
 # SU2 (ver. 7.5.0 "Blackbird"): The Open-Source CFD Code
 
-Computational analysis tools have revolutionized the way we design engineering systems, but most established codes are proprietary, unavailable, or prohibitively expensive for many users. The SU2 team is changing this, making multiphysics analysis and design optimization freely available as open-source software and involving everyone in its creation and development. 
+Computational analysis tools have revolutionized the way we design engineering systems, but most established codes are proprietary, unavailable, or prohibitively expensive for many users. The SU2 team is changing this, making multiphysics analysis and design optimization freely available as open-source software and involving everyone in its creation and development.
 
 For an overview of the technical details in SU2, please see the following AIAA Journal article:
 
-"SU2: An open-source suite for multiphysics simulation and design," AIAA Journal, 54(3):828-846, 2016. http://arc.aiaa.org/doi/10.2514/1.J053813
+"SU2: An open-source suite for multiphysics simulation and design," AIAA Journal, 54(3):828-846, 2016. <http://arc.aiaa.org/doi/10.2514/1.J053813>
 
 Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
 
@@ -22,17 +21,17 @@ Code Quality:<br/>
 
 # SU2 Introduction
 
-SU2 is a suite of open-source software tools written in C++ for the numerical solution of partial differential equations (PDE) and performing PDE constrained optimization. 
+SU2 is a suite of open-source software tools written in C++ for the numerical solution of partial differential equations (PDE) and performing PDE constrained optimization.
 
-The primary applications are computational fluid dynamics and aerodynamic shape optimization, but has been extended to treat more general equations such as electrodynamics and chemically reacting flows. 
+The primary applications are computational fluid dynamics and aerodynamic shape optimization, but has been extended to treat more general equations such as electrodynamics and chemically reacting flows.
 
 You will find more information and the latest news in:
-   - SU2 Home Page: https://su2code.github.io
-   - GitHub repository: https://github.com/su2code
-   - CFD Online: http://www.cfd-online.com/Forums/su2/
-   - Twitter: https://twitter.com/su2code
-   - Facebook: https://www.facebook.com/su2code
 
+- SU2 Home Page: <https://su2code.github.io>
+- GitHub repository: <https://github.com/su2code>
+- CFD Online: <http://www.cfd-online.com/Forums/su2/>
+- Twitter: <https://twitter.com/su2code>
+- Facebook: <https://www.facebook.com/su2code>
 
 # SU2 Installation
 
@@ -41,7 +40,8 @@ You will find more information and the latest news in:
 You can find precompiled binaries of the latest version on our [download page](https://su2code.github.io/download.html) or under [releases](https://github.com/su2code/SU2/releases).
 
 ## Build SU2
-The build system of SU2 is based on a combination of [meson](http://mesonbuild.com/) (as the front-end) and [ninja](https://ninja-build.org/) (as the back-end). Meson is an open source build system meant to be both extremely fast, and, even more importantly, as user friendly as possible. Ninja is a small low-level build system with a focus on speed. 
+
+The build system of SU2 is based on a combination of [meson](http://mesonbuild.com/) (as the front-end) and [ninja](https://ninja-build.org/) (as the back-end). Meson is an open source build system meant to be both extremely fast, and, even more importantly, as user friendly as possible. Ninja is a small low-level build system with a focus on speed.
 
 Short summary of the minimal requirements:
 
@@ -51,9 +51,11 @@ Short summary of the minimal requirements:
 **Note:** all other necessary build tools and dependencies are shipped with the source code or are downloaded automatically.
 
 If you have these tools installed, you can create a configuration using the `meson.py` found in the root source code folder:
+
 ```
 ./meson.py build
 ```
+
 Use `ninja` to compile and install the code
 
 ```
@@ -62,11 +64,12 @@ Use `ninja` to compile and install the code
 
 For more information on how to install and build SU2 on Linux, MacOS or Windows, have a look at the [documentation](https://su2code.github.io/docs_v7/).
 
-##  SU2 Path setup
+## SU2 Path setup
 
-When installation is complete, please be sure to add the `$SU2_HOME` and `$SU2_RUN` environment variables, and update your `$PATH` with `$SU2_RUN`. 
+When installation is complete, please be sure to add the `$SU2_HOME` and `$SU2_RUN` environment variables, and update your `$PATH` with `$SU2_RUN`.
 
 For example, add these lines to your `.bashrc` file:
+
 ```
 export SU2_RUN="your_prefix/bin"
 export SU2_HOME="/path/to/SU2vX.X.X/"
@@ -82,13 +85,11 @@ Thanks for building, and happy optimizing!
 
 - The SU2 Development Team
 
-
 # SU2 Developers
-
 
 We follow the popular "GitFlow" branching model for scalable development. In the SU2 repository, the master branch represents the latest stable major or minor release (7.0, 6.2.0, etc.), it should only be modified during version releases. Work that is staged for release is put into the develop branch via Pull Requests on GitHub from various "feature" branches where folks do their day-to-day work on the code. At release time, the work that has been merged into the develop branch is pushed to the master branch and tagged as a release.
 
-SU2 is being developed by individuals and organized teams all around the world. 
+SU2 is being developed by individuals and organized teams all around the world.
 
 A list of current contributors can be found in the AUTHORS.md file.
 


### PR DESCRIPTION
## Proposed Changes

The SU2 logo has been move in #1771 but its path has not been modified in the README. I update it and improve a bit the formatting of the markdown.

## Related Work

No

## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [x] I am submitting my contribution to the develop branch.
- [ ] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [ ] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
