### PR TITLE
Inconsistencies and improvements to SST model

### DIFF
--- a/Common/include/CConfig.hpp
+++ b/Common/include/CConfig.hpp
@@ -1168,6 +1168,9 @@ private:
   nHistoryOutput, nVolumeOutput;  /*!< \brief Number of variables printed to the history file. */
   bool Multizone_Residual;        /*!< \brief Determines if memory should be allocated for the multizone residual. */
   SST_ParsedOptions sstParsedOptions; /*!< \brief Additional parameters for the SST turbulence model. */
+  su2double lowerLimitTKE,
+            lowerLimitDissipation;
+  su2double prodLimConst;
   SA_ParsedOptions saParsedOptions;   /*!< \brief Additional parameters for the SA turbulence model. */
   LM_ParsedOptions lmParsedOptions;   /*!< \brief Additional parameters for the LM transition model. */
   su2double uq_delta_b;         /*!< \brief Parameter used to perturb eigenvalues of Reynolds Stress Matrix */
@@ -9852,6 +9855,10 @@ public:
    */
   SST_ParsedOptions GetSSTParsedOptions() const { return sstParsedOptions; }
 
+  su2double GetLowerLimitTKE() const { return lowerLimitTKE; }
+  su2double GetLowerLimitDissipation() const { return lowerLimitDissipation; }
+  su2double GetProdLimConst() const { return prodLimConst; }
+  
   /*!
    * \brief Get parsed SA option data structure.
    * \return SA option data structure.

--- a/Common/include/CConfig.hpp
+++ b/Common/include/CConfig.hpp
@@ -869,8 +869,7 @@ private:
   array<su2double, N_POLY_COEFFS> MuPolyCoefficientsND{{0.0}};  /*!< \brief Definition of the non-dimensional temperature polynomial coefficients for viscosity. */
   array<su2double, N_POLY_COEFFS> KtPolyCoefficientsND{{0.0}};  /*!< \brief Definition of the non-dimensional temperature polynomial coefficients for thermal conductivity. */
   su2double TurbIntensityAndViscRatioFreeStream[2]; /*!< \brief Freestream turbulent intensity and viscosity ratio for turbulence and transition models. */
-  su2double TKE_ProductionLimiterConstant; /*!< \brief Freestream turbulent intensity and viscosity ratio for turbulence and transition models. */
-  bool Change_TKE_ProductionLimiterConstant;
+
   su2double Energy_FreeStream,     /*!< \brief Free-stream total energy of the fluid.  */
   ModVel_FreeStream,               /*!< \brief Magnitude of the free-stream velocity of the fluid.  */
   ModVel_FreeStreamND,             /*!< \brief Non-dimensional magnitude of the free-stream velocity of the fluid.  */
@@ -8819,8 +8818,6 @@ public:
    * \brief Set freestream turbonormal for initializing solution.
    */
   const su2double* GetFreeStreamTurboNormal(void) const { return FreeStreamTurboNormal; }
-  const su2double GetTKE_ProductionLimiterConstant(void) const { return TKE_ProductionLimiterConstant; }
-  const bool GetChange_TKE_ProductionLimiterConstant(void) const { return Change_TKE_ProductionLimiterConstant; }
 
   /*!
    * \brief Set multizone properties.
@@ -9858,7 +9855,7 @@ public:
   su2double GetLowerLimitTKE() const { return lowerLimitTKE; }
   su2double GetLowerLimitDissipation() const { return lowerLimitDissipation; }
   su2double GetProdLimConst() const { return prodLimConst; }
-  
+
   /*!
    * \brief Get parsed SA option data structure.
    * \return SA option data structure.

--- a/Common/include/CConfig.hpp
+++ b/Common/include/CConfig.hpp
@@ -856,7 +856,8 @@ private:
   nMu_Temperature_Ref,           /*!< \brief Number of species reference temperature for Sutherland model. */
   nMu_S,                         /*!< \brief Number of species reference S for Sutherland model. */
   nThermal_Conductivity_Constant,/*!< \brief Number of species constant thermal conductivity. */
-  nPrandtl_Lam,                  /*!< \brief Number of species laminar Prandtl number. */
+  nPrandtl_Lam,                  /*!< \brief Number of species 
+  addDoubleOption("FREESTREAM_TURB2LAMVISCRATIO", TurbIntensityAndViscRatioFreeStream[1], 10.0); Prandtl number. */
   nPrandtl_Turb,                 /*!< \brief Number of species turbulent Prandtl number. */
   nConstant_Lewis_Number;       /*!< \brief Number of species Lewis Number. */
   su2double Diffusivity_Constant;   /*!< \brief Constant mass diffusivity for scalar transport.  */
@@ -868,6 +869,8 @@ private:
   array<su2double, N_POLY_COEFFS> MuPolyCoefficientsND{{0.0}};  /*!< \brief Definition of the non-dimensional temperature polynomial coefficients for viscosity. */
   array<su2double, N_POLY_COEFFS> KtPolyCoefficientsND{{0.0}};  /*!< \brief Definition of the non-dimensional temperature polynomial coefficients for thermal conductivity. */
   su2double TurbIntensityAndViscRatioFreeStream[2]; /*!< \brief Freestream turbulent intensity and viscosity ratio for turbulence and transition models. */
+  su2double TKE_ProductionLimiterConstant; /*!< \brief Freestream turbulent intensity and viscosity ratio for turbulence and transition models. */
+  bool Change_TKE_ProductionLimiterConstant;
   su2double Energy_FreeStream,     /*!< \brief Free-stream total energy of the fluid.  */
   ModVel_FreeStream,               /*!< \brief Magnitude of the free-stream velocity of the fluid.  */
   ModVel_FreeStreamND,             /*!< \brief Non-dimensional magnitude of the free-stream velocity of the fluid.  */
@@ -8813,6 +8816,8 @@ public:
    * \brief Set freestream turbonormal for initializing solution.
    */
   const su2double* GetFreeStreamTurboNormal(void) const { return FreeStreamTurboNormal; }
+  const su2double GetTKE_ProductionLimiterConstant(void) const { return TKE_ProductionLimiterConstant; }
+  const bool GetChange_TKE_ProductionLimiterConstant(void) const { return Change_TKE_ProductionLimiterConstant; }
 
   /*!
    * \brief Set multizone properties.

--- a/Common/include/option_structure.hpp
+++ b/Common/include/option_structure.hpp
@@ -990,18 +990,20 @@ enum class SST_OPTIONS {
   V,           /*!< \brief Menter k-w SST model with vorticity production terms. */
   KL,          /*!< \brief Menter k-w SST model with Kato-Launder production terms. */
   UQ,          /*!< \brief Menter k-w SST model with uncertainty quantification modifications. */
+  FULLPROD,    /*!< \brief Menter k-w SST model with full production term. */
 };
 static const MapType<std::string, SST_OPTIONS> SST_Options_Map = {
   MakePair("NONE", SST_OPTIONS::NONE)
   MakePair("V1994m", SST_OPTIONS::V1994m)
   MakePair("V2003m", SST_OPTIONS::V2003m)
   /// TODO: For now we do not support "unmodified" versions of SST.
-  //MakePair("V1994", SST_OPTIONS::V1994)
-  //MakePair("V2003", SST_OPTIONS::V2003)
+  MakePair("V1994", SST_OPTIONS::V1994)
+  MakePair("V2003", SST_OPTIONS::V2003)
   MakePair("SUSTAINING", SST_OPTIONS::SUST)
   MakePair("VORTICITY", SST_OPTIONS::V)
   MakePair("KATO-LAUNDER", SST_OPTIONS::KL)
   MakePair("UQ", SST_OPTIONS::UQ)
+  MakePair("FULLPROD", SST_OPTIONS::FULLPROD)
 };
 
 /*!
@@ -1013,6 +1015,7 @@ struct SST_ParsedOptions {
   bool sust = false;                          /*!< \brief Bool for SST model with sustaining terms. */
   bool uq = false;                            /*!< \brief Bool for using uncertainty quantification. */
   bool modified = false;                      /*!< \brief Bool for modified (m) SST model. */
+  bool fullProd = false;                      /*!< \brief Bool for full production term. */
 };
 
 /*!
@@ -1029,6 +1032,8 @@ inline SST_ParsedOptions ParseSSTOptions(const SST_OPTIONS *SST_Options, unsigne
     const auto sst_options_end = SST_Options + nSST_Options;
     return std::find(SST_Options, sst_options_end, option) != sst_options_end;
   };
+
+  const bool found_fullProd = IsPresent(SST_OPTIONS::FULLPROD);
 
   const bool found_1994 = IsPresent(SST_OPTIONS::V1994);
   const bool found_2003 = IsPresent(SST_OPTIONS::V2003);
@@ -1071,6 +1076,7 @@ inline SST_ParsedOptions ParseSSTOptions(const SST_OPTIONS *SST_Options, unsigne
   SSTParsedOptions.sust = sst_sust;
   SSTParsedOptions.modified = sst_m;
   SSTParsedOptions.uq = sst_uq;
+  SSTParsedOptions.fullProd = found_fullProd;
   return SSTParsedOptions;
 }
 

--- a/Common/include/option_structure.hpp
+++ b/Common/include/option_structure.hpp
@@ -991,6 +991,8 @@ enum class SST_OPTIONS {
   KL,          /*!< \brief Menter k-w SST model with Kato-Launder production terms. */
   UQ,          /*!< \brief Menter k-w SST model with uncertainty quantification modifications. */
   FULLPROD,    /*!< \brief Menter k-w SST model with full production term. */
+  LLT,         /*!< \brief Menter k-w SST model with Lower Limits Treatments. */
+  PRODLIM,     /*!< \brief Menter k-w SST model with user-defined production limiter constant. */
 };
 static const MapType<std::string, SST_OPTIONS> SST_Options_Map = {
   MakePair("NONE", SST_OPTIONS::NONE)
@@ -1004,6 +1006,8 @@ static const MapType<std::string, SST_OPTIONS> SST_Options_Map = {
   MakePair("KATO-LAUNDER", SST_OPTIONS::KL)
   MakePair("UQ", SST_OPTIONS::UQ)
   MakePair("FULLPROD", SST_OPTIONS::FULLPROD)
+  MakePair("LLT", SST_OPTIONS::LLT)
+  MakePair("PRODLIM", SST_OPTIONS::PRODLIM)
 };
 
 /*!
@@ -1016,6 +1020,8 @@ struct SST_ParsedOptions {
   bool uq = false;                            /*!< \brief Bool for using uncertainty quantification. */
   bool modified = false;                      /*!< \brief Bool for modified (m) SST model. */
   bool fullProd = false;                      /*!< \brief Bool for full production term. */
+  bool llt = false;                           /*!< \brief Bool for Lower Limits Treatment. */
+  bool prodLim = false;                       /*!< \brief Bool for user-defined production limiter constant. */
 };
 
 /*!
@@ -1034,6 +1040,8 @@ inline SST_ParsedOptions ParseSSTOptions(const SST_OPTIONS *SST_Options, unsigne
   };
 
   const bool found_fullProd = IsPresent(SST_OPTIONS::FULLPROD);
+  const bool found_llt = IsPresent(SST_OPTIONS::LLT);
+  const bool found_prodLim = IsPresent(SST_OPTIONS::PRODLIM);
 
   const bool found_1994 = IsPresent(SST_OPTIONS::V1994);
   const bool found_2003 = IsPresent(SST_OPTIONS::V2003);
@@ -1077,6 +1085,8 @@ inline SST_ParsedOptions ParseSSTOptions(const SST_OPTIONS *SST_Options, unsigne
   SSTParsedOptions.modified = sst_m;
   SSTParsedOptions.uq = sst_uq;
   SSTParsedOptions.fullProd = found_fullProd;
+  SSTParsedOptions.llt = found_llt;
+  SSTParsedOptions.prodLim = found_prodLim;
   return SSTParsedOptions;
 }
 

--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -6180,7 +6180,7 @@ void CConfig::SetOutput(SU2_COMPONENT val_software, unsigned short val_izone) {
             }
             cout << "." << endl;
 
-            if (Change_TKE_ProductionLimiterConstant) cout << "Changinf the value of the TKE production limiter constant to " << TKE_ProductionLimiterConstant << endl;
+            if (sstParsedOptions.prodLim) cout << "Changing the value of the TKE production limiter constant to " << prodLimConst << endl;
             
             break;
         }

--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -6181,6 +6181,7 @@ void CConfig::SetOutput(SU2_COMPONENT val_software, unsigned short val_izone) {
             cout << "." << endl;
 
             if (sstParsedOptions.prodLim) cout << "Changing the value of the TKE production limiter constant to " << prodLimConst << endl;
+            if (sstParsedOptions.llt) cout << "Changing the value of the lower limits of TKE and Omega " << endl;
             
             break;
         }

--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -1431,8 +1431,6 @@ void CConfig::SetConfig_Options() {
   addDoubleOption("INITIAL_BCTHRUST", Initial_BCThrust, 4000.0);
   /* DESCRIPTION:  */
   addDoubleOption("FREESTREAM_TURB2LAMVISCRATIO", TurbIntensityAndViscRatioFreeStream[1], 10.0);
-  addBoolOption("CHANGE_TKE_PRODUCTION_LIMITER_CONSTANT", Change_TKE_ProductionLimiterConstant, false);
-  addDoubleOption("TKE_PRODUCTION_LIMITER_CONSTANT", TKE_ProductionLimiterConstant, 10.0);
   /* DESCRIPTION: Side-slip angle (degrees, only for compressible flows) */
   addDoubleOption("SIDESLIP_ANGLE", AoS, 0.0);
   /*!\brief AOA  \n DESCRIPTION: Angle of attack (degrees, only for compressible flows) \ingroup Config*/

--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -1118,6 +1118,10 @@ void CConfig::SetConfig_Options() {
   /*!\brief SST_OPTIONS \n DESCRIPTION: Specify SA turbulence model options/corrections. \n Options: see \link SA_Options_Map \endlink \n DEFAULT: NONE \ingroup Config*/
   addEnumListOption("SA_OPTIONS", nSA_Options, SA_Options, SA_Options_Map);
 
+  addDoubleOption("LOWER_LIMIT_TKE", lowerLimitTKE, 1e-20);
+  addDoubleOption("LOWER_LIMIT_DISSIPATION", lowerLimitDissipation, 1e-6);
+  addDoubleOption("PROD_LIM_CONST", prodLimConst, 20.0);
+
   /*!\brief KIND_TRANS_MODEL \n DESCRIPTION: Specify transition model OPTIONS: see \link Trans_Model_Map \endlink \n DEFAULT: NONE \ingroup Config*/
   addEnumOption("KIND_TRANS_MODEL", Kind_Trans_Model, Trans_Model_Map, TURB_TRANS_MODEL::NONE);
   /*!\brief SST_OPTIONS \n DESCRIPTION: Specify LM transition model options/correlations. \n Options: see \link LM_Options_Map \endlink \n DEFAULT: NONE \ingroup Config*/

--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -1427,6 +1427,8 @@ void CConfig::SetConfig_Options() {
   addDoubleOption("INITIAL_BCTHRUST", Initial_BCThrust, 4000.0);
   /* DESCRIPTION:  */
   addDoubleOption("FREESTREAM_TURB2LAMVISCRATIO", TurbIntensityAndViscRatioFreeStream[1], 10.0);
+  addBoolOption("CHANGE_TKE_PRODUCTION_LIMITER_CONSTANT", Change_TKE_ProductionLimiterConstant, false);
+  addDoubleOption("TKE_PRODUCTION_LIMITER_CONSTANT", TKE_ProductionLimiterConstant, 10.0);
   /* DESCRIPTION: Side-slip angle (degrees, only for compressible flows) */
   addDoubleOption("SIDESLIP_ANGLE", AoS, 0.0);
   /*!\brief AOA  \n DESCRIPTION: Angle of attack (degrees, only for compressible flows) \ingroup Config*/
@@ -6175,6 +6177,9 @@ void CConfig::SetOutput(SU2_COMPONENT val_software, unsigned short val_izone) {
                 break;
             }
             cout << "." << endl;
+
+            if (Change_TKE_ProductionLimiterConstant) cout << "Changinf the value of the TKE production limiter constant to " << TKE_ProductionLimiterConstant << endl;
+            
             break;
         }
         switch (Kind_Trans_Model) {

--- a/SU2_CFD/include/numerics/CNumerics.hpp
+++ b/SU2_CFD/include/numerics/CNumerics.hpp
@@ -190,6 +190,8 @@ protected:
 
   bool bounded_scalar = false;    /*!< \brief Flag for bounded scalar problem */
 
+  su2double ProdDistr[4];
+
 public:
   /*!
    * \brief Return type used in some "ComputeResidual" overloads to give a
@@ -1605,6 +1607,8 @@ public:
    * \return is_bounded_scalar : scalar solver uses bounded scalar convective transport
    */
   inline bool GetBoundedScalar() const { return bounded_scalar;}
+
+  inline su2double GetProdDest(int index) const {return ProdDistr[index];}
 };
 
 /*!

--- a/SU2_CFD/include/numerics/CNumerics.hpp
+++ b/SU2_CFD/include/numerics/CNumerics.hpp
@@ -190,7 +190,7 @@ protected:
 
   bool bounded_scalar = false;    /*!< \brief Flag for bounded scalar problem */
 
-  su2double ProdDistr[4];
+  su2double ProdDistr[5];
 
 public:
   /*!

--- a/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
+++ b/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
@@ -870,9 +870,8 @@ class CSourcePieceWise_TurbSST final : public CNumerics {
       ProdDistr[4] = PLim;
 
       /*--- Cross diffusion ---*/
-      su2double CrossDiffusionTerm = (1.0 - F1_i) * CDkw_i;
-      if (CrossDiffusionTerm < 0.0) CrossDiffusionTerm = -min(Pw, abs(CrossDiffusionTerm));
-      Residual[1] += CrossDiffusionTerm * Volume;
+      const su2double CrossDiffusionTerm =  CDkw_i < 0.0 ? -min(Pw, abs(CrossDiffusionTerm)) : CrossDiffusionTerm;
+      Residual[1] += (1.0 - F1_i) * CrossDiffusionTerm * Volume;
 
       /*--- Contribution due to 2D axisymmetric formulation ---*/
 

--- a/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
+++ b/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
@@ -805,6 +805,9 @@ class CSourcePieceWise_TurbSST final : public CNumerics {
       const su2double prod_limit = prod_lim_const * beta_star * Density_i * ScalarVar_i[1] * ScalarVar_i[0];
 
       su2double P = Eddy_Viscosity_i * pow(P_Base, 2);
+      if (!sstParsedOptions.modified) P -= Eddy_Viscosity_i * diverg*diverg * 2.0/3.0;
+      if (sstParsedOptions.fullProd) P -= Density_i * ScalarVar_i[0] * diverg * 2.0/3.0;
+
       su2double pk = max(0.0, min(P, prod_limit));
 
       const auto& eddy_visc_var = sstParsedOptions.version == SST_OPTIONS::V1994 ? VorticityMag : StrainMag_i;
@@ -863,6 +866,7 @@ class CSourcePieceWise_TurbSST final : public CNumerics {
       /*--- Implicit part ---*/
 
       Jacobian_i[0][0] = -beta_star * ScalarVar_i[1] * Volume;
+      if (sstParsedOptions.fullProd) Jacobian_i[0][0] -= diverg * Volume*2.0/3.0;
       Jacobian_i[0][1] = -beta_star * ScalarVar_i[0] * Volume;
       Jacobian_i[1][0] = 0.0;
       Jacobian_i[1][1] = -2.0 * beta_blended * ScalarVar_i[1] * Volume;

--- a/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
+++ b/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
@@ -870,8 +870,9 @@ class CSourcePieceWise_TurbSST final : public CNumerics {
       ProdDistr[4] = PLim;
 
       /*--- Cross diffusion ---*/
-
-      Residual[1] += (1.0 - F1_i) * CDkw_i * Volume;
+      su2double CrossDiffusionTerm = (1.0 - F1_i) * CDkw_i;
+      if (CrossDiffusionTerm < 0.0) CrossDiffusionTerm = -min(Pw, abs(CrossDiffusionTerm));
+      Residual[1] += CrossDiffusionTerm * Volume;
 
       /*--- Contribution due to 2D axisymmetric formulation ---*/
 

--- a/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
+++ b/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
@@ -609,6 +609,8 @@ class CSourcePieceWise_TurbSST final : public CNumerics {
   /*--- Ambient values for SST-SUST. ---*/
   const su2double kAmb, omegaAmb;
 
+  su2double Pk, Dk, Pw, Dw;
+
   su2double F1_i, F2_i, CDkw_i;
   su2double Residual[2];
   su2double* Jacobian_i[2];
@@ -846,14 +848,23 @@ class CSourcePieceWise_TurbSST final : public CNumerics {
       }
 
       /*--- Add the production terms to the residuals. ---*/
+      Pk = pk;
+      Pw = pw;
 
       Residual[0] += pk * Volume;
       Residual[1] += pw * Volume;
 
       /*--- Add the dissipation  terms to the residuals.---*/
+      Dk = dk;
+      Dw = dw;
 
       Residual[0] -= dk * Volume;
       Residual[1] -= dw * Volume;
+
+      ProdDistr[0] = Pk;
+      ProdDistr[1] = Dk;
+      ProdDistr[2] = Pw;
+      ProdDistr[3] = Dw;
 
       /*--- Cross diffusion ---*/
 

--- a/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
+++ b/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
@@ -810,6 +810,8 @@ class CSourcePieceWise_TurbSST final : public CNumerics {
       if (!sstParsedOptions.modified) P -= Eddy_Viscosity_i * diverg*diverg * 2.0/3.0;
       if (sstParsedOptions.fullProd) P -= Density_i * ScalarVar_i[0] * diverg * 2.0/3.0;
 
+      su2double PLim = 0.0;
+      if ( P > prod_limit ) PLim = 1.0;
       su2double pk = max(0.0, min(P, prod_limit));
 
       const auto& eddy_visc_var = sstParsedOptions.version == SST_OPTIONS::V1994 ? VorticityMag : StrainMag_i;
@@ -865,6 +867,7 @@ class CSourcePieceWise_TurbSST final : public CNumerics {
       ProdDistr[1] = Dk;
       ProdDistr[2] = Pw;
       ProdDistr[3] = Dw;
+      ProdDistr[4] = PLim;
 
       /*--- Cross diffusion ---*/
 

--- a/SU2_CFD/include/variables/CTurbVariable.hpp
+++ b/SU2_CFD/include/variables/CTurbVariable.hpp
@@ -43,6 +43,10 @@ public:
   static constexpr size_t MAXNVAR = 2;
   VectorType turb_index;
   VectorType intermittency;         /*!< \brief Value of the intermittency for the trans. model. */
+  VectorType Pk;
+  VectorType Pw;
+  VectorType Dk;
+  VectorType Dw;
 
   /*!
    * \brief Constructor of the class.
@@ -100,5 +104,34 @@ public:
    */
   inline void SetIntermittency(unsigned long iPoint, su2double val_intermittency) final { intermittency(iPoint) = val_intermittency; }
 
+  /*!
+   * \brief Set the intermittency of the transition model.
+   * \param[in] iPoint - Point index.
+   * \param[in] val_intermittency - New value of the intermittency.
+   */
+  inline void SetProdDestr(unsigned long iPoint, su2double* val_ProdDestr) final { 
+    Pk(iPoint) = val_ProdDestr[0];
+    Dk(iPoint) = val_ProdDestr[1];
+    Pw(iPoint) = val_ProdDestr[2];
+    Dw(iPoint) = val_ProdDestr[3]; 
+  }
+
+  /*!
+   * \brief Set the intermittency of the transition model.
+   * \param[in] iPoint - Point index.
+   * \param[in] val_intermittency - New value of the intermittency.
+   */
+  inline su2double GetProdTKE(unsigned long iPoint) const final { 
+    return Pk(iPoint); 
+  }
+  inline su2double GetDestrTKE(unsigned long iPoint) const final { 
+    return Dk(iPoint); 
+  }
+  inline su2double GetProdW(unsigned long iPoint) const final { 
+    return Pw(iPoint); 
+  }
+  inline su2double GetDestrW(unsigned long iPoint) const final { 
+    return Dw(iPoint); 
+  }
 };
 

--- a/SU2_CFD/include/variables/CTurbVariable.hpp
+++ b/SU2_CFD/include/variables/CTurbVariable.hpp
@@ -47,6 +47,7 @@ public:
   VectorType Pw;
   VectorType Dk;
   VectorType Dw;
+  VectorType PkLim;
 
   /*!
    * \brief Constructor of the class.
@@ -114,6 +115,7 @@ public:
     Dk(iPoint) = val_ProdDestr[1];
     Pw(iPoint) = val_ProdDestr[2];
     Dw(iPoint) = val_ProdDestr[3]; 
+    PkLim(iPoint) = val_ProdDestr[4]; 
   }
 
   /*!
@@ -132,6 +134,9 @@ public:
   }
   inline su2double GetDestrW(unsigned long iPoint) const final { 
     return Dw(iPoint); 
+  }
+  inline su2double GetPkLim(unsigned long iPoint) const final { 
+    return PkLim(iPoint); 
   }
 };
 

--- a/SU2_CFD/include/variables/CVariable.hpp
+++ b/SU2_CFD/include/variables/CVariable.hpp
@@ -2340,4 +2340,10 @@ public:
 
   inline virtual const su2double *GetScalarSources(unsigned long iPoint) const { return nullptr; }
   inline virtual const su2double *GetScalarLookups(unsigned long iPoint) const { return nullptr; }
+
+  inline virtual void SetProdDestr(unsigned long iPoint, su2double* val_ProdDestr) { }
+  inline virtual su2double GetProdTKE(unsigned long iPoint) const { return 0.0; }
+  inline virtual su2double GetDestrTKE(unsigned long iPoint) const { return 0.0; }
+  inline virtual su2double GetProdW(unsigned long iPoint) const { return 0.0; }
+  inline virtual su2double GetDestrW(unsigned long iPoint) const { return 0.0; }
 };

--- a/SU2_CFD/include/variables/CVariable.hpp
+++ b/SU2_CFD/include/variables/CVariable.hpp
@@ -2346,4 +2346,5 @@ public:
   inline virtual su2double GetDestrTKE(unsigned long iPoint) const { return 0.0; }
   inline virtual su2double GetProdW(unsigned long iPoint) const { return 0.0; }
   inline virtual su2double GetDestrW(unsigned long iPoint) const { return 0.0; }
+  inline virtual su2double GetPkLim(unsigned long iPoint) const { return 0.0; }
 };

--- a/SU2_CFD/src/output/CFlowOutput.cpp
+++ b/SU2_CFD/src/output/CFlowOutput.cpp
@@ -1252,6 +1252,10 @@ void CFlowOutput::SetVolumeOutputFieldsScalarSolution(const CConfig* config){
     case TURB_FAMILY::KW:
       AddVolumeOutput("TKE", "Turb_Kin_Energy", "SOLUTION", "Turbulent kinetic energy");
       AddVolumeOutput("DISSIPATION", "Omega", "SOLUTION", "Rate of dissipation");
+      AddVolumeOutput("PROD_TKE", "Prod_TKE", "SOLUTION", "Production of turbulent kinetic energy");
+      AddVolumeOutput("DESTR_TKE", "Destr_TKE", "SOLUTION", "Destruction of turbulent kinetic energy");
+      AddVolumeOutput("PROD_W", "Prod_W", "SOLUTION", "Production of rate of dissipation");
+      AddVolumeOutput("DESTR_W", "Destr_W", "SOLUTION", "Destruction of rate of dissipation");
       break;
 
     case TURB_FAMILY::NONE:
@@ -1528,6 +1532,10 @@ void CFlowOutput::LoadVolumeDataScalar(const CConfig* config, const CSolver* con
     case TURB_FAMILY::KW:
       SetVolumeOutputValue("TKE", iPoint, Node_Turb->GetSolution(iPoint, 0));
       SetVolumeOutputValue("DISSIPATION", iPoint, Node_Turb->GetSolution(iPoint, 1));
+      SetVolumeOutputValue("PROD_TKE", iPoint, Node_Turb->GetProdTKE(iPoint));
+      SetVolumeOutputValue("DESTR_TKE", iPoint, Node_Turb->GetDestrTKE(iPoint));
+      SetVolumeOutputValue("PROD_W", iPoint, Node_Turb->GetProdW(iPoint));
+      SetVolumeOutputValue("DESTR_W", iPoint, Node_Turb->GetDestrW(iPoint));
       SetVolumeOutputValue("RES_TKE", iPoint, turb_solver->LinSysRes(iPoint, 0));
       SetVolumeOutputValue("RES_DISSIPATION", iPoint, turb_solver->LinSysRes(iPoint, 1));
       if (limiter) {

--- a/SU2_CFD/src/output/CFlowOutput.cpp
+++ b/SU2_CFD/src/output/CFlowOutput.cpp
@@ -1254,6 +1254,7 @@ void CFlowOutput::SetVolumeOutputFieldsScalarSolution(const CConfig* config){
       AddVolumeOutput("DISSIPATION", "Omega", "SOLUTION", "Rate of dissipation");
       AddVolumeOutput("PROD_TKE", "Prod_TKE", "SOLUTION", "Production of turbulent kinetic energy");
       AddVolumeOutput("DESTR_TKE", "Destr_TKE", "SOLUTION", "Destruction of turbulent kinetic energy");
+      AddVolumeOutput("PROD_TKE_LIM", "Prod_TKE_Lim", "SOLUTION", "Check if production limiter has been used for TKE");
       AddVolumeOutput("PROD_W", "Prod_W", "SOLUTION", "Production of rate of dissipation");
       AddVolumeOutput("DESTR_W", "Destr_W", "SOLUTION", "Destruction of rate of dissipation");
       break;
@@ -1538,6 +1539,7 @@ void CFlowOutput::LoadVolumeDataScalar(const CConfig* config, const CSolver* con
       SetVolumeOutputValue("DISSIPATION", iPoint, Node_Turb->GetSolution(iPoint, 1));
       SetVolumeOutputValue("PROD_TKE", iPoint, Node_Turb->GetProdTKE(iPoint));
       SetVolumeOutputValue("DESTR_TKE", iPoint, Node_Turb->GetDestrTKE(iPoint));
+      SetVolumeOutputValue("PROD_TKE_LIM", iPoint, Node_Turb->GetPkLim(iPoint));
       SetVolumeOutputValue("PROD_W", iPoint, Node_Turb->GetProdW(iPoint));
       SetVolumeOutputValue("DESTR_W", iPoint, Node_Turb->GetDestrW(iPoint));
       SetVolumeOutputValue("RES_TKE", iPoint, turb_solver->LinSysRes(iPoint, 0));

--- a/SU2_CFD/src/output/CFlowOutput.cpp
+++ b/SU2_CFD/src/output/CFlowOutput.cpp
@@ -1257,6 +1257,8 @@ void CFlowOutput::SetVolumeOutputFieldsScalarSolution(const CConfig* config){
       AddVolumeOutput("PROD_TKE_LIM", "Prod_TKE_Lim", "SOLUTION", "Check if production limiter has been used for TKE");
       AddVolumeOutput("PROD_W", "Prod_W", "SOLUTION", "Production of rate of dissipation");
       AddVolumeOutput("DESTR_W", "Destr_W", "SOLUTION", "Destruction of rate of dissipation");
+      AddVolumeOutput("CDkw", "CDkw", "SOLUTION", "Cross-Diffusion term");
+      AddVolumeOutput("F1", "F1", "SOLUTION", "F1 blending function");
       break;
 
     case TURB_FAMILY::NONE:
@@ -1542,6 +1544,8 @@ void CFlowOutput::LoadVolumeDataScalar(const CConfig* config, const CSolver* con
       SetVolumeOutputValue("PROD_TKE_LIM", iPoint, Node_Turb->GetPkLim(iPoint));
       SetVolumeOutputValue("PROD_W", iPoint, Node_Turb->GetProdW(iPoint));
       SetVolumeOutputValue("DESTR_W", iPoint, Node_Turb->GetDestrW(iPoint));
+      SetVolumeOutputValue("CDkw", iPoint, Node_Turb->GetCrossDiff(iPoint));
+      SetVolumeOutputValue("F1", iPoint, Node_Turb->GetF1blending(iPoint));
       SetVolumeOutputValue("RES_TKE", iPoint, turb_solver->LinSysRes(iPoint, 0));
       SetVolumeOutputValue("RES_DISSIPATION", iPoint, turb_solver->LinSysRes(iPoint, 1));
       if (limiter) {

--- a/SU2_CFD/src/output/CFlowOutput.cpp
+++ b/SU2_CFD/src/output/CFlowOutput.cpp
@@ -1484,6 +1484,7 @@ void CFlowOutput::SetVolumeOutputFieldsScalarMisc(const CConfig* config) {
     }
     AddVolumeOutput("Q_CRITERION", "Q_Criterion", "VORTEX_IDENTIFICATION", "Value of the Q-Criterion");
     AddVolumeOutput("WALL_DISTANCE", "Wall_Distance", "MISC", "Wall distance value");
+    AddVolumeOutput("STRAIN_MAG", "Strain_Magnitude", "MISC", "Strain magnitude value");
   }
 
   // Timestep info
@@ -1518,6 +1519,7 @@ void CFlowOutput::LoadVolumeDataScalar(const CConfig* config, const CSolver* con
     }
     SetVolumeOutputValue("Q_CRITERION", iPoint, GetQCriterion(Node_Flow->GetVelocityGradient(iPoint)));
     SetVolumeOutputValue("WALL_DISTANCE", iPoint, Node_Geo->GetWall_Distance(iPoint));
+    SetVolumeOutputValue("STRAIN_MAG", iPoint, Node_Turb->GetStrainMag(iPoint));
   }
 
   const bool limiter = (config->GetKind_SlopeLimit_Turb() != LIMITER::NONE);

--- a/SU2_CFD/src/output/CFlowOutput.cpp
+++ b/SU2_CFD/src/output/CFlowOutput.cpp
@@ -1483,6 +1483,7 @@ void CFlowOutput::SetVolumeOutputFieldsScalarMisc(const CConfig* config) {
       AddVolumeOutput("VORTICITY", "Vorticity", "VORTEX_IDENTIFICATION", "Value of the vorticity");
     }
     AddVolumeOutput("Q_CRITERION", "Q_Criterion", "VORTEX_IDENTIFICATION", "Value of the Q-Criterion");
+    AddVolumeOutput("WALL_DISTANCE", "Wall_Distance", "MISC", "Wall distance value");
   }
 
   // Timestep info
@@ -1516,6 +1517,7 @@ void CFlowOutput::LoadVolumeDataScalar(const CConfig* config, const CSolver* con
       SetVolumeOutputValue("VORTICITY", iPoint, Node_Flow->GetVorticity(iPoint)[2]);
     }
     SetVolumeOutputValue("Q_CRITERION", iPoint, GetQCriterion(Node_Flow->GetVelocityGradient(iPoint)));
+    SetVolumeOutputValue("WALL_DISTANCE", iPoint, Node_Geo->GetWall_Distance(iPoint));
   }
 
   const bool limiter = (config->GetKind_SlopeLimit_Turb() != LIMITER::NONE);

--- a/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
+++ b/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
@@ -102,11 +102,13 @@ CTurbSSTSolver::CTurbSSTSolver(CGeometry *geometry, CConfig *config, unsigned sh
     constants[8] = constants[4]/constants[6] - constants[2]*0.41*0.41/sqrt(constants[6]);  //alfa_1
     constants[9] = constants[5]/constants[6] - constants[3]*0.41*0.41/sqrt(constants[6]);  //alfa_2
     constants[10] = 20.0; // production limiter constant
+    if (sstParsedOptions.prodLim) constants[10] = config->GetProdLimConst();
   } else {
     /* SST-V2003 */
     constants[8] = 5.0 / 9.0;  //gamma_1
     constants[9] = 0.44;  //gamma_2
     constants[10] = 10.0; // production limiter constant
+    if (sstParsedOptions.prodLim) constants[10] = config->GetProdLimConst();
   }
 
   if (config->GetChange_TKE_ProductionLimiterConstant()) constants[10] = config->GetTKE_ProductionLimiterConstant();
@@ -134,6 +136,11 @@ CTurbSSTSolver::CTurbSSTSolver(CGeometry *geometry, CConfig *config, unsigned sh
 
   Solution_Inf[0] = kine_Inf;
   Solution_Inf[1] = omega_Inf;
+
+  if (sstParsedOptions.llt) {
+    lowerlimit[0] = kine_Inf * config->GetLowerLimitTKE();
+    lowerlimit[1] = omega_Inf * config->GetLowerLimitDissipation();
+  }
 
   /*--- Eddy viscosity, initialized without stress limiter at the infinity ---*/
   muT_Inf = rhoInf*kine_Inf/omega_Inf;

--- a/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
+++ b/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
@@ -376,11 +376,12 @@ void CTurbSSTSolver::Source_Residual(CGeometry *geometry, CSolver **solver_conta
       nodes->SetIntermittency(iPoint, numerics->GetIntermittencyEff());
     }
 
-    su2double ProdDestr[4];
+    su2double ProdDestr[5];
     ProdDestr[0] = numerics->GetProdDest(0);
     ProdDestr[1] = numerics->GetProdDest(1);
     ProdDestr[2] = numerics->GetProdDest(2);
     ProdDestr[3] = numerics->GetProdDest(3);
+    ProdDestr[4] = numerics->GetProdDest(4);
     nodes->SetProdDestr(iPoint, ProdDestr);
 
     /*--- Subtract residual and the Jacobian ---*/

--- a/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
+++ b/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
@@ -110,7 +110,6 @@ CTurbSSTSolver::CTurbSSTSolver(CGeometry *geometry, CConfig *config, unsigned sh
     constants[10] = 10.0; // production limiter constant
     if (sstParsedOptions.prodLim) constants[10] = config->GetProdLimConst();
   }
-
   
   /*--- Initialize lower and upper limits---*/
   lowerlimit[0] = 1.0e-10;

--- a/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
+++ b/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
@@ -111,7 +111,6 @@ CTurbSSTSolver::CTurbSSTSolver(CGeometry *geometry, CConfig *config, unsigned sh
     if (sstParsedOptions.prodLim) constants[10] = config->GetProdLimConst();
   }
 
-  if (config->GetChange_TKE_ProductionLimiterConstant()) constants[10] = config->GetTKE_ProductionLimiterConstant();
   
   /*--- Initialize lower and upper limits---*/
   lowerlimit[0] = 1.0e-10;

--- a/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
+++ b/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
@@ -108,6 +108,9 @@ CTurbSSTSolver::CTurbSSTSolver(CGeometry *geometry, CConfig *config, unsigned sh
     constants[9] = 0.44;  //gamma_2
     constants[10] = 10.0; // production limiter constant
   }
+
+  if (config->GetChange_TKE_ProductionLimiterConstant()) constants[10] = config->GetTKE_ProductionLimiterConstant();
+  
   /*--- Initialize lower and upper limits---*/
   lowerlimit[0] = 1.0e-10;
   upperlimit[0] = 1.0e10;

--- a/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
+++ b/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
@@ -371,6 +371,13 @@ void CTurbSSTSolver::Source_Residual(CGeometry *geometry, CSolver **solver_conta
       nodes->SetIntermittency(iPoint, numerics->GetIntermittencyEff());
     }
 
+    su2double ProdDestr[4];
+    ProdDestr[0] = numerics->GetProdDest(0);
+    ProdDestr[1] = numerics->GetProdDest(1);
+    ProdDestr[2] = numerics->GetProdDest(2);
+    ProdDestr[3] = numerics->GetProdDest(3);
+    nodes->SetProdDestr(iPoint, ProdDestr);
+
     /*--- Subtract residual and the Jacobian ---*/
 
     LinSysRes.SubtractBlock(iPoint, residual);

--- a/SU2_CFD/src/variables/CTurbSSTVariable.cpp
+++ b/SU2_CFD/src/variables/CTurbSSTVariable.cpp
@@ -72,14 +72,14 @@ void CTurbSSTVariable::SetBlendingFunc(unsigned long iPoint, su2double val_visco
   // CDkw(iPoint) = max(CDkw(iPoint), pow(10.0, -prod_lim_const));
   su2double exponent = 20.0;
   if (sstParsedOptions.version == SST_OPTIONS::V2003) exponent = 10.0;
-  CDkw(iPoint) = max(CDkw(iPoint), pow(10.0, -exponent));
+  const su2double CDkw_Clipped = max(CDkw(iPoint), pow(10.0, -exponent));
 
   /*--- F1 ---*/
 
   arg2A = sqrt(Solution(iPoint,0))/(beta_star*Solution(iPoint,1)*val_dist+EPS*EPS);
   arg2B = 500.0*val_viscosity / (val_density*val_dist*val_dist*Solution(iPoint,1)+EPS*EPS);
   arg2 = max(arg2A, arg2B);
-  arg1 = min(arg2, 4.0*val_density*sigma_om2*Solution(iPoint,0) / (CDkw(iPoint)*val_dist*val_dist+EPS*EPS));
+  arg1 = min(arg2, 4.0*val_density*sigma_om2*Solution(iPoint,0) / (CDkw_Clipped*val_dist*val_dist+EPS*EPS));
   F1(iPoint) = tanh(pow(arg1, 4.0));
 
   /*--- F2 ---*/
@@ -94,7 +94,7 @@ void CTurbSSTVariable::SetBlendingFunc(unsigned long iPoint, su2double val_visco
     F1(iPoint) = max(F1(iPoint), F3);
   }
 
-  AD::SetPreaccOut(F1(iPoint)); AD::SetPreaccOut(F2(iPoint)); AD::SetPreaccOut(CDkw(iPoint));
+  AD::SetPreaccOut(F1(iPoint)); AD::SetPreaccOut(F2(iPoint)); AD::SetPreaccOut(CDkw_Clipped);
   AD::EndPreacc();
 
 }

--- a/SU2_CFD/src/variables/CTurbSSTVariable.cpp
+++ b/SU2_CFD/src/variables/CTurbSSTVariable.cpp
@@ -69,7 +69,10 @@ void CTurbSSTVariable::SetBlendingFunc(unsigned long iPoint, su2double val_visco
   for (unsigned long iDim = 0; iDim < nDim; iDim++)
     CDkw(iPoint) += Gradient(iPoint,0,iDim)*Gradient(iPoint,1,iDim);
   CDkw(iPoint) *= 2.0*val_density*sigma_om2/Solution(iPoint,1);
-  CDkw(iPoint) = max(CDkw(iPoint), pow(10.0, -prod_lim_const));
+  // CDkw(iPoint) = max(CDkw(iPoint), pow(10.0, -prod_lim_const));
+  su2double exponent = 20.0;
+  if (sstParsedOptions.version == SST_OPTIONS::V2003) exponent = 10.0;
+  CDkw(iPoint) = max(CDkw(iPoint), pow(10.0, -exponent));
 
   /*--- F1 ---*/
 

--- a/SU2_CFD/src/variables/CTurbVariable.cpp
+++ b/SU2_CFD/src/variables/CTurbVariable.cpp
@@ -40,6 +40,7 @@ CTurbVariable::CTurbVariable(unsigned long npoint, unsigned long ndim, unsigned 
       Pw.resize(nPoint) = su2double(1.0);
       Dk.resize(nPoint) = su2double(1.0);
       Dw.resize(nPoint) = su2double(1.0);
+      PkLim.resize(nPoint) = su2double(1.0);
     }
 
    }

--- a/SU2_CFD/src/variables/CTurbVariable.cpp
+++ b/SU2_CFD/src/variables/CTurbVariable.cpp
@@ -35,4 +35,11 @@ CTurbVariable::CTurbVariable(unsigned long npoint, unsigned long ndim, unsigned 
     turb_index.resize(nPoint) = su2double(1.0);
     intermittency.resize(nPoint) = su2double(1.0);
 
+    if (TurbModelFamily(config->GetKind_Turb_Model()) == TURB_FAMILY::KW) {
+      Pk.resize(nPoint) = su2double(1.0);
+      Pw.resize(nPoint) = su2double(1.0);
+      Dk.resize(nPoint) = su2double(1.0);
+      Dw.resize(nPoint) = su2double(1.0);
+    }
+
    }


### PR DESCRIPTION
## Proposed Changes
Hi everyone, 

I have found some inconsistencies with respect to the literature on the implementation of the Menter's SST model. I would like to use this branch as test bench for any corrections/improvements made to the SST model.

Implementation errors found:
- Use of production limiter constant in the clipping of the cross-diffusion term for the computation of the F1 blending function in CTurbSSTVariable.cpp. 
- SST naming conventions (V in V2003m should stay for Vorticity production term.). Not yet assessed.
- Wrong cross-diffusion term included into the residual of w in turb_sources.hpp. It should not be only the positive value as considered in the computation of the F1 blending function. As stated in https://doi.org/10.2514/3.12149.  "CDkw is the
positive portion of the cross-diffusion term in Eq (A2)" pag. 1604. Moreover, a clipping has been introduced for large negative values of this term, as suggested in Peng, Shia-Hui, Peter Eliasson, and Lars Davidson. "Examination of the shear stress transport assumption with a low-Reynolds number k-omega model for aerodynamic flows." Eq 17.
- Boundary conditions errors at inlets, following the Issue #1851. A fix has been proposed following @pcarruscag  suggestions for the supersonic inlet BC.

Changes to SST model proposed:
- Inclusion of non modified versions of SST. In this case I think that more work is needed to be sure that the correct terms are taken into account everywhere in the code.

I've seen the proposed changes to the lower limits of k and w in #2323 and I tried implementing it in my branch. However, if the implementation proposed in the respective PR is preferred then I will change mine. 

## Related Work
#2323 #1851 



## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [X] I am submitting my contribution to the develop branch.
- [ ] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [ ] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [ ] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
