### PR TITLE
Using free stream tremperature for initialization of wall temperature for pure conjugate heat transfer problems

### DIFF
--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -9234,7 +9234,7 @@ su2double CConfig::GetIsothermal_Temperature(const string& val_marker) const {
     if (Marker_Isothermal[iMarker_Isothermal] == val_marker)
       return Isothermal_Temperature[iMarker_Isothermal];
 
-  return Isothermal_Temperature[0];
+  return Temperature_FreeStream;
 }
 
 su2double CConfig::GetWall_HeatFlux(const string& val_marker) const {

--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -9234,6 +9234,7 @@ su2double CConfig::GetIsothermal_Temperature(const string& val_marker) const {
     if (Marker_Isothermal[iMarker_Isothermal] == val_marker)
       return Isothermal_Temperature[iMarker_Isothermal];
 
+  // Return free-stream temperature for pure CHT cases.
   return Temperature_FreeStream;
 }
 


### PR DESCRIPTION
## Proposed Changes
For pure conjugate heat transfer problems, the temperature at the walls is initialized using the free stream temperature. Using the Isothermal_Temperature[0] for pure CHT problems results in a segmentation fault error.


## Related Work



## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [X] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [ ] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
