### PR TITLE
Relax tolerances of python wrapper hybrid AD tests

### DIFF
--- a/TestCases/hybrid_regression_AD.py
+++ b/TestCases/hybrid_regression_AD.py
@@ -234,7 +234,7 @@ def main():
     pywrapper_FEA_AD_FlowLoad.test_vals     = [-0.131742, -0.553318, -0.000364, -0.003101] #last 4 columns
     pywrapper_FEA_AD_FlowLoad.command       = TestCase.Command(exec = "python", param = "run_adjoint.py --parallel -f")
     pywrapper_FEA_AD_FlowLoad.timeout       = 1600
-    pywrapper_FEA_AD_FlowLoad.tol           = 0.000001
+    pywrapper_FEA_AD_FlowLoad.tol           = 1e-4
     pywrapper_FEA_AD_FlowLoad.new_output    = False
     test_list.append(pywrapper_FEA_AD_FlowLoad)
     pass_list.append(pywrapper_FEA_AD_FlowLoad.run_test())
@@ -247,7 +247,7 @@ def main():
     pywrapper_CFD_AD_MeshDisp.test_vals     = [30.000000, -2.520967, 1.375188, 0.000000] #last 4 columns
     pywrapper_CFD_AD_MeshDisp.command       = TestCase.Command(exec = "python", param = "run_adjoint.py --parallel -f")
     pywrapper_CFD_AD_MeshDisp.timeout       = 1600
-    pywrapper_CFD_AD_MeshDisp.tol           = 0.000001
+    pywrapper_CFD_AD_MeshDisp.tol           = 1e-4
     pywrapper_CFD_AD_MeshDisp.new_output    = False
     test_list.append(pywrapper_CFD_AD_MeshDisp)
     pass_list.append(pywrapper_CFD_AD_MeshDisp.run_test())


### PR DESCRIPTION
## Proposed Changes
The thread sanitizer analysis of the hybrid AD regression tests is clean, including the tests added in #1966. Given that the deviations observed in the CI pipeline (see #1980) are small, this is probably due to inherent non-determinism like varying orders of atomic updates on adjoint variables. This PR sets the tolerance of the recently added tests to the same tolerance that was already used for the other hybrid AD tests. 

## Related Work
#1966, fixes #1980

## PR Checklist

- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [X] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [X] I have added a test case that demonstrates my contribution, if necessary.
- [X] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
