### PR TITLE
Fix CHT boundary problem for flamelet computations

### DIFF
--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -9234,8 +9234,7 @@ su2double CConfig::GetIsothermal_Temperature(const string& val_marker) const {
     if (Marker_Isothermal[iMarker_Isothermal] == val_marker)
       return Isothermal_Temperature[iMarker_Isothermal];
 
-  // Return free-stream temperature for pure CHT cases.
-  return Temperature_FreeStream;
+  return Isothermal_Temperature[0];
 }
 
 su2double CConfig::GetWall_HeatFlux(const string& val_marker) const {

--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -9234,7 +9234,7 @@ su2double CConfig::GetIsothermal_Temperature(const string& val_marker) const {
     if (Marker_Isothermal[iMarker_Isothermal] == val_marker)
       return Isothermal_Temperature[iMarker_Isothermal];
 
-  return Temperature_FreeStream;
+  return Isothermal_Temperature[0];
 }
 
 su2double CConfig::GetWall_HeatFlux(const string& val_marker) const {

--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -9234,7 +9234,7 @@ su2double CConfig::GetIsothermal_Temperature(const string& val_marker) const {
     if (Marker_Isothermal[iMarker_Isothermal] == val_marker)
       return Isothermal_Temperature[iMarker_Isothermal];
 
-  return Isothermal_Temperature[0];
+  return Temperature_FreeStream;
 }
 
 su2double CConfig::GetWall_HeatFlux(const string& val_marker) const {

--- a/SU2_CFD/src/integration/CIntegration.cpp
+++ b/SU2_CFD/src/integration/CIntegration.cpp
@@ -171,14 +171,13 @@ void CIntegration::Space_Integration(CGeometry *geometry,
         break;
       case CHT_WALL_INTERFACE:
 
-        if ( MainSolver == FLOW_SOL && (config->GetKind_FluidModel() == FLUID_FLAMELET) ){
-          solver_container[MainSolver]->BC_Isothermal_Wall(geometry, solver_container, conv_bound_numerics, visc_bound_numerics, config, iMarker);
-          break;
-        }
-        if ((MainSolver == SPECIES_SOL) || (MainSolver == HEAT_SOL) || ((MainSolver == FLOW_SOL) && ((config->GetKind_Regime() == ENUM_REGIME::COMPRESSIBLE) || config->GetEnergy_Equation()))) {
-          solver_container[MainSolver]->BC_ConjugateHeat_Interface(geometry, solver_container, conv_bound_numerics, config, iMarker);
-        }
-        else {
+        if ((MainSolver == FLOW_SOL && (config->GetKind_FluidModel() == FLUID_FLAMELET)) ||
+            (MainSolver == SPECIES_SOL) || (MainSolver == HEAT_SOL) ||
+            ((MainSolver == FLOW_SOL) &&
+             ((config->GetKind_Regime() == ENUM_REGIME::COMPRESSIBLE) || config->GetEnergy_Equation()))) {
+          solver_container[MainSolver]->BC_ConjugateHeat_Interface(geometry, solver_container, conv_bound_numerics,
+                                                                   config, iMarker);
+        } else {
           solver_container[MainSolver]->BC_HeatFlux_Wall(geometry, solver_container, conv_bound_numerics, visc_bound_numerics, config, iMarker);
         }
         break;


### PR DESCRIPTION
## Proposed Changes

Continuation of previous pull request https://github.com/su2code/SU2/pull/2281

[CHT + flamelet was only working if there was an additional isothermal wall present.] 

## Related Work




## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [X] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [ ] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
