### PR TITLE
Rename python Driver method 'Postprocessing' to 'Finalize'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ ninja
 
 # Ignore SU2 pre-configuration timestamp created by preconfigure.py
 su2preconfig.timestamp
+
+# Clangd server files
+.cache

--- a/SU2_CFD/include/drivers/CDriver.hpp
+++ b/SU2_CFD/include/drivers/CDriver.hpp
@@ -364,7 +364,7 @@ class CDriver : public CDriverBase {
   /*!
    * \brief Deallocation routine
    */
-  void Postprocessing();
+  void Finalize();
 
   /*!
    * \brief A virtual member.

--- a/SU2_CFD/include/drivers/CDriverBase.hpp
+++ b/SU2_CFD/include/drivers/CDriverBase.hpp
@@ -120,7 +120,7 @@ class CDriverBase {
   /*!
    * \brief A virtual member.
    */
-  virtual void Postprocessing(){}
+  virtual void Finalize(){}
 
 /// \addtogroup PySU2
 /// @{
@@ -446,7 +446,7 @@ class CDriverBase {
   /*!
    * \brief Delete containers.
    */
-  void CommonPostprocessing();
+  void CommonFinalize();
 
   /*!
    * \brief Read in the config and mesh files.

--- a/SU2_CFD/src/SU2_CFD.cpp
+++ b/SU2_CFD/src/SU2_CFD.cpp
@@ -154,9 +154,9 @@ int main(int argc, char *argv[]) {
 
   driver->StartSolver();
 
-  /*--- Postprocess all the containers, close history file, exit SU2. ---*/
+  /*--- Finalize solver, delete all the containers, close history file, exit SU2. ---*/
 
-  driver->Postprocessing();
+  driver->Finalize();
 
   delete driver;
 

--- a/SU2_CFD/src/drivers/CDriver.cpp
+++ b/SU2_CFD/src/drivers/CDriver.cpp
@@ -346,7 +346,7 @@ void CDriver::SetContainers_Null(){
 }
 
 
-void CDriver::Postprocessing() {
+void CDriver::Finalize() {
 
   const bool wrt_perf = config_container[ZONE_0]->GetWrt_Performance();
 
@@ -363,7 +363,7 @@ void CDriver::Postprocessing() {
   }
 
   if (rank == MASTER_NODE)
-    cout << endl <<"------------------------- Solver Postprocessing -------------------------" << endl;
+    cout << endl <<"------------------------- Finalizing Solver -------------------------" << endl;
 
   for (iZone = 0; iZone < nZone; iZone++) {
     for (iInst = 0; iInst < nInst[iZone]; iInst++){

--- a/SU2_CFD/src/drivers/CDriverBase.cpp
+++ b/SU2_CFD/src/drivers/CDriverBase.cpp
@@ -84,7 +84,7 @@ void CDriverBase::SetContainers_Null() {
   }
 }
 
-void CDriverBase::CommonPostprocessing() {
+void CDriverBase::CommonFinalize() {
 
   if (numerics_container != nullptr) {
     for (iZone = 0; iZone < nZone; iZone++) {

--- a/SU2_DEF/include/drivers/CDeformationDriver.hpp
+++ b/SU2_DEF/include/drivers/CDeformationDriver.hpp
@@ -66,7 +66,7 @@ class CDeformationDriver : public CDriverBase {
   /*!
    * \brief Deallocation routine.
    */
-  void Postprocessing();
+  void Finalize();
 
   /*!
    * \brief Communicate boundary mesh displacements.

--- a/SU2_DEF/include/drivers/CDiscAdjDeformationDriver.hpp
+++ b/SU2_DEF/include/drivers/CDiscAdjDeformationDriver.hpp
@@ -57,7 +57,7 @@ class CDiscAdjDeformationDriver : public CDriverBase {
   /*!
    * \brief Deallocation routine.
    */
-  void Postprocessing();
+  void Finalize();
 
  protected:
   /*!

--- a/SU2_DEF/src/SU2_DEF.cpp
+++ b/SU2_DEF/src/SU2_DEF.cpp
@@ -63,7 +63,7 @@ int main(int argc, char* argv[]) {
 
   /*--- Postprocess all the containers, close history file, and exit SU2. ---*/
 
-  driver.Postprocessing();
+  driver.Finalize();
 
   /*--- Finalize MPI parallelization. ---*/
 

--- a/SU2_DEF/src/drivers/CDeformationDriver.cpp
+++ b/SU2_DEF/src/drivers/CDeformationDriver.cpp
@@ -535,9 +535,8 @@ void CDeformationDriver::Output() {
   }
 }
 
-void CDeformationDriver::Postprocessing() {
-  if (rank == MASTER_NODE)
-    cout << "\n------------------------- Solver Postprocessing -------------------------" << endl;
+void CDeformationDriver::Finalize() {
+  if (rank == MASTER_NODE) cout << "\n------------------------- Finalize Solver -------------------------" << endl;
 
   if (driver_config->GetDeform_Mesh()) {
     for (iZone = 0; iZone < nZone; iZone++) {
@@ -550,7 +549,7 @@ void CDeformationDriver::Postprocessing() {
         delete[] numerics_container[iZone][INST_0][MESH_0];
         delete[] numerics_container[iZone][INST_0];
       }
-      /*--- The remaining levels in the container are deleted in CommonPostprocessing ---*/
+      /*--- The remaining levels in the container are deleted in CommonFinalize ---*/
     }
 
     for (iZone = 0; iZone < nZone; iZone++) {
@@ -559,11 +558,11 @@ void CDeformationDriver::Postprocessing() {
         delete[] solver_container[iZone][INST_0][MESH_0];
         delete[] solver_container[iZone][INST_0];
       }
-      /*--- The remaining levels in the container are deleted in CommonPostprocessing ---*/
+      /*--- The remaining levels in the container are deleted in CommonFinalize ---*/
     }
   }
 
-  CommonPostprocessing();
+  CommonFinalize();
 
   /*--- Exit the solver cleanly. ---*/
 

--- a/SU2_DEF/src/drivers/CDiscAdjDeformationDriver.cpp
+++ b/SU2_DEF/src/drivers/CDiscAdjDeformationDriver.cpp
@@ -367,16 +367,15 @@ void CDiscAdjDeformationDriver::Run() {
   OutputGradient(Gradient, config_container[ZONE_0], Gradient_file);
 }
 
-void CDiscAdjDeformationDriver::Postprocessing() {
+void CDiscAdjDeformationDriver::Finalize() {
   for (auto iDV = 0u; iDV < config_container[ZONE_0]->GetnDV(); iDV++) {
     delete[] Gradient[iDV];
   }
   delete[] Gradient;
 
-  if (rank == MASTER_NODE)
-    cout << "\n------------------------- Solver Postprocessing -------------------------" << endl;
+  if (rank == MASTER_NODE) cout << "\n------------------------- Finalize Solver  -------------------------" << endl;
 
-  CommonPostprocessing();
+  CommonFinalize();
 
   /*--- Exit the solver cleanly. ---*/
 

--- a/SU2_DOT/src/SU2_DOT.cpp
+++ b/SU2_DOT/src/SU2_DOT.cpp
@@ -66,7 +66,7 @@ int main(int argc, char* argv[]) {
 
   /*--- Postprocess all the containers, close history file, and exit SU2. ---*/
 
-  driver.Postprocessing();
+  driver.Finalize();
 
   /*--- Finalize AD. ---*/
 

--- a/SU2_GEO/src/SU2_GEO.cpp
+++ b/SU2_GEO/src/SU2_GEO.cpp
@@ -1429,7 +1429,7 @@ int main(int argc, char* argv[]) {
   }
 
   if (rank == MASTER_NODE)
-    cout << endl << "------------------------- Solver Postprocessing -------------------------" << endl;
+    cout << endl << "------------------------- Finalize Solver -------------------------" << endl;
 
   delete[] Xcoord_Airfoil;
   delete[] Ycoord_Airfoil;

--- a/SU2_PY/SU2_CFD.py
+++ b/SU2_PY/SU2_CFD.py
@@ -160,8 +160,8 @@ def main():
     # Launch the solver for the entire computation
     SU2Driver.StartSolver()
 
-    # Postprocess the solver and exit cleanly
-    SU2Driver.Postprocessing()
+    # Finalize the solver and exit cleanly
+    SU2Driver.Finalize()
 
     if SU2Driver != None:
         del SU2Driver

--- a/SU2_PY/fsi_computation.py
+++ b/SU2_PY/fsi_computation.py
@@ -231,7 +231,7 @@ def main():
         comm.barrier()
 
     # --- Exit cleanly the fluid and solid solvers --- #
-    FluidSolver.Postprocessing()
+    FluidSolver.Finalize()
     if myid == rootProcess:
         SolidSolver.exit()
 

--- a/SU2_SOL/src/SU2_SOL.cpp
+++ b/SU2_SOL/src/SU2_SOL.cpp
@@ -685,7 +685,7 @@ int main(int argc, char* argv[]) {
   config = nullptr;
 
   if (rank == MASTER_NODE)
-    cout << endl << "------------------------- Solver Postprocessing -------------------------" << endl;
+    cout << endl << "------------------------- Finalize Solver -------------------------" << endl;
 
   if (geometry_container != nullptr) {
     for (iZone = 0; iZone < nZone; iZone++) {

--- a/TestCases/py_wrapper/deforming_bump_in_channel/run.py
+++ b/TestCases/py_wrapper/deforming_bump_in_channel/run.py
@@ -88,8 +88,8 @@ def main():
     TimeIter += 1
     time += deltaT
 
-  # Postprocess the solver and exit cleanly
-  SU2Driver.Postprocessing()
+  # Finalize the solver and exit cleanly
+  SU2Driver.Finalize()
 
 
 # Imposed deformation

--- a/TestCases/py_wrapper/disc_adj_fea/flow_load_sens/run_adjoint.py
+++ b/TestCases/py_wrapper/disc_adj_fea/flow_load_sens/run_adjoint.py
@@ -118,8 +118,8 @@ def main():
     print("Sens[0]\tSens[1]\tDisp[0]\tDisp[1]\t")
     print(100, 100, sens[0][0], sens[0][1], disp[0][0], disp[0][1])
 
-  # Postprocess the solver and exit cleanly
-  SU2Driver.Postprocessing()
+  # Finalize the solver and exit cleanly
+  SU2Driver.Finalize()
 
   if SU2Driver != None:
     del SU2Driver

--- a/TestCases/py_wrapper/disc_adj_flow/mesh_disp_sens/run_adjoint.py
+++ b/TestCases/py_wrapper/disc_adj_flow/mesh_disp_sens/run_adjoint.py
@@ -115,8 +115,8 @@ def main():
     if (iVertex == 30) and rank == 0:
       print(1000,1000,iVertex, sensX, sensY, sensZ)
 
-  # Postprocess the solver and exit cleanly
-  SU2Driver.Postprocessing()
+  # Finalize the solver and exit cleanly
+  SU2Driver.Finalize()
 
   if SU2Driver != None:
     del SU2Driver

--- a/TestCases/py_wrapper/flatPlate_rigidMotion/launch_flatPlate_rigidMotion.py
+++ b/TestCases/py_wrapper/flatPlate_rigidMotion/launch_flatPlate_rigidMotion.py
@@ -134,8 +134,8 @@ def main():
     TimeIter += 1
     time += deltaT
 
-  # Postprocess the solver and exit cleanly
-  SU2Driver.Postprocessing()
+  # Finalize the solver and exit cleanly
+  SU2Driver.Finalize()
 
   if SU2Driver != None:
     del SU2Driver


### PR DESCRIPTION
## Proposed Changes

The driver method `Postprocessing()` actually frees all the containers and finalizes the driver. As it does not reflect what is actually done and is easy to confuse with the method `Postprocess()`, the PR proposes renaming the method to `Finalize()`.


## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [ ] I am submitting my contribution to the develop branch.
- [ ] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [ ] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
