### PR TITLE
Fix condition to set penalty function

### DIFF
--- a/SU2_PY/SU2/eval/design.py
+++ b/SU2_PY/SU2/eval/design.py
@@ -269,7 +269,7 @@ def obj_p(config,state,this_obj,def_objs):
         (def_objs[this_obj]['OBJTYPE']=='<' and funcval > constraint )):
         penalty = (constraint - funcval)**2.0
     # If 'DEFAULT' objtype this returns the function value.
-    else:
+    elif (def_objs[this_obj]['OBJTYPE']=='DEFAULT'):
         penalty = funcval
     return penalty
 


### PR DESCRIPTION
## Proposed Changes
*Give a brief overview of your contribution here in a few sentences.*
When `(Objective < Value ) * Scale` ('<' can be '>') is added to OPT_OBJECTIVE in the configuration file, it is treated as a penalty function. When the constraint is satisfied, the penalty function value should be zero. However, it is currently set to the function value. The same `elif` condition as in `obj_dp` should be used. 

## Related Work
*Resolve any issues (bug fix or feature request), note any related PRs, or mention interactions with the work of others, if any.*
Resolve #1968.


## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [x] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [x] I have added a test case that demonstrates my contribution, if necessary.
- [x] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
