### PR TITLE
Clarify and extend AD tape choices

### DIFF
--- a/Common/include/code_config.hpp
+++ b/Common/include/code_config.hpp
@@ -98,20 +98,30 @@ FORCEINLINE Out su2staticcast_p(In ptr) {
 #if defined(HAVE_OMP)
 using su2double = codi::RealReverseIndexOpenMPGen<double, double>;
 #else
-#if defined(CODI_INDEX_TAPE)
-using su2double = codi::RealReverseIndex;
-// #elif defined(CODI_PRIMAL_TAPE)
-// using su2double = codi::RealReversePrimal;
-// #elif defined(CODI_PRIMAL_INDEX_TAPE)
-// using su2double = codi::RealReversePrimalIndex;
-#else
+#if defined(CODI_JACOBIAN_LINEAR_TAPE)
 using su2double = codi::RealReverse;
+#elif defined(CODI_JACOBIAN_REUSE_TAPE)
+using su2double = codi::RealReverseIndexGen<double, double, codi::ReuseIndexManager<int> >;
+#elif defined(CODI_JACOBIAN_MULTIUSE_TAPE)
+using su2double = codi::RealReverseIndex;
+#elif defined(CODI_PRIMAL_LINEAR_TAPE)
+using su2double = codi::RealReversePrimal;
+#elif defined(CODI_PRIMAL_REUSE_TAPE)
+using su2double = codi::RealReversePrimalIndexGen<double, double, codi::ReuseIndexManager<int> >;
+#elif defined(CODI_PRIMAL_MULTIUSE_TAPE)
+using su2double = codi::RealReversePrimalIndex;
+#else
+#error "Please define a CoDiPack tape."
 #endif
+#endif
+
+#if defined(HAVE_OMP) || defined(CODI_JACOBIAN_REUSE_TAPE) || defined(CODI_JACOBIAN_MULTIUSE_TAPE) || \
+    defined(CODI_PRIMAL_REUSE_TAPE) || defined(CODI_PRIMAL_MULTIUSE_TAPE)
+#define CODI_INDEX_REUSE
 #endif
 #elif defined(CODI_FORWARD_TYPE)  // forward mode AD
 #include "codi.hpp"
 using su2double = codi::RealForward;
-
 #else  // primal / direct / no AD
 using su2double = double;
 #endif

--- a/SU2_CFD/src/drivers/CDiscAdjMultizoneDriver.cpp
+++ b/SU2_CFD/src/drivers/CDiscAdjMultizoneDriver.cpp
@@ -786,9 +786,9 @@ void CDiscAdjMultizoneDriver::SetAdjObjFunction() {
 
 void CDiscAdjMultizoneDriver::ComputeAdjoints(unsigned short iZone, bool eval_transfer) {
 
-#if defined(CODI_INDEX_TAPE) || defined(HAVE_OPDI)
+#if defined(CODI_INDEX_REUSE)
   if (nZone > 1 && rank == MASTER_NODE) {
-    std::cout << "WARNING: Index AD types do not support multiple zones." << std::endl;
+    std::cout << "WARNING: AD types that reuse indices do not support multiple zones." << std::endl;
   }
 #endif
 

--- a/meson.build
+++ b/meson.build
@@ -78,12 +78,20 @@ if get_option('enable-autodiff') or get_option('enable-directdiff')
 endif
 
 if get_option('enable-autodiff')
-  if get_option('codi-tape') == 'JacobianIndex'
-    codi_rev_args += '-DCODI_INDEX_TAPE'
-  #elif get_option('codi-tape') == 'PrimalLinear'
-  #  codi_rev_args += '-DCODI_PRIMAL_TAPE'
-  #elif get_option('codi-tape') == 'PrimalIndex'
-  #  codi_rev_args += '-DCODI_PRIMAL_INDEX_TAPE'
+  if get_option('codi-tape') == 'JacobianLinear'
+    codi_rev_args += '-DCODI_JACOBIAN_LINEAR_TAPE'
+  elif get_option('codi-tape') == 'JacobianReuse'
+    codi_rev_args += '-DCODI_JACOBIAN_REUSE_TAPE'
+  elif get_option('codi-tape') == 'JacobianMultiUse'
+    codi_rev_args += '-DCODI_JACOBIAN_MULTIUSE_TAPE'
+  elif get_option('codi-tape') == 'PrimalLinear'
+    codi_rev_args += '-DCODI_PRIMAL_LINEAR_TAPE'
+  elif get_option('codi-tape') == 'PrimalReuse'
+    codi_rev_args += '-DCODI_PRIMAL_REUSE_TAPE'
+  elif get_option('codi-tape') == 'PrimalMultiUse'
+    codi_rev_args += '-DCODI_PRIMAL_MULTIUSE_TAPE'
+  else
+    message('Invalid CoDiPack tape choice @1@'.format(get_option('codi-tape')))
   endif
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -77,7 +77,7 @@ if get_option('enable-autodiff') or get_option('enable-directdiff')
   codi_for_args = ['-DCODI_FORWARD_TYPE']
 endif
 
-if get_option('enable-autodiff')
+if get_option('enable-autodiff') and not omp
   if get_option('codi-tape') == 'JacobianLinear'
     codi_rev_args += '-DCODI_JACOBIAN_LINEAR_TAPE'
   elif get_option('codi-tape') == 'JacobianReuse'
@@ -92,6 +92,10 @@ if get_option('enable-autodiff')
     codi_rev_args += '-DCODI_PRIMAL_MULTIUSE_TAPE'
   else
     message('Invalid CoDiPack tape choice @1@'.format(get_option('codi-tape')))
+  endif
+
+  if get_option('codi-tape') != 'JacobianLinear'
+    warning('The tape choice @1@ is not tested regularly in SU2'.format(get_option('codi-tape')))
   endif
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -21,7 +21,7 @@ option('enable-mpp',  type : 'boolean', value : false, description: 'enable Muta
 option('enable-coolprop',  type : 'boolean', value : false, description: 'enable CoolProp support')
 option('enable-mlpcpp', type : 'boolean', value : false, description: 'enable MLPCpp support')
 option('opdi-backend', type : 'combo', choices : ['auto', 'macro', 'ompt'], value : 'auto', description: 'OpDiLib backend choice')
-option('codi-tape', type : 'combo', choices : ['JacobianLinear', 'JacobianIndex'], value : 'JacobianLinear', description: 'CoDiPack tape choice')
+option('codi-tape', type : 'combo', choices : ['JacobianLinear', 'JacobianReuse', 'JacobianMultiUse', 'PrimalLinear', 'PrimalReuse', 'PrimalMultiUse'], value : 'JacobianLinear', description: 'CoDiPack tape choice')
 option('opdi-shared-read-opt', type : 'boolean', value : true, description : 'OpDiLib shared reading optimization')
 option('librom_root', type : 'string', value : '', description: 'libROM base directory')
 option('enable-librom', type : 'boolean', value : false, description: 'enable LLNL libROM support')

--- a/meson_scripts/init.py
+++ b/meson_scripts/init.py
@@ -55,7 +55,7 @@ def init_submodules(
 
     # This information of the modules is used if projects was not cloned using git
     # The sha tag must be maintained manually to point to the correct commit
-    sha_version_codi = "17232fed05245dbb8f04a31e274a02d53458c75c"
+    sha_version_codi = "c30f195eb9d772cadc75e9dbf4c88cb351ee34bb"
     github_repo_codi = "https://github.com/scicompkl/CoDiPack"
     sha_version_medi = "aafc2d1966ba1233640af737e71c77c1a86183fd"
     github_repo_medi = "https://github.com/SciCompKL/MeDiPack"


### PR DESCRIPTION
## Proposed Changes
`JacobianIndex`, one of the `codi-tape` build options, was prone to misunderstandings since it was not clear whether or not the underlying type supports copy optimizations. There are two options now, `JacobianReuse`, which does not support copy optimizations and is similar to the hybrid AD type in that regard, and `JacobianMultiUse`, which does support copy optimizations and is similar to the default type with linear management in that regard.
 
I took the opportunity to also add options for primal value tapes in a consistent manner, they were there previously but less detailed and commented out.

## PR Checklist

- [X] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [x] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [x] I have added a test case that demonstrates my contribution, if necessary.
- [x] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
