### PR TITLE
Fix meson issues

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -46,7 +46,7 @@ if build_machine.system() != 'windows'
 endif
 
 # meson script path
-script_path = meson.source_root() / 'meson_scripts'
+script_path = meson.project_source_root() / 'meson_scripts'
 
 # mpi flag
 mpi = false
@@ -325,10 +325,10 @@ message('''---------------------------------------------------------------------
          export PYTHONPATH=$PYTHONPATH:$SU2_RUN
 
          Use './ninja -C @13@ install' to compile and install SU2
-'''.format(get_option('prefix')+'/bin', meson.source_root(), get_option('enable-tecio'), get_option('enable-cgns'),
+'''.format(get_option('prefix')+'/bin', meson.project_source_root(), get_option('enable-tecio'), get_option('enable-cgns'),
            get_option('enable-autodiff'), get_option('enable-directdiff'), get_option('enable-pywrapper'), get_option('enable-mkl'),
            get_option('enable-openblas'), get_option('enable-pastix'), get_option('enable-mixedprec'), get_option('enable-librom'), get_option('enable-coolprop'),
-           get_option('enable-mlpcpp'), meson.build_root().startswith(meson.source_root()) ? meson.build_root().split('/')[-1] : meson.build_root()))
+           get_option('enable-mlpcpp'), meson.project_build_root().startswith(meson.project_source_root()) ? meson.project_build_root().split('/')[-1] : meson.project_build_root()))
 
 if get_option('enable-mpp')
   message(''' To run SU2 with Mutation++ library, add these lines to your .bashrc file:

--- a/meson.build
+++ b/meson.build
@@ -313,6 +313,7 @@ message('''---------------------------------------------------------------------
          Mixed Float:    @10@
          libROM:         @11@
          CoolProp:       @12@
+         MLPCpp:         @13@
 
          Please be sure to add the $SU2_HOME and $SU2_RUN environment variables,
          and update your $PATH (and $PYTHONPATH if applicable) with $SU2_RUN
@@ -324,7 +325,7 @@ message('''---------------------------------------------------------------------
          export PATH=$PATH:$SU2_RUN
          export PYTHONPATH=$PYTHONPATH:$SU2_RUN
 
-         Use './ninja -C @13@ install' to compile and install SU2
+         Use './ninja -C @14@ install' to compile and install SU2
 '''.format(get_option('prefix')+'/bin', meson.project_source_root(), get_option('enable-tecio'), get_option('enable-cgns'),
            get_option('enable-autodiff'), get_option('enable-directdiff'), get_option('enable-pywrapper'), get_option('enable-mkl'),
            get_option('enable-openblas'), get_option('enable-pastix'), get_option('enable-mixedprec'), get_option('enable-librom'), get_option('enable-coolprop'),


### PR DESCRIPTION
## Proposed Changes
This PR fixes small issues in the meson build system that I noticed during recent work on SU2.
1. deprecation warnings about `meson.source_root()`
2. an incorrectly displayed `ninja` command

## PR Checklist

- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [X] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [X] I have added a test case that demonstrates my contribution, if necessary.
- [X] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
