### PR TITLE
Update CoolProp to v6.5.0

### DIFF
--- a/meson_scripts/init.py
+++ b/meson_scripts/init.py
@@ -67,7 +67,7 @@ def init_submodules(
     github_repo_ninja = "https://github.com/ninja-build/ninja"
     sha_version_mpp = "5ff579f43781cae07411e5ab46291c9971536be6"
     github_repo_mpp = "https://github.com/mutationpp/Mutationpp"
-    sha_version_coolprop = "0ce42fcf3bb2c373512bc825a4f0c1973a78f307"
+    sha_version_coolprop = "bafdea1f39ee873a6bb9833e3a21fe41f90b85e8"
     github_repo_coolprop = "https://github.com/CoolProp/CoolProp"
     sha_version_mel = "2484cd3258ef800a10e361016cb341834ee7930b"
     github_repo_mel = "https://github.com/pcarruscag/MEL"
@@ -218,7 +218,7 @@ def submodule_status(path, sha_commit):
                 cwd=sys.path[0],
             )
             # to update CoolProp external libraries
-        if sha_commit == "0ce42fcf3bb2c373512bc825a4f0c1973a78f307":
+        if "CoolProp" in path:
             # update coolprop
             original_path = os.getcwd()
             print("update CoolProp")


### PR DESCRIPTION
## Proposed Changes
Update CoolProp to v6.5.0 which was recently released. I picked the commit of the release, but newer commits are available. I also "cleaned up" a bit the submodule function so that it would become easier to update CoolProp in the future and make the intent of the code clearer. 

## Related Work
CoolProp v6.5.0 has an updated EOS for CO2, with which I am currently playing around. This new version has the same EOS as NIST. It also comes with a variety of bug fixes and improvements.


## PR Checklist

- [x] I am submitting my contribution to the develop branch.
- [ ] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- The code generates quite a few warning when compiling on Debian 12, which uses GCC12 , but none were introduced in this commit. I tested the compilation using an Apptainer/Singularity container.
- [ ] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- I changed the Python code, for which I saw no entry in the style guide.
- [ ] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- I did not run it as I did not know about it, but I do not think it applies for this (though maybe it does)
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- Not necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
- No documentation related to SU2 should be affected.

I do have one question which is not directly related to this PR. I have an Apptainer/Singularity container for SU2 which has most of the bells and whistles. I saw that you have docker containers, but for HPC (and normal computers) Docker [can have a large performance penalty](https://www.youtube.com/watch?v=2FPB74YB-ng). Would you like for me to contribute my Apptainer recipes? 

Any and all feedback welcome!

P.S: I did not know that even after updating the hash commit of CoolProp in the meson script, I also had to update the submodule, that is not very intuitive. In this current state, the Meson commit hash has little to no value if it gets changed independently afterwards :)
P.P.S: I also did not know that SU2 v8.0 was going to be released this earlier, otherwise I would have tried to get it updated earlier!
