### PR TITLE
Show error message when FLUID_MIXTURE is used with KIND_SCALAR_MODEL = NONE

### DIFF
--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -3920,6 +3920,13 @@ void CConfig::SetPostprocessing(SU2_COMPONENT val_software, unsigned short val_i
         SU2_MPI::Error("The use of FLUID_MIXTURE requires the INC_DENSITY_MODEL option to be VARIABLE",
                        CURRENT_FUNCTION);
       }
+      /*--- Check whether the Kind scalar model used is correct, in the case of FLUID_MIXTURE the kind scalar model must
+       be SPECIES_TRANSPORT. Otherwise, if the scalar model is NONE, the species transport equations will not be solved.
+       --- */
+      if (Kind_Species_Model != SPECIES_MODEL::SPECIES_TRANSPORT) {
+        SU2_MPI::Error("The use of FLUID_MIXTURE requires the KIND_SCALAR_MODEL option to be SPECIES_TRANSPORT",
+                       CURRENT_FUNCTION);
+      }
 
       switch (Kind_ViscosityModel) {
         case VISCOSITYMODEL::CONSTANT:


### PR DESCRIPTION
## Proposed Changes

This pull request restricts the use of  the FLUID_MIXTURE model only when the KIND_SCALAR_MODEL is SPECIES_TRANSPORT. 


## Related Work

Reported in CDF-Online
https://www.cfd-online.com/Forums/su2/257519-kind_scalar_model-mixture.html


## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [ x] I am submitting my contribution to the develop branch.
- [ x] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [ x] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [ ] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
