### PR TITLE
Remove `'U'` mode from Python `open()` function

### DIFF
--- a/TestCases/TestCase.py
+++ b/TestCases/TestCase.py
@@ -340,10 +340,10 @@ class TestCase:
                 diff = ''
                 try:
                     fromdate = time.ctime(os.stat(fromfile).st_mtime)
-                    fromlines = open(fromfile, 'U').readlines()
+                    fromlines = open(fromfile, 'r').readlines()
                     try:
                         todate = time.ctime(os.stat(tofile).st_mtime)
-                        tolines = open(tofile, 'U').readlines()
+                        tolines = open(tofile, 'r').readlines()
 
                         # If file tolerance is set to 0, make regular diff
                         if self.tol_file_percent == 0.0:


### PR DESCRIPTION
## Proposed Changes
Remove use of `'U'` mode from Python `open()` function in TestCase.py. 



## Related Work
Issue #2170. Identifies test case that didn't run from `serial_regression.py`.



## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [x] I am submitting my contribution to the develop branch.
- [ ] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [ ] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [ ] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
