### PR TITLE
Fix adjoint vector size

### DIFF
--- a/Common/include/basic_types/ad_structure.hpp
+++ b/Common/include/basic_types/ad_structure.hpp
@@ -66,7 +66,7 @@ inline void PrintStatistics() {}
  * graph. \param[in] data - The variable to be registered as input. \param[in] push_index - boolean whether we also want
  * to push the index.
  */
-inline void RegisterInput(su2double& data, bool push_index = true) {}
+inline void RegisterInput(su2double& data) {}
 
 /*!
  * \brief Registers the variable as an output. I.e. as the root of the computational graph.

--- a/Common/include/basic_types/ad_structure.hpp
+++ b/Common/include/basic_types/ad_structure.hpp
@@ -62,9 +62,8 @@ inline bool TapeActive() { return false; }
 inline void PrintStatistics() {}
 
 /*!
- * \brief Registers the variable as an input and saves internal data (indices). I.e. as a leaf of the computational
- * graph. \param[in] data - The variable to be registered as input. \param[in] push_index - boolean whether we also want
- * to push the index.
+ * \brief Registers the variable as an input. I.e. as a leaf of the computational graph.
+ * \param[in] data - The variable to be registered as input.
  */
 inline void RegisterInput(su2double& data) {}
 

--- a/SU2_CFD/src/drivers/CDiscAdjMultizoneDriver.cpp
+++ b/SU2_CFD/src/drivers/CDiscAdjMultizoneDriver.cpp
@@ -780,6 +780,7 @@ void CDiscAdjMultizoneDriver::SetAdjObjFunction() {
     }
   }
   if (rank == MASTER_NODE) {
+    AD::ResizeAdjoints();
     AD::SetDerivative(ObjFunc_Index, SU2_TYPE::GetValue(seeding));
   }
 }

--- a/meson.build
+++ b/meson.build
@@ -95,7 +95,7 @@ if get_option('enable-autodiff') and not omp
   endif
 
   if get_option('codi-tape') != 'JacobianLinear'
-    warning('The tape choice @1@ is not tested regularly in SU2'.format(get_option('codi-tape')))
+    warning('The tape choice @0@ is not tested regularly in SU2'.format(get_option('codi-tape')))
   endif
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -96,7 +96,7 @@ if get_option('enable-autodiff') and not omp
   elif get_option('codi-tape') == 'PrimalMultiUse'
     codi_rev_args += '-DCODI_PRIMAL_MULTIUSE_TAPE'
   else
-    message('Invalid CoDiPack tape choice @1@'.format(get_option('codi-tape')))
+    error('Invalid CoDiPack tape choice @0@'.format(get_option('codi-tape')))
   endif
 
   if get_option('codi-tape') != 'JacobianLinear'

--- a/meson.build
+++ b/meson.build
@@ -75,6 +75,11 @@ if get_option('enable-autodiff') or get_option('enable-directdiff')
   codi_dep = [declare_dependency(include_directories: 'externals/codi/include')]
   codi_rev_args = ['-DCODI_REVERSE_TYPE']
   codi_for_args = ['-DCODI_FORWARD_TYPE']
+
+  if get_option('debug')
+    codi_rev_args += '-DCODI_EnableAssert'
+    codi_for_args += '-DCODI_EnableAssert'
+  endif
 endif
 
 if get_option('enable-autodiff') and not omp

--- a/meson_scripts/init.py
+++ b/meson_scripts/init.py
@@ -55,7 +55,7 @@ def init_submodules(
 
     # This information of the modules is used if projects was not cloned using git
     # The sha tag must be maintained manually to point to the correct commit
-    sha_version_codi = "c30f195eb9d772cadc75e9dbf4c88cb351ee34bb"
+    sha_version_codi = "8ee822a9b0bb8235a2494467b774e27fb64ff14f"
     github_repo_codi = "https://github.com/scicompkl/CoDiPack"
     sha_version_medi = "aafc2d1966ba1233640af737e71c77c1a86183fd"
     github_repo_medi = "https://github.com/SciCompKL/MeDiPack"


### PR DESCRIPTION
## Proposed Changes
This PR fixes an issue in the discrete adjoint multizone driver where adjoints are seeded before sufficient adjoint vector size is guaranteed, resulting in an objective function gradient of zero.

The PR also contains other small fixes.
 
## PR Checklist

- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [X] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [X] I have added a test case that demonstrates my contribution, if necessary.
- [X] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
