### PR TITLE
Fix HeatFlux non-dimensionalization

### DIFF
--- a/SU2_CFD/include/solvers/CFVMFlowSolverBase.inl
+++ b/SU2_CFD/include/solvers/CFVMFlowSolverBase.inl
@@ -2430,7 +2430,6 @@ void CFVMFlowSolverBase<V, FlowRegime>::Friction_Forces(const CGeometry* geometr
   const su2double Alpha = config->GetAoA() * PI_NUMBER / 180.0;
   const su2double Beta = config->GetAoS() * PI_NUMBER / 180.0;
   const su2double RefLength = config->GetRefLength();
-  const su2double RefHeatFlux = config->GetHeat_Flux_Ref();
   const su2double Gas_Constant = config->GetGas_ConstantND();
   auto Origin = config->GetRefOriginMoment(0);
 
@@ -2587,7 +2586,7 @@ void CFVMFlowSolverBase<V, FlowRegime>::Friction_Forces(const CGeometry* geometr
           if (!energy) dTdn = 0.0;
           thermal_conductivity = nodes->GetThermalConductivity(iPoint);
         }
-        HeatFlux[iMarker][iVertex] = -thermal_conductivity * dTdn * RefHeatFlux;
+        HeatFlux[iMarker][iVertex] = -thermal_conductivity * dTdn;
 
       } else {
 
@@ -2658,8 +2657,11 @@ void CFVMFlowSolverBase<V, FlowRegime>::Friction_Forces(const CGeometry* geometr
         MomentZ_Force[0] += (-Force[0] * Coord[1]);
         MomentZ_Force[1] += (Force[1] * Coord[0]);
 
-        HF_Visc[iMarker] += HeatFlux[iMarker][iVertex] * Area;
-        MaxHF_Visc[iMarker] += pow(HeatFlux[iMarker][iVertex], MaxNorm);
+        /*--- Note that Screen Outputs are re-dimensionalzed but volume outputs are not.
+         *    Since the HeatFlux-container is used for volume output as well, introduce the re-dim here. ---*/
+        const su2double dimensional_HeatFlux = HeatFlux[iMarker][iVertex] * config->GetHeat_Flux_Ref();
+        HF_Visc[iMarker] += dimensional_HeatFlux * Area;
+        MaxHF_Visc[iMarker] += pow(dimensional_HeatFlux, MaxNorm);
       }
     }
 

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -867,12 +867,12 @@ STREAMWISE_PERIODIC_OUTLET_HEAT= 0.0
 MARKER_EULER= ( airfoil )
 %
 % Navier-Stokes (no-slip), constant heat flux wall  marker(s) (NONE = no marker)
-% Format: ( marker name, constant heat flux (J/m^2), ... )
+% Format: ( marker name, constant heat flux (W/m^2), ... )
 MARKER_HEATFLUX= ( NONE )
 %
 % Navier-Stokes (no-slip), heat-transfer/convection wall marker(s) (NONE = no marker)
 % Available for compressible and incompressible flow.
-% Format: ( marker name, constant heat-transfer coefficient (J/(K*m^2)), constant reservoir Temperature (K) ... )
+% Format: ( marker name, constant heat-transfer coefficient (W/(K*m^2)), constant reservoir Temperature (K) ... )
 MARKER_HEATTRANSFER= ( NONE )
 %
 % Navier-Stokes (no-slip), isothermal wall marker(s) (NONE = no marker)


### PR DESCRIPTION
## Proposed Changes
Hi all,

volume heatflux output is not non-dimensional which is inconsistent with how the rest of volume output is handled.
Note that the History outputs (like TOTAL_HEATFLUX over a bunch of surfaces) is re-dimensionalized -> Apparently that hasn't bothered too many people until now but generally that might be sth we/I want to change (?) Let me know

I fixed it in a way that follows the current convention.

In CConjugateHeatInteface.cpp the required heat_flux is (re)computed on its own so I do not expect a problem there but I will check manually as well
- [ ] Reminder Checkmark to actually do so
If there is other places which might be affected let me know.

## PR Checklist

- [x] I am submitting my contribution to the develop branch.
- [ ] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [x] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
