### PR TITLE
fix grad_val

### DIFF
--- a/SU2_CFD/src/solvers/CDiscAdjSolver.cpp
+++ b/SU2_CFD/src/solvers/CDiscAdjSolver.cpp
@@ -162,8 +162,6 @@ void CDiscAdjSolver::RegisterSolution(CGeometry *geometry, CConfig *config) {
   /*--- Boolean true indicates that an input is registered ---*/
   direct_solver->GetNodes()->RegisterSolution(true);
 
-  direct_solver->RegisterSolutionExtra(true, config);
-
   if (time_n_needed)
     direct_solver->GetNodes()->RegisterSolution_time_n();
 
@@ -261,6 +259,8 @@ void CDiscAdjSolver::RegisterVariables(CGeometry *geometry, CConfig *config, boo
     config->SetIncPressureOut_BC(BPressure);
     config->SetIncTemperature_BC(Temperature);
 
+    direct_solver->RegisterSolutionExtra(reset, config);
+
   }
 
   /*--- Register incompressible radiation values as input ---*/
@@ -299,7 +299,6 @@ void CDiscAdjSolver::RegisterOutput(CGeometry *geometry, CConfig *config) {
 
   direct_solver->GetNodes()->RegisterSolution(false);
 
-  direct_solver->RegisterSolutionExtra(false, config);
 }
 
 void CDiscAdjSolver::ExtractAdjoint_Solution(CGeometry *geometry, CConfig *config, bool CrossTerm) {


### PR DESCRIPTION
## Proposed Changes
*As mentioned in the last few dev meetings, there was some error with GradVal for the streamwise solver with Massflow. This was because the take was not cleared during SetRecoding. In the current version, the register of extra solutions is moved to Register Variables and gradients look consistent.*



## Related Work
*SWP-Isothermal with mass flow also shows good gradient validation after implementing this fix. In theory, this should not fix any other part of the code.*



## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [ x ] I am submitting my contribution to the develop branch.
- [ x ] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [ x ] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [ ] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
![CAD_GRAD_AFTER](https://github.com/su2code/SU2/assets/22835014/e0bfa7aa-0347-48a7-abf6-8e0526a706b6)
CAD Sensitivites after making changes, gradients are symmetric for the upper and lower variables.
![CAD_GRAD_BEFORE](https://github.com/su2code/SU2/assets/22835014/49f9d6fa-040c-4ee2-9fe8-da7e6c5d5b72)
CAD Sensitivities before making changes, gradients are not-symmetric for the upper and lower variables.
![Case_Image_RTemp](https://github.com/su2code/SU2/assets/22835014/a1335570-f0a4-412f-aceb-fc2a7dcd754a)
Test Case!
![FFD_GRAD_AFTER](https://github.com/su2code/SU2/assets/22835014/4e3eb1ff-51ed-4adc-afc7-00ec16d17506)
FFD Sensitives also co-relate well
