### PR TITLE
Adding V&V case compos. dep. model to test cases.

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -171,7 +171,7 @@ jobs:
         uses: docker://ghcr.io/su2code/su2/test-su2:230704-1323
         with:
           # -t <Tutorials-branch> -c <Testcases-branch>
-          args: -b ${{github.ref}} -t develop -c develop -s ${{matrix.testscript}}
+          args: -b ${{github.ref}} -t develop -c feature_validation_sandia_jet -s ${{matrix.testscript}}
       - name: Cleanup
         uses: docker://ghcr.io/su2code/su2/test-su2:230704-1323
         with:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -171,7 +171,7 @@ jobs:
         uses: docker://ghcr.io/su2code/su2/test-su2:230704-1323
         with:
           # -t <Tutorials-branch> -c <Testcases-branch>
-          args: -b ${{github.ref}} -t develop -c feature_validation_sandia_jet -s ${{matrix.testscript}}
+          args: -b ${{github.ref}} -t develop -c develop -s ${{matrix.testscript}}
       - name: Cleanup
         uses: docker://ghcr.io/su2code/su2/test-su2:230704-1323
         with:

--- a/TestCases/vandv.py
+++ b/TestCases/vandv.py
@@ -94,7 +94,7 @@ def main():
     sandiajet_sst.cfg_dir   = "vandv/species_transport/sandia_jet"
     sandiajet_sst.cfg_file  = "VALIDATION.cfg"
     sandiajet_sst.test_iter = 5
-    sandiajet_sst.test_vals = [-11.527743, -11.150388, -11.944923, -10.750834, -11.116769, -4.030059]
+    sandiajet_sst.test_vals = [-16.249917, -13.835991, -14.303372, -13.276035, -10.074262, -14.027223, 5, -1.672359, 5, -4.938477, 5, -3.462217, 2.5859e-04, 2.8215e-32, 4.5010e-68, 2.5859e-04, 4.0474e+03, 3.9468e+03, 4.9170e+01, 5.1441e+01]
     test_list.append(sandiajet_sst)
 
     #################

--- a/TestCases/vandv.py
+++ b/TestCases/vandv.py
@@ -85,6 +85,18 @@ def main():
     swbli_sst.test_vals = [-11.527743, -11.150388, -11.944923, -10.750834, -11.116769, -4.030059, 0.002339, -2.730391, -4.067274, 1.276300]
     test_list.append(swbli_sst)
 
+    ##########################
+    ### Incompressible RANS ###
+    ##########################
+
+    # Sandia jet - sst-v2003m
+    sandiajet_sst           = TestCase('sandiajet_sst')
+    sandiajet_sst.cfg_dir   = "vandv/species_transport/sandia_jet"
+    sandiajet_sst.cfg_file  = "VALIDATION.cfg"
+    sandiajet_sst.test_iter = 5
+    sandiajet_sst.test_vals = [-11.527743, -11.150388, -11.944923, -10.750834, -11.116769, -4.030059]
+    test_list.append(sandiajet_sst)
+
     #################
     ### RUN TESTS ###
     #################

--- a/TestCases/vandv/species_transport/sandia_jet/VALIDATION.cfg
+++ b/TestCases/vandv/species_transport/sandia_jet/VALIDATION.cfg
@@ -1,0 +1,151 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                                   %
+% SU2 configuration file                                                            %
+% Case description: V&V Composition-dependent model Sandia's turbulent jet    	    %
+% Author: S.J.H. Bosmans                                                            %
+% Institution: TU Eindhoven (TU/e)                                                  %
+% Date: 2023/05/04                                                                  %
+% File Version 7.5.0 "Blackbird"                                                    %
+%                                                                                   %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% ------------- DIRECT, ADJOINT, AND LINEARIZED PROBLEM DEFINITION ------------%
+%
+SOLVER= INC_RANS
+KIND_TURB_MODEL= SST
+SST_OPTIONS= V2003m
+RESTART_SOL= YES
+%
+% ---------------- INCOMPRESSIBLE FLOW CONDITION DEFINITION -------------------%
+%
+INC_DENSITY_MODEL= VARIABLE
+INC_DENSITY_INIT= 1.828
+%
+INC_VELOCITY_INIT= ( 53.0, 0.0, 0.0 )
+%
+INC_ENERGY_EQUATION= NO
+INC_TEMPERATURE_INIT= 294.0
+%
+INC_NONDIM= DIMENSIONAL
+%
+% -------------------- FLUID PROPERTIES ------------------------------------- %
+%
+FLUID_MODEL= FLUID_MIXTURE
+%
+MOLECULAR_WEIGHT= 44.097, 28.960
+THERMODYNAMIC_PRESSURE = 101325.0
+%
+SPECIFIC_HEAT_CP = 1680.0, 1009.39
+%
+CONDUCTIVITY_MODEL= CONSTANT_CONDUCTIVITY
+THERMAL_CONDUCTIVITY_CONSTANT= 0.0179, 0.0258
+%
+PRANDTL_LAM= 0.72, 0.72
+TURBULENT_CONDUCTIVITY_MODEL= CONSTANT_PRANDTL_TURB
+PRANDTL_TURB= 0.90, 0.90
+%
+% --------------------------- VISCOSITY MODEL ---------------------------------%
+%
+VISCOSITY_MODEL= CONSTANT_VISCOSITY
+%
+MU_CONSTANT= 8.04E-06, 1.8551E-05 
+% 
+MIXING_VISCOSITY_MODEL = WILKE
+%
+% -------------------- BOUNDARY CONDITION DEFINITION --------------------------%
+%
+MARKER_HEATFLUX= ( wall, 0.0 )
+AXISYMMETRIC= YES
+MARKER_SYM= ( symmetry )
+MARKER_EULER= ( top_wall )
+MARKER_INLET_TURBULENT= ( inlet_gas, 0.04, 5, inlet_air, 0.004, 1 )
+%
+INC_INLET_TYPE=  VELOCITY_INLET VELOCITY_INLET
+SPECIFIED_INLET_PROFILE= NO
+%INLET_FILENAME= inlet_jet.dat
+%INLET_MATCHING_TOLERANCE= 1.2E-06
+%
+MARKER_INLET= ( inlet_gas, 294, 53.0, 1.0, 0.0 0.0, inlet_air, 294, 9.2, 1.0, 0.0, 0.0 )
+MARKER_INLET_SPECIES= ( inlet_gas, 1.0, inlet_air, 0.0 )
+%
+INC_OUTLET_TYPE= PRESSURE_OUTLET
+MARKER_OUTLET= ( outlet, 0.0 )
+%
+% ------------- COMMON PARAMETERS DEFINING THE NUMERICAL METHOD ---------------%
+%
+NUM_METHOD_GRAD= WEIGHTED_LEAST_SQUARES
+%
+CFL_NUMBER= 200.0
+CFL_ADAPT= NO
+CFL_REDUCTION_SPECIES= 1.0
+CFL_REDUCTION_TURB= 0.5
+%
+ITER= 9999
+%
+% ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
+%
+LINEAR_SOLVER= FGMRES
+LINEAR_SOLVER_PREC= ILU
+LINEAR_SOLVER_ERROR= 1E-5
+LINEAR_SOLVER_ITER= 5
+%
+% -------------------- FLOW NUMERICAL METHOD DEFINITION -----------------------%
+%
+CONV_NUM_METHOD_FLOW= FDS
+MUSCL_FLOW= NO
+SLOPE_LIMITER_FLOW = NONE
+TIME_DISCRE_FLOW= EULER_IMPLICIT
+%
+% -------------------- SCALAR TRANSPORT ---------------------------------------%
+%
+KIND_SCALAR_MODEL= SPECIES_TRANSPORT
+%
+DIFFUSIVITY_MODEL= UNITY_LEWIS
+%
+SCHMIDT_NUMBER_TURBULENT= 0.7
+%
+CONV_NUM_METHOD_SPECIES= BOUNDED_SCALAR
+MUSCL_SPECIES= NO
+SLOPE_LIMITER_SPECIES = NONE
+%
+TIME_DISCRE_SPECIES= EULER_IMPLICIT
+%
+SPECIES_INIT= 0.05
+SPECIES_CLIPPING= NO
+SPECIES_CLIPPING_MIN= 0.0
+SPECIES_CLIPPING_MAX= 1.0
+%
+% -------------------- TURBULENT TRANSPORT ---------------------------------------%
+%
+CONV_NUM_METHOD_TURB= BOUNDED_SCALAR
+MUSCL_TURB= NO
+%
+% --------------------------- CONVERGENCE PARAMETERS --------------------------%
+%
+CONV_FIELD= RMS_PRESSURE, RMS_VELOCITY-X, RMS_VELOCITY-Y, RMS_TKE, RMS_SPECIES
+CONV_RESIDUAL_MINVAL= -14.0
+CONV_CAUCHY_ELEMS= 100
+CONV_CAUCHY_EPS= 1E-6
+%
+% ------------------------- INPUT/OUTPUT INFORMATION --------------------------%
+%
+MESH_FILENAME= MESH_validation.su2
+%
+SCREEN_OUTPUT= INNER_ITER WALL_TIME RMS_RES LINSOL_ITER LINSOL_RESIDUAL LINSOL_ITER_TURB LINSOL_RESIDUAL_TURB LINSOL_ITER_SPECIES LINSOL_RESIDUAL_SPECIES SURFACE_SPECIES_VARIANCE SURFACE_TOTAL_PRESSURE
+SCREEN_WRT_FREQ_INNER= 10
+%
+HISTORY_OUTPUT= ITER RMS_RES LINSOL SPECIES_COEFF SPECIES_COEFF_SURF SURFACE_TOTAL_PRESSURE
+CONV_FILENAME= history
+MARKER_ANALYZE= inlet_gas,inlet_air, outlet
+MARKER_ANALYZE_AVERAGE= AREA
+%
+OUTPUT_FILES= RESTART_ASCII, PARAVIEW_MULTIBLOCK
+VOLUME_OUTPUT= RESIDUAL, PRIMITIVE
+OUTPUT_WRT_FREQ= 100
+%
+READ_BINARY_RESTART= NO
+RESTART_FILENAME= restart.csv
+SOLUTION_FILENAME= solution.csv
+%
+WRT_PERFORMANCE= YES
+OUTPUT_PRECISION= 16


### PR DESCRIPTION
## Proposed Changes
Re-adding required files for test case VV sandia jet and changed regression.yml to get residual values required for vandv.py
@bigfooted @Cristopher-Morales. (This PR is created to get the residual values for the vandv.py script.)
 


## Related Work




## PR Checklist


- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [X] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [X] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
