### PR TITLE
Fix bug in inlet profile writer.

### DIFF
--- a/SU2_CFD/src/CMarkerProfileReaderFVM.cpp
+++ b/SU2_CFD/src/CMarkerProfileReaderFVM.cpp
@@ -356,6 +356,7 @@ void CMarkerProfileReaderFVM::MergeProfileMarkers() {
 
         }
       }
+      columnIndex++;
     }
   }
 

--- a/SU2_CFD/src/CMarkerProfileReaderFVM.cpp
+++ b/SU2_CFD/src/CMarkerProfileReaderFVM.cpp
@@ -38,7 +38,6 @@ CMarkerProfileReaderFVM::CMarkerProfileReaderFVM(CGeometry      *val_geometry,
                                                  vector<string> val_columnValues) {
 
   /*--- Store input values and pointers to class data. ---*/
-
   rank = SU2_MPI::GetRank();
   size = SU2_MPI::GetSize();
 
@@ -51,7 +50,6 @@ CMarkerProfileReaderFVM::CMarkerProfileReaderFVM(CGeometry      *val_geometry,
   numberOfVars = val_number_vars;
   columnNames  = std::move(val_columnNames);
   columnValues = std::move(val_columnValues);
-
   /* Attempt to open the specified file. */
   ifstream profile_file;
   profile_file.open(filename.data(), ios::in);
@@ -302,6 +300,10 @@ void CMarkerProfileReaderFVM::MergeProfileMarkers() {
    by the master and sorted by marker tag in one large n-dim. array. ---*/
 
   su2double *Coords_Local; jPoint = 0;
+
+  /*--- Index to the string in columNames and columnValues ---*/
+  unsigned short columnIndex=0;
+
   for (iMarker = 0; iMarker < config->GetnMarker_All(); iMarker++) {
     if (config->GetMarker_All_KindBC(iMarker) == markerType) {
 
@@ -334,16 +336,12 @@ void CMarkerProfileReaderFVM::MergeProfileMarkers() {
 
           SPRINTF(&Buffer_Send_Str[jPoint*MAX_STRING_SIZE], "%s",
                   config->GetMarker_All_TagBound(iMarker).c_str());
-
           /*--- Store the column names ---*/
-
           SPRINTF(&Buffer_Send_Name[jPoint*MAX_STRING_SIZE], "%s",
-                  columnNames[iMarker].c_str());
-
+                  columnNames[columnIndex].c_str());
            /*--- Store the column values ---*/
-
          SPRINTF(&Buffer_Send_Value[jPoint*MAX_STRING_SIZE], "%s",
-                  columnValues[iMarker].c_str());
+                  columnValues[columnIndex].c_str());
 
           /*--- Increment jPoint as the counter. We need this because iPoint
            may include halo nodes that we skip over during this loop. ---*/

--- a/SU2_CFD/src/CMarkerProfileReaderFVM.cpp
+++ b/SU2_CFD/src/CMarkerProfileReaderFVM.cpp
@@ -38,6 +38,7 @@ CMarkerProfileReaderFVM::CMarkerProfileReaderFVM(CGeometry      *val_geometry,
                                                  vector<string> val_columnValues) {
 
   /*--- Store input values and pointers to class data. ---*/
+
   rank = SU2_MPI::GetRank();
   size = SU2_MPI::GetSize();
 
@@ -50,6 +51,7 @@ CMarkerProfileReaderFVM::CMarkerProfileReaderFVM(CGeometry      *val_geometry,
   numberOfVars = val_number_vars;
   columnNames  = std::move(val_columnNames);
   columnValues = std::move(val_columnValues);
+
   /* Attempt to open the specified file. */
   ifstream profile_file;
   profile_file.open(filename.data(), ios::in);
@@ -336,10 +338,14 @@ void CMarkerProfileReaderFVM::MergeProfileMarkers() {
 
           SPRINTF(&Buffer_Send_Str[jPoint*MAX_STRING_SIZE], "%s",
                   config->GetMarker_All_TagBound(iMarker).c_str());
+
           /*--- Store the column names ---*/
+
           SPRINTF(&Buffer_Send_Name[jPoint*MAX_STRING_SIZE], "%s",
                   columnNames[columnIndex].c_str());
+
            /*--- Store the column values ---*/
+
          SPRINTF(&Buffer_Send_Value[jPoint*MAX_STRING_SIZE], "%s",
                   columnValues[columnIndex].c_str());
 


### PR DESCRIPTION
## Proposed Changes
*Give a brief overview of your contribution here in a few sentences.*
When no inlet profile exists, su2 creates one for you. There was a bug where the index of the marker was used to look up the string of column names, instead of the index of the inlet markers. 

## Related Work
*Resolve any issues (bug fix or feature request), note any related PRs, or mention interactions with the work of others, if any.*



## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [x] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [x] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
