### PR TITLE
Improved Tape Statistics

### DIFF
--- a/Common/include/basic_types/ad_structure.hpp
+++ b/Common/include/basic_types/ad_structure.hpp
@@ -29,9 +29,6 @@
 
 #include "../code_config.hpp"
 #include "../parallelization/omp_structure.hpp"
-#ifdef HAVE_MPI
-#include <mpi.h>
-#endif
 
 /*!
  * \namespace AD

--- a/Common/include/basic_types/ad_structure.hpp
+++ b/Common/include/basic_types/ad_structure.hpp
@@ -381,19 +381,19 @@ FORCEINLINE void PrintStatistics(Comm communicator, bool printingRank) {
 
 #ifdef HAVE_OPDI
 
-  // clang-format off
-
   if (printingRank) {
     std::cout << "-------------------------------------------------------\n";
     std::cout << "  OpenMP parallel parts of the tape\n";
     std::cout << "  (aggregated across OpenMP threads)\n";
-    #ifdef HAVE_MPI
-      std::cout << "  (aggregated across MPI processes)\n";
-    #endif
+#ifdef HAVE_MPI
+    std::cout << "  (aggregated across MPI processes)\n";
+#endif
     std::cout << "-------------------------------------------------------\n";
   }
 
   codi::TapeValues* aggregatedOpenMPTapeValues = nullptr;
+
+  // clang-format off
 
   SU2_OMP_PARALLEL {
     if (omp_get_thread_num() == 0) {  // master thread

--- a/Common/include/basic_types/ad_structure.hpp
+++ b/Common/include/basic_types/ad_structure.hpp
@@ -359,14 +359,12 @@ FORCEINLINE bool TapeActive() { return AD::getTape().isActive(); }
 template <typename Comm>
 FORCEINLINE void PrintStatistics(Comm communicator, bool printingRank) {
   if (printingRank) {
-#ifdef HAVE_OPDI
     std::cout << "-------------------------------------------------------\n";
     std::cout << "  Serial parts of the tape\n";
 #ifdef HAVE_MPI
     std::cout << "  (aggregated across MPI processes)\n";
 #endif
     std::cout << "-------------------------------------------------------\n";
-#endif
   }
 
   codi::TapeValues serialTapeValues = AD::getTape().getTapeValues();
@@ -408,10 +406,6 @@ FORCEINLINE void PrintStatistics(Comm communicator, bool printingRank) {
       totalMemoryAllocated += aggregatedOpenMPTapeValues->getAllocatedMemorySize();
       if (printingRank) {
         aggregatedOpenMPTapeValues->formatDefault(std::cout);
-        std::cout << "-------------------------------------------------------\n";
-        std::cout << "  Total memory used      :  " << totalMemoryUsed / 1024.0 / 1024.0 << " MB\n";
-        std::cout << "  Total memory allocated :  " << totalMemoryAllocated / 1024.0 / 1024.0 << " MB\n";
-        std::cout << "-------------------------------------------------------\n";
       }
       aggregatedOpenMPTapeValues = nullptr;
     } else {  // other threads
@@ -425,6 +419,13 @@ FORCEINLINE void PrintStatistics(Comm communicator, bool printingRank) {
 
 // clang-format on
 #endif
+
+  if (printingRank) {
+    std::cout << "-------------------------------------------------------\n";
+    std::cout << "  Total memory used      :  " << totalMemoryUsed / 1024.0 / 1024.0 << " MB\n";
+    std::cout << "  Total memory allocated :  " << totalMemoryAllocated / 1024.0 / 1024.0 << " MB\n";
+    std::cout << "-------------------------------------------------------\n";
+  }
 }
 
 FORCEINLINE void ClearAdjoints() { AD::getTape().clearAdjoints(); }

--- a/Common/include/basic_types/ad_structure.hpp
+++ b/Common/include/basic_types/ad_structure.hpp
@@ -377,6 +377,7 @@ FORCEINLINE void PrintStatistics(Comm communicator, bool printingRank) {
   }
 
   double totalMemoryUsed = serialTapeValues.getUsedMemorySize();
+  double totalMemoryAllocated = serialTapeValues.getAllocatedMemorySize();
 
 #ifdef HAVE_OPDI
 
@@ -404,11 +405,13 @@ FORCEINLINE void PrintStatistics(Comm communicator, bool printingRank) {
 
       aggregatedOpenMPTapeValues->combineDataMPI(communicator);
       totalMemoryUsed += aggregatedOpenMPTapeValues->getUsedMemorySize();
+      totalMemoryAllocated += aggregatedOpenMPTapeValues->getAllocatedMemorySize();
       if (printingRank) {
         aggregatedOpenMPTapeValues->formatDefault(std::cout);
-        std::cout << "-------------------------------------\n";
+        std::cout << "-------------------------------------------------------\n";
         std::cout << "  Total memory used      :  " << totalMemoryUsed / 1024.0 / 1024.0 << " MB\n";
-        std::cout << "-------------------------------------\n";
+        std::cout << "  Total memory allocated :  " << totalMemoryAllocated / 1024.0 / 1024.0 << " MB\n";
+        std::cout << "-------------------------------------------------------\n";
       }
       aggregatedOpenMPTapeValues = nullptr;
     } else {  // other threads

--- a/SU2_CFD/src/drivers/CDiscAdjMultizoneDriver.cpp
+++ b/SU2_CFD/src/drivers/CDiscAdjMultizoneDriver.cpp
@@ -670,19 +670,7 @@ void CDiscAdjMultizoneDriver::SetRecording(RECORDING kind_recording, Kind_Tape t
   }
 
   if (kind_recording != RECORDING::CLEAR_INDICES && driver_config->GetWrt_AD_Statistics()) {
-    if (rank == MASTER_NODE) AD::PrintStatistics();
-#ifdef CODI_REVERSE_TYPE
-    if (size > SINGLE_NODE) {
-      su2double myMem = AD::getTape().getTapeValues().getUsedMemorySize(), totMem = 0.0;
-      SU2_MPI::Allreduce(&myMem, &totMem, 1, MPI_DOUBLE, MPI_SUM, SU2_MPI::GetComm());
-      if (rank == MASTER_NODE) {
-        cout << "MPI\n";
-        cout << "-------------------------------------\n";
-        cout << "  Total memory used      :  " << totMem << " MB\n";
-        cout << "-------------------------------------\n" << endl;
-      }
-    }
-#endif
+    AD::PrintStatistics(SU2_MPI::GetComm(), rank == MASTER_NODE);
   }
 
   AD::StopRecording();

--- a/SU2_CFD/src/drivers/CDiscAdjSinglezoneDriver.cpp
+++ b/SU2_CFD/src/drivers/CDiscAdjSinglezoneDriver.cpp
@@ -305,19 +305,7 @@ void CDiscAdjSinglezoneDriver::SetRecording(RECORDING kind_recording){
   SetObjFunction();
 
   if (kind_recording != RECORDING::CLEAR_INDICES && config_container[ZONE_0]->GetWrt_AD_Statistics()) {
-    if (rank == MASTER_NODE) AD::PrintStatistics();
-#ifdef CODI_REVERSE_TYPE
-    if (size > SINGLE_NODE) {
-      su2double myMem = AD::getTape().getTapeValues().getUsedMemorySize(), totMem = 0.0;
-      SU2_MPI::Allreduce(&myMem, &totMem, 1, MPI_DOUBLE, MPI_SUM, SU2_MPI::GetComm());
-      if (rank == MASTER_NODE) {
-        cout << "MPI\n";
-        cout << "-------------------------------------\n";
-        cout << "  Total memory used      :  " << totMem << " MB\n";
-        cout << "-------------------------------------\n" << endl;
-      }
-    }
-#endif
+    AD::PrintStatistics(SU2_MPI::GetComm(), rank == MASTER_NODE);
   }
 
   AD::StopRecording();

--- a/meson_scripts/init.py
+++ b/meson_scripts/init.py
@@ -55,7 +55,7 @@ def init_submodules(
 
     # This information of the modules is used if projects was not cloned using git
     # The sha tag must be maintained manually to point to the correct commit
-    sha_version_codi = "9ca6c38280610b3ea5337ca3e5b5085ee1c66b59"
+    sha_version_codi = "75344991146b606ff8667e2a54943905a49aeb4b"
     github_repo_codi = "https://github.com/scicompkl/CoDiPack"
     sha_version_medi = "ab3a7688f6d518f8d940eb61a341d89f51922ba4"
     github_repo_medi = "https://github.com/SciCompKL/MeDiPack"

--- a/meson_scripts/init.py
+++ b/meson_scripts/init.py
@@ -55,7 +55,7 @@ def init_submodules(
 
     # This information of the modules is used if projects was not cloned using git
     # The sha tag must be maintained manually to point to the correct commit
-    sha_version_codi = "75344991146b606ff8667e2a54943905a49aeb4b"
+    sha_version_codi = "8408470208cc41866583d681995222f7ca45dff0"
     github_repo_codi = "https://github.com/scicompkl/CoDiPack"
     sha_version_medi = "ab3a7688f6d518f8d940eb61a341d89f51922ba4"
     github_repo_medi = "https://github.com/SciCompKL/MeDiPack"

--- a/meson_scripts/init.py
+++ b/meson_scripts/init.py
@@ -55,7 +55,7 @@ def init_submodules(
 
     # This information of the modules is used if projects was not cloned using git
     # The sha tag must be maintained manually to point to the correct commit
-    sha_version_codi = "8408470208cc41866583d681995222f7ca45dff0"
+    sha_version_codi = "c6b039e5c9edb7675f90ffc725f9dd8e66571264"
     github_repo_codi = "https://github.com/scicompkl/CoDiPack"
     sha_version_medi = "ab3a7688f6d518f8d940eb61a341d89f51922ba4"
     github_repo_medi = "https://github.com/SciCompKL/MeDiPack"


### PR DESCRIPTION
## Proposed Changes
Prior to this PR, tape statistics were collected and printed for the tape of thread 0 of rank 0, with special handling for the memory usage of thread 0, which was reduced across MPI processes. This PR extends this to also take OpenMP parallel parts into account (threads other than thread 0), and reduces everything (not only used memory) across MPI processes.

## Related Work
any prior work on hybrid AD

## PR Checklist

- [X] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [X] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [X] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [x] I have added a test case that demonstrates my contribution, if necessary.
- [X] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
