### PR TITLE
Corrections to SA implementation

### DIFF
--- a/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
+++ b/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
@@ -48,7 +48,7 @@ struct CSAVariables {
   const su2double cb2_sigma = cb2 / sigma;
   const su2double cw1 = cb1 / k2 + (1 + cb2) / sigma;
   const su2double cr1 = 0.5;
-  const su2double CRot = 1.0;
+  const su2double CRot = 2.0;
   const su2double c2 = 0.7, c3 = 0.9;
 
   /*--- List of auxiliary functions ---*/

--- a/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
+++ b/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
@@ -189,12 +189,10 @@ class CSourceBase_TurbSA : public CNumerics {
 
       /*--- Dacles-Mariani et. al. rotation correction ("-R"). ---*/
       if (options.rot) {
-        if (ScalarVar_i[0] > 0) {
-          var.Prod = var.Shat + var.CRot * min(0.0, StrainMag_i - var.Omega);
-        } else {
+        var.Prod += var.CRot * min(0.0, StrainMag_i - var.Omega);
+        
         /*--- Do not allow negative production for SA-neg. ---*/
-          var.Prod = abs(var.Omega + var.CRot * min(0.0, StrainMag_i - var.Omega));
-        }
+        if (ScalarVar_i[0] < 0) var.Prod = abs(var.Prod);
       }
 
       /*--- Compute ft2 term ---*/
@@ -239,7 +237,6 @@ class CSourceBase_TurbSA : public CNumerics {
       } else if (transition_LM){
 
         var.intermittency = intermittency_eff_i;
-        //var.intermittency = 1.0;
         // Is wrong the reference from NASA?
         // Original max(min(gamma, 0.5), 1.0) always gives 1 as result.
         var.interDestrFactor = min(max(intermittency_i, 0.5), 1.0);

--- a/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
+++ b/SU2_CFD/include/numerics/turbulent/turb_sources.hpp
@@ -185,7 +185,7 @@ class CSourceBase_TurbSA : public CNumerics {
       /*--- Compute modified vorticity ---*/
       ModVort::get(ScalarVar_i[0], nu, var);
       var.inv_Shat = 1.0 / var.Shat;
-      var.Prod = var.SHat;
+      var.Prod = var.Shat;
 
       /*--- Dacles-Mariani et. al. rotation correction ("-R"). ---*/
       if (options.rot) {


### PR DESCRIPTION
## Proposed Changes
The CRot value was set to 1.0 for the HLPW5 but the standard value is 2.0 as suggested in TMR. Plus, there may be some inconsistencies with the negative branch of SA when used with the R variant. $\hat{S}$ should be used in the computation of the production term when $\hat{\nu}>0$. When $\hat{\nu}<0$, instead, the vorticity $\Omega$ should be used together with the $c_{t3}$ constant. Citing TMR:

"This model is the same as the "standard" version (SA), except that the (SA-R) production term becomes: 

$c_{b1}(1-f_{t2})[\hat{S}+C_{rot}min(0,S-\Omega)]\hat{\nu}$

...

However, a negative production term is not acceptable for the negative branch ($\hat{\nu} < 0$) of the (SA-neg) model. If coding (SA-neg-R), a possible C0 continuous production term in the negative (SA-neg-R) branch is the following: 

$c_{b1}(1-c_{t3})[\hat{\Omega}+C_{rot}min(0,S-\Omega)]\hat{\nu}$

"

I don't understand if the second production term has to be used everytime  SA-neg is considered or only at the points where $\hat{\nu}<0$.

If it is already taken into account, then I'll modify the PR.

## Related Work


## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [X] I am submitting my contribution to the develop branch.
- [ ] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [ ] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [ ] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
