### PR TITLE
Periodic BC: add dummy BCs.

### DIFF
--- a/Common/include/CConfig.hpp
+++ b/Common/include/CConfig.hpp
@@ -224,6 +224,7 @@ private:
   string Inlet_Filename;        /*!< \brief Filename specifying an inlet profile. */
   su2double Inlet_Matching_Tol; /*!< \brief Tolerance used when matching a point to a point from the inlet file. */
   string ActDisk_FileName;      /*!< \brief Filename specifying an actuator disk. */
+  bool Periodic_DummyBC;        /*!< \brief True if achieve periodic BCs with dummy points. */
 
   string *Marker_Euler,           /*!< \brief Euler wall markers. */
   *Marker_FarField,               /*!< \brief Far field markers. */
@@ -4866,6 +4867,12 @@ public:
    * \return <code>FALSE</code> means that the sharp edges will be removed from the sensitivity.
    */
   bool GetSens_Remove_Sharp(void) const { return Sens_Remove_Sharp; }
+
+  /*!
+   * \brief Check if achieve periodic BCs with dummy points.
+   * \return True if achieve periodic BCs with dummy points.
+   */
+  bool GetPeriodic_DummyBC(void) const { return Periodic_DummyBC; }
 
   /*!
    * \brief Get the kind of inlet boundary condition treatment (total conditions or mass flow).

--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -1487,6 +1487,7 @@ void CConfig::SetConfig_Options() {
    rotation_angle_z-axis, translation_x, translation_y, translation_z, ... ) */
   addPeriodicOption("MARKER_PERIODIC", nMarker_PerBound, Marker_PerBound, Marker_PerDonor,
                     Periodic_RotCenter, Periodic_RotAngles, Periodic_Translation);
+  addBoolOption("PERIODIC_DUMMY", Periodic_DummyBC, false);
 
   /*!\brief MARKER_PYTHON_CUSTOM\n DESCRIPTION: Python customizable marker(s) \ingroup Config*/
   addStringListOption("MARKER_PYTHON_CUSTOM", nMarker_PyCustom, Marker_PyCustom);

--- a/SU2_CFD/include/gradients/computeGradientsLeastSquares.hpp
+++ b/SU2_CFD/include/gradients/computeGradientsLeastSquares.hpp
@@ -191,7 +191,7 @@ void computeGradientsLeastSquares(CSolver* solver,
                                   GradientType& gradient,
                                   RMatrixType& Rmatrix)
 {
-  const bool periodic = (solver != nullptr) && (config.GetnMarker_Periodic() > 0);
+  const bool periodic = (solver != nullptr) && (config.GetnMarker_Periodic() > 0) && (!config.GetPeriodic_DummyBC());
 
   const size_t nPointDomain = geometry.GetnPointDomain();
 

--- a/SU2_CFD/include/limiters/computeLimiters_impl.hpp
+++ b/SU2_CFD/include/limiters/computeLimiters_impl.hpp
@@ -89,7 +89,8 @@ void computeLimiters_impl(CSolver* solver,
 
   const bool periodic = (solver != nullptr) &&
                         (kindPeriodicComm1 != PERIODIC_NONE) &&
-                        (config.GetnMarker_Periodic() > 0);
+                        (config.GetnMarker_Periodic() > 0) &&
+                        (!config.GetPeriodic_DummyBC());
 
 #ifdef HAVE_OMP
   constexpr size_t OMP_MAX_CHUNK = 512;

--- a/SU2_CFD/include/solvers/CFVMFlowSolverBase.hpp
+++ b/SU2_CFD/include/solvers/CFVMFlowSolverBase.hpp
@@ -726,7 +726,7 @@ class CFVMFlowSolverBase : public CSolver {
 
     /*--- We can access memory more efficiently if there are no periodic boundaries. ---*/
 
-    const bool isPeriodic = (config->GetnMarker_Periodic() > 0);
+    const bool isPeriodic = (config->GetnMarker_Periodic() > 0) && (!config->GetPeriodic_DummyBC());
 
     /*--- Loop domain points. ---*/
 

--- a/SU2_CFD/include/solvers/CSolver.hpp
+++ b/SU2_CFD/include/solvers/CSolver.hpp
@@ -305,6 +305,30 @@ public:
                              unsigned short commType);
 
   /*!
+   * \brief Routine to load a solver quantity into the data structures for MPI periodic communication and to launch non-blocking sends and recvs.
+   * \param[in] geometry - Geometrical definition of the problem.
+   * \param[in] config   - Definition of the particular problem.
+   * \param[in] val_periodic_index - Index for the periodic marker to be treated (first in a pair).
+   * \param[in] commType - Enumerated type for the quantity to be communicated.
+   */
+  void InitiatePeriodicDummyComms(CGeometry *geometry,
+                                  const CConfig *config,
+                                  unsigned short val_periodic_index,
+                                  unsigned short commType);
+
+  /*!
+   * \brief Routine to complete the set of non-blocking periodic communications launched by InitiatePeriodicComms() and unpacking of the data in the solver class.
+   * \param[in] geometry - Geometrical definition of the problem.
+   * \param[in] config   - Definition of the particular problem.
+   * \param[in] val_periodic_index - Index for the periodic marker to be treated (first in a pair).
+   * \param[in] commType - Enumerated type for the quantity to be unpacked.
+   */
+  void CompletePeriodicDummyComms(CGeometry *geometry,
+                                  const CConfig *config,
+                                  unsigned short val_periodic_index,
+                                  unsigned short commType);
+
+  /*!
    * \brief Set number of linear solver iterations.
    * \param[in] val_iterlinsolver - Number of linear iterations.
    */

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -903,6 +903,11 @@ MARKER_SUPERSONIC_OUTLET= ( NONE )
 % rotation_angle_z-axis, translation_x, translation_y, translation_z, ... )
 MARKER_PERIODIC= ( NONE )
 %
+% Periodic BCs with dummy points (NO, YES)
+% Four layers in both side for MUSCL: the inner two layers send and the outer layers recieve;
+% if no MUSCL, only two layers are needed for one side but the original implementation is enough. 
+PERIODIC_DUMMY= NO
+%
 % Engine Inflow boundary type (FAN_FACE_MACH, FAN_FACE_PRESSURE, FAN_FACE_MDOT)
 ENGINE_INFLOW_TYPE= FAN_FACE_MACH
 %


### PR DESCRIPTION
## Proposed Changes
Add periodic BCs with dummy points.  With internal markers, we could probe data from any inner surfaces, and here, we choose to construct periodic boundaries using dummy points which is preset on the input domain just like the internal markers. Four layers in both side is needed for MUSCL: the inner two layers send and the outer layers recieve.
With this way, we can use a larger CFL number similar to the cases using symmetry BCs and avoid passing too many variables with mpi.
 
## Related Work
#1467 or other works about periodic BCs

## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [X] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [X] I have added a test case that demonstrates my contribution, if necessary.
- [X] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
