### PR TITLE
add Cur_Time column to the default history field for transient analysis;

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -98,6 +98,7 @@ Kedar Naik
 Kürşat Yurt
 LaSerpe
 Lennaert Tol
+Liang Cheng
 Lisa Kusch
 Matteo Pini
 Max Aehle

--- a/Common/include/parallelization/omp_structure.hpp
+++ b/Common/include/parallelization/omp_structure.hpp
@@ -189,14 +189,14 @@ void omp_finalize();
  */
 
 #define BEGIN_SU2_OMP_SAFE_GLOBAL_ACCESS             \
-  SU2_OMP_BARRIER                                    \
+  SU2_OMP_BARRIER;                                   \
   if (omp_in_parallel()) AD::StartNoSharedReading(); \
   SU2_OMP_MASTER
 
 #define END_SU2_OMP_SAFE_GLOBAL_ACCESS             \
   END_SU2_OMP_MASTER                               \
   if (omp_in_parallel()) AD::EndNoSharedReading(); \
-  SU2_OMP_BARRIER
+  SU2_OMP_BARRIER;
 
 #define SU2_OMP_SAFE_GLOBAL_ACCESS(...) BEGIN_SU2_OMP_SAFE_GLOBAL_ACCESS{__VA_ARGS__} END_SU2_OMP_SAFE_GLOBAL_ACCESS
 

--- a/SU2_CFD/include/output/COutput.hpp
+++ b/SU2_CFD/include/output/COutput.hpp
@@ -807,6 +807,11 @@ protected:
   void SetCommonHistoryFields();
 
   /*!
+   * \brief Request the history fields common for all solvers.
+   */
+  void RequestCommonHistory(bool dynamic);
+
+  /*!
    * \brief Parses user-defined outputs.
    */
   void SetCustomOutputs(const CConfig *config);

--- a/SU2_CFD/src/output/CAdjFlowCompOutput.cpp
+++ b/SU2_CFD/src/output/CAdjFlowCompOutput.cpp
@@ -36,9 +36,7 @@ CAdjFlowCompOutput::CAdjFlowCompOutput(CConfig *config, unsigned short nDim) : C
   /*--- Set the default history fields if nothing is set in the config file ---*/
 
   if (nRequestedHistoryFields == 0) {
-    requestedHistoryFields.emplace_back("ITER");
-    if (config->GetTime_Domain()) requestedHistoryFields.emplace_back("CUR_TIME");
-    requestedHistoryFields.emplace_back("RMS_RES");
+    RequestCommonHistory(config->GetTime_Domain());
     requestedHistoryFields.emplace_back("SENSITIVITY");
     nRequestedHistoryFields = requestedHistoryFields.size();
   }

--- a/SU2_CFD/src/output/CAdjFlowCompOutput.cpp
+++ b/SU2_CFD/src/output/CAdjFlowCompOutput.cpp
@@ -37,6 +37,7 @@ CAdjFlowCompOutput::CAdjFlowCompOutput(CConfig *config, unsigned short nDim) : C
 
   if (nRequestedHistoryFields == 0) {
     requestedHistoryFields.emplace_back("ITER");
+    if (config->GetTime_Domain()) requestedHistoryFields.emplace_back("CUR_TIME");
     requestedHistoryFields.emplace_back("RMS_RES");
     requestedHistoryFields.emplace_back("SENSITIVITY");
     nRequestedHistoryFields = requestedHistoryFields.size();

--- a/SU2_CFD/src/output/CAdjFlowIncOutput.cpp
+++ b/SU2_CFD/src/output/CAdjFlowIncOutput.cpp
@@ -43,6 +43,7 @@ CAdjFlowIncOutput::CAdjFlowIncOutput(CConfig *config, unsigned short nDim) : CAd
 
   if (nRequestedHistoryFields == 0) {
     requestedHistoryFields.emplace_back("ITER");
+    if (config->GetTime_Domain()) requestedHistoryFields.emplace_back("CUR_TIME");
     requestedHistoryFields.emplace_back("RMS_RES");
     requestedHistoryFields.emplace_back("SENSITIVITY");
     nRequestedHistoryFields = requestedHistoryFields.size();

--- a/SU2_CFD/src/output/CAdjFlowIncOutput.cpp
+++ b/SU2_CFD/src/output/CAdjFlowIncOutput.cpp
@@ -42,9 +42,7 @@ CAdjFlowIncOutput::CAdjFlowIncOutput(CConfig *config, unsigned short nDim) : CAd
   /*--- Set the default history fields if nothing is set in the config file ---*/
 
   if (nRequestedHistoryFields == 0) {
-    requestedHistoryFields.emplace_back("ITER");
-    if (config->GetTime_Domain()) requestedHistoryFields.emplace_back("CUR_TIME");
-    requestedHistoryFields.emplace_back("RMS_RES");
+    RequestCommonHistory(config->GetTime_Domain());
     requestedHistoryFields.emplace_back("SENSITIVITY");
     nRequestedHistoryFields = requestedHistoryFields.size();
   }

--- a/SU2_CFD/src/output/CAdjHeatOutput.cpp
+++ b/SU2_CFD/src/output/CAdjHeatOutput.cpp
@@ -36,9 +36,7 @@ CAdjHeatOutput::CAdjHeatOutput(CConfig *config, unsigned short nDim) : COutput(c
   /*--- Set the default history fields if nothing is set in the config file ---*/
 
   if (nRequestedHistoryFields == 0){
-    requestedHistoryFields.emplace_back("ITER");
-    if (config->GetTime_Domain()) requestedHistoryFields.emplace_back("CUR_TIME");
-    requestedHistoryFields.emplace_back("RMS_RES");
+    RequestCommonHistory(config->GetTime_Domain());
     requestedHistoryFields.emplace_back("SENSITIVITY");
     nRequestedHistoryFields = requestedHistoryFields.size();
   }

--- a/SU2_CFD/src/output/CAdjHeatOutput.cpp
+++ b/SU2_CFD/src/output/CAdjHeatOutput.cpp
@@ -37,6 +37,7 @@ CAdjHeatOutput::CAdjHeatOutput(CConfig *config, unsigned short nDim) : COutput(c
 
   if (nRequestedHistoryFields == 0){
     requestedHistoryFields.emplace_back("ITER");
+    if (config->GetTime_Domain()) requestedHistoryFields.emplace_back("CUR_TIME");
     requestedHistoryFields.emplace_back("RMS_RES");
     requestedHistoryFields.emplace_back("SENSITIVITY");
     nRequestedHistoryFields = requestedHistoryFields.size();

--- a/SU2_CFD/src/output/CElasticityOutput.cpp
+++ b/SU2_CFD/src/output/CElasticityOutput.cpp
@@ -43,9 +43,7 @@ CElasticityOutput::CElasticityOutput(CConfig *config, unsigned short nDim) : COu
 
   /*--- Default fields for screen output ---*/
   if (nRequestedHistoryFields == 0){
-    requestedHistoryFields.emplace_back("ITER");
-    if (dynamic) requestedHistoryFields.emplace_back("CUR_TIME");
-    requestedHistoryFields.emplace_back("RMS_RES");
+    RequestCommonHistory(dynamic);
     nRequestedHistoryFields = requestedHistoryFields.size();
   }
 

--- a/SU2_CFD/src/output/CElasticityOutput.cpp
+++ b/SU2_CFD/src/output/CElasticityOutput.cpp
@@ -44,6 +44,7 @@ CElasticityOutput::CElasticityOutput(CConfig *config, unsigned short nDim) : COu
   /*--- Default fields for screen output ---*/
   if (nRequestedHistoryFields == 0){
     requestedHistoryFields.emplace_back("ITER");
+    if (dynamic) requestedHistoryFields.emplace_back("CUR_TIME");
     requestedHistoryFields.emplace_back("RMS_RES");
     nRequestedHistoryFields = requestedHistoryFields.size();
   }

--- a/SU2_CFD/src/output/CFlowCompFEMOutput.cpp
+++ b/SU2_CFD/src/output/CFlowCompFEMOutput.cpp
@@ -38,9 +38,7 @@ CFlowCompFEMOutput::CFlowCompFEMOutput(CConfig *config, unsigned short nDim) : C
   /*--- Set the default history fields if nothing is set in the config file ---*/
 
   if (nRequestedHistoryFields == 0){
-    requestedHistoryFields.emplace_back("ITER");
-    if (config->GetTime_Domain()) requestedHistoryFields.emplace_back("CUR_TIME");
-    requestedHistoryFields.emplace_back("RMS_RES");
+    RequestCommonHistory(config->GetTime_Domain());
     nRequestedHistoryFields = requestedHistoryFields.size();
   }
   if (nRequestedScreenFields == 0){

--- a/SU2_CFD/src/output/CFlowCompFEMOutput.cpp
+++ b/SU2_CFD/src/output/CFlowCompFEMOutput.cpp
@@ -39,6 +39,7 @@ CFlowCompFEMOutput::CFlowCompFEMOutput(CConfig *config, unsigned short nDim) : C
 
   if (nRequestedHistoryFields == 0){
     requestedHistoryFields.emplace_back("ITER");
+    if (config->GetTime_Domain()) requestedHistoryFields.emplace_back("CUR_TIME");
     requestedHistoryFields.emplace_back("RMS_RES");
     nRequestedHistoryFields = requestedHistoryFields.size();
   }

--- a/SU2_CFD/src/output/CFlowCompOutput.cpp
+++ b/SU2_CFD/src/output/CFlowCompOutput.cpp
@@ -37,9 +37,7 @@ CFlowCompOutput::CFlowCompOutput(const CConfig *config, unsigned short nDim) : C
   /*--- Set the default history fields if nothing is set in the config file ---*/
 
   if (nRequestedHistoryFields == 0){
-    requestedHistoryFields.emplace_back("ITER");
-    if (config->GetTime_Domain()) requestedHistoryFields.emplace_back("CUR_TIME");
-    requestedHistoryFields.emplace_back("RMS_RES");
+    RequestCommonHistory(config->GetTime_Domain());
     nRequestedHistoryFields = requestedHistoryFields.size();
   }
   if (nRequestedScreenFields == 0){

--- a/SU2_CFD/src/output/CFlowCompOutput.cpp
+++ b/SU2_CFD/src/output/CFlowCompOutput.cpp
@@ -38,6 +38,7 @@ CFlowCompOutput::CFlowCompOutput(const CConfig *config, unsigned short nDim) : C
 
   if (nRequestedHistoryFields == 0){
     requestedHistoryFields.emplace_back("ITER");
+    if (config->GetTime_Domain()) requestedHistoryFields.emplace_back("CUR_TIME");
     requestedHistoryFields.emplace_back("RMS_RES");
     nRequestedHistoryFields = requestedHistoryFields.size();
   }

--- a/SU2_CFD/src/output/CFlowIncOutput.cpp
+++ b/SU2_CFD/src/output/CFlowIncOutput.cpp
@@ -46,9 +46,7 @@ CFlowIncOutput::CFlowIncOutput(CConfig *config, unsigned short nDim) : CFlowOutp
   /*--- Set the default history fields if nothing is set in the config file ---*/
 
   if (nRequestedHistoryFields == 0){
-    requestedHistoryFields.emplace_back("ITER");
-    if (config->GetTime_Domain()) requestedHistoryFields.emplace_back("CUR_TIME");
-    requestedHistoryFields.emplace_back("RMS_RES");
+    RequestCommonHistory(config->GetTime_Domain());
     nRequestedHistoryFields = requestedHistoryFields.size();
   }
 

--- a/SU2_CFD/src/output/CFlowIncOutput.cpp
+++ b/SU2_CFD/src/output/CFlowIncOutput.cpp
@@ -47,6 +47,7 @@ CFlowIncOutput::CFlowIncOutput(CConfig *config, unsigned short nDim) : CFlowOutp
 
   if (nRequestedHistoryFields == 0){
     requestedHistoryFields.emplace_back("ITER");
+    if (config->GetTime_Domain()) requestedHistoryFields.emplace_back("CUR_TIME");
     requestedHistoryFields.emplace_back("RMS_RES");
     nRequestedHistoryFields = requestedHistoryFields.size();
   }

--- a/SU2_CFD/src/output/CHeatOutput.cpp
+++ b/SU2_CFD/src/output/CHeatOutput.cpp
@@ -35,9 +35,7 @@ CHeatOutput::CHeatOutput(CConfig *config, unsigned short nDim) : CFVMOutput(conf
   /*--- Set the default history fields if nothing is set in the config file ---*/
 
   if (nRequestedHistoryFields == 0){
-    requestedHistoryFields.emplace_back("ITER");
-    if (config->GetTime_Domain()) requestedHistoryFields.emplace_back("CUR_TIME");
-    requestedHistoryFields.emplace_back("RMS_RES");
+    RequestCommonHistory(config->GetTime_Domain());
     nRequestedHistoryFields = requestedHistoryFields.size();
   }
   if (nRequestedScreenFields == 0){

--- a/SU2_CFD/src/output/CHeatOutput.cpp
+++ b/SU2_CFD/src/output/CHeatOutput.cpp
@@ -36,6 +36,7 @@ CHeatOutput::CHeatOutput(CConfig *config, unsigned short nDim) : CFVMOutput(conf
 
   if (nRequestedHistoryFields == 0){
     requestedHistoryFields.emplace_back("ITER");
+    if (config->GetTime_Domain()) requestedHistoryFields.emplace_back("CUR_TIME");
     requestedHistoryFields.emplace_back("RMS_RES");
     nRequestedHistoryFields = requestedHistoryFields.size();
   }

--- a/SU2_CFD/src/output/CMultizoneOutput.cpp
+++ b/SU2_CFD/src/output/CMultizoneOutput.cpp
@@ -45,6 +45,7 @@ CMultizoneOutput::CMultizoneOutput(const CConfig* driver_config, const CConfig* 
 
   if (nRequestedHistoryFields == 0){
     requestedHistoryFields.emplace_back("ITER");
+    if (config[ZONE_0]->GetTime_Domain()) requestedHistoryFields.emplace_back("CUR_TIME");
     for (iZone = 0; iZone < nZone; iZone++){
       requestedHistoryFields.emplace_back(bgs_res_name + "[" + PrintingToolbox::to_string(iZone) + "]");
       requestedHistoryFields.emplace_back("AVG_RES[" + PrintingToolbox::to_string(iZone) + "]");

--- a/SU2_CFD/src/output/CNEMOCompOutput.cpp
+++ b/SU2_CFD/src/output/CNEMOCompOutput.cpp
@@ -38,9 +38,7 @@ CNEMOCompOutput::CNEMOCompOutput(const CConfig *config, unsigned short nDim) : C
   /*--- Set the default history fields if nothing is set in the config file ---*/
 
   if (nRequestedHistoryFields == 0){
-    requestedHistoryFields.emplace_back("ITER");
-    if (config->GetTime_Domain()) requestedHistoryFields.emplace_back("CUR_TIME");
-    requestedHistoryFields.emplace_back("RMS_RES");
+    RequestCommonHistory(config->GetTime_Domain());
     nRequestedHistoryFields = requestedHistoryFields.size();
   }
   if (nRequestedScreenFields == 0){

--- a/SU2_CFD/src/output/CNEMOCompOutput.cpp
+++ b/SU2_CFD/src/output/CNEMOCompOutput.cpp
@@ -39,6 +39,7 @@ CNEMOCompOutput::CNEMOCompOutput(const CConfig *config, unsigned short nDim) : C
 
   if (nRequestedHistoryFields == 0){
     requestedHistoryFields.emplace_back("ITER");
+    if (config->GetTime_Domain()) requestedHistoryFields.emplace_back("CUR_TIME");
     requestedHistoryFields.emplace_back("RMS_RES");
     nRequestedHistoryFields = requestedHistoryFields.size();
   }

--- a/SU2_CFD/src/output/COutput.cpp
+++ b/SU2_CFD/src/output/COutput.cpp
@@ -2017,6 +2017,13 @@ void COutput::SetCommonHistoryFields() {
 
 }
 
+void COutput::RequestCommonHistory(bool dynamic) {
+
+  requestedHistoryFields.emplace_back("ITER");
+  if (dynamic) requestedHistoryFields.emplace_back("CUR_TIME");
+  requestedHistoryFields.emplace_back("RMS_RES");
+}
+
 void COutput::SetCustomOutputs(const CConfig* config) {
 
   const auto& inputString = config->GetCustomOutputs();


### PR DESCRIPTION
## Proposed Changes
*add Cur_Time column to the default history.csv file for transient analysis*



## Related Work
*I propose this change mainly for third-party post-processing purposes, the post module can easily acquire the time information from the history file. In addition, the time data in the history file allows the users to know the current simulation time intuitively.*



## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [x] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [ ] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
