### PR TITLE
Feature CFL adaptation initial iteration

### DIFF
--- a/Common/include/CConfig.hpp
+++ b/Common/include/CConfig.hpp
@@ -1109,7 +1109,7 @@ private:
   bool Radiation;                      /*!< \brief Determines if a radiation model is incorporated. */
   su2double CFL_Rad;                   /*!< \brief CFL Number for the radiation solver. */
 
-  array<su2double,5> default_cfl_adapt;  /*!< \brief Default CFL adapt param array for the COption class. */
+  array<su2double,6> default_cfl_adapt;  /*!< \brief Default CFL adapt param array for the COption class. */
   su2double vel_init[3], /*!< \brief initial velocity array for the COption class. */
   vel_inf[3],            /*!< \brief freestream velocity array for the COption class. */
   eng_cyl[7],            /*!< \brief engine box array for the COption class. */

--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -1777,11 +1777,11 @@ void CConfig::SetConfig_Options() {
   /* DESCRIPTION: Activate The adaptive CFL number. */
   addBoolOption("CFL_ADAPT", CFL_Adapt, false);
   /* !\brief CFL_ADAPT_PARAM
-   * DESCRIPTION: Parameters of the adaptive CFL number (factor down, factor up, CFL limit (min and max), acceptable linear residual )
+   * DESCRIPTION: Parameters of the adaptive CFL number (factor down, factor up, CFL limit (min and max)[, acceptable linear residual][, starting iteration]).
    * Factor down generally <1.0, factor up generally > 1.0 to cause the CFL to increase when the under-relaxation parameter is 1.0
    * and to decrease when the under-relaxation parameter is less than 0.1. Factor is multiplicative. \ingroup Config*/
   default_cfl_adapt[0] = 1.0; default_cfl_adapt[1] = 1.0; default_cfl_adapt[2] = 10.0; default_cfl_adapt[3] = 100.0;
-  default_cfl_adapt[4] = 0.001;
+  default_cfl_adapt[4] = 0.001; default_cfl_adapt[5] = 0.0;
   addDoubleListOption("CFL_ADAPT_PARAM", nCFL_AdaptParam, CFL_AdaptParam);
   /* DESCRIPTION: Reduction factor of the CFL coefficient in the adjoint problem */
   addDoubleOption("CFL_REDUCTION_ADJFLOW", CFLRedCoeff_AdjFlow, 0.8);
@@ -7230,7 +7230,8 @@ void CConfig::SetOutput(SU2_COMPONENT val_software, unsigned short val_izone) {
       if (!CFL_Adapt) cout << "No CFL adaptation." << endl;
       else cout << "CFL adaptation. Factor down: "<< CFL_AdaptParam[0] <<", factor up: "<< CFL_AdaptParam[1]
         <<",\n                lower limit: "<< CFL_AdaptParam[2] <<", upper limit: " << CFL_AdaptParam[3]
-        <<",\n                acceptable linear residual: "<< CFL_AdaptParam[4] << "." << endl;
+        <<",\n                acceptable linear residual: "<< CFL_AdaptParam[4]
+        <<"'\n                starting iteration: "<< CFL_AdaptParam[5] << "." << endl;
 
       if (nMGLevels !=0) {
         PrintingToolbox::CTablePrinter MGTable(&std::cout);

--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -1781,7 +1781,7 @@ void CConfig::SetConfig_Options() {
    * Parameters in square brackets are optional, parameter "starting iteration" only valid with parameter "acceptable linear residual".
    * Factor down generally <1.0, factor up generally > 1.0 to cause the CFL to increase when the under-relaxation parameter is 1.0
    * and to decrease when the under-relaxation parameter is less than 0.1. Factor is multiplicative. \ingroup Config*/
-  default_cfl_adapt[0] = 1.0; default_cfl_adapt[1] = 1.0; default_cfl_adapt[2] = 10.0; default_cfl_adapt[3] = 100.0;
+  default_cfl_adapt[0] = 0.1; default_cfl_adapt[1] = 2.0; default_cfl_adapt[2] = 10.0; default_cfl_adapt[3] = 1e10;
   default_cfl_adapt[4] = 0.001; default_cfl_adapt[5] = 0.0;
   addDoubleListOption("CFL_ADAPT_PARAM", nCFL_AdaptParam, CFL_AdaptParam);
   /* DESCRIPTION: Reduction factor of the CFL coefficient in the adjoint problem */

--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -1781,8 +1781,12 @@ void CConfig::SetConfig_Options() {
    * Parameters in square brackets are optional, parameter "starting iteration" only valid with parameter "acceptable linear residual".
    * Factor down generally <1.0, factor up generally > 1.0 to cause the CFL to increase when the under-relaxation parameter is 1.0
    * and to decrease when the under-relaxation parameter is less than 0.1. Factor is multiplicative. \ingroup Config*/
-  default_cfl_adapt[0] = 0.1; default_cfl_adapt[1] = 2.0; default_cfl_adapt[2] = 10.0; default_cfl_adapt[3] = 1e10;
-  default_cfl_adapt[4] = 0.001; default_cfl_adapt[5] = 0.0;
+  default_cfl_adapt[0] = 0.1;
+  default_cfl_adapt[1] = 1.2;
+  default_cfl_adapt[2] = 10.0;
+  default_cfl_adapt[3] = 100.0;
+  default_cfl_adapt[4] = 0.001;
+  default_cfl_adapt[5] = 0.0;
   addDoubleListOption("CFL_ADAPT_PARAM", nCFL_AdaptParam, CFL_AdaptParam);
   /* DESCRIPTION: Reduction factor of the CFL coefficient in the adjoint problem */
   addDoubleOption("CFL_REDUCTION_ADJFLOW", CFLRedCoeff_AdjFlow, 0.8);

--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -1778,6 +1778,7 @@ void CConfig::SetConfig_Options() {
   addBoolOption("CFL_ADAPT", CFL_Adapt, false);
   /* !\brief CFL_ADAPT_PARAM
    * DESCRIPTION: Parameters of the adaptive CFL number (factor down, factor up, CFL limit (min and max)[, acceptable linear residual][, starting iteration]).
+   * Parameters in square brackets are optional, parameter "starting iteration" only valid with parameter "acceptable linear residual".
    * Factor down generally <1.0, factor up generally > 1.0 to cause the CFL to increase when the under-relaxation parameter is 1.0
    * and to decrease when the under-relaxation parameter is less than 0.1. Factor is multiplicative. \ingroup Config*/
   default_cfl_adapt[0] = 1.0; default_cfl_adapt[1] = 1.0; default_cfl_adapt[2] = 10.0; default_cfl_adapt[3] = 100.0;

--- a/SU2_CFD/src/solvers/CSolver.cpp
+++ b/SU2_CFD/src/solvers/CSolver.cpp
@@ -1717,6 +1717,7 @@ void CSolver::AdaptCFLNumber(CGeometry **geometry,
   const su2double CFLMin            = config->GetCFL_AdaptParam(2);
   const su2double CFLMax            = config->GetCFL_AdaptParam(3);
   const su2double acceptableLinTol  = config->GetCFL_AdaptParam(4);
+  const su2double startingIter      = config->GetCFL_AdaptParam(5);
   const bool fullComms              = (config->GetComm_Level() == COMM_FULL);
 
   /* Number of iterations considered to check for stagnation. */
@@ -1764,8 +1765,11 @@ void CSolver::AdaptCFLNumber(CGeometry **geometry,
 
     /* Check if we should decrease or if we can increase, the 20% is to avoid flip-flopping. */
     resetCFL = linRes > 0.99;
-    reduceCFL = linRes > 1.2*linTol;
-    canIncrease = linRes < linTol;
+    
+    /* only change CFL number when larger than starting iteration */
+    reduceCFL = linRes > 1.2*linTol && (config->GetOuterIter() > startingIter);
+
+    canIncrease = (linRes < linTol) && (config->GetOuterIter() > startingIter);
 
     if ((iMesh == MESH_0) && (Res_Count > 0)) {
       Old_Func = New_Func;

--- a/SU2_CFD/src/solvers/CSolver.cpp
+++ b/SU2_CFD/src/solvers/CSolver.cpp
@@ -1765,7 +1765,8 @@ void CSolver::AdaptCFLNumber(CGeometry **geometry,
 
     /* Check if we should decrease or if we can increase, the 20% is to avoid flip-flopping. */
     resetCFL = linRes > 0.99;
-    
+unsigned long iter = config->GetMultizone_Problem() ? config->GetOuterIter() : config->GetInnerIter();
+
     /* only change CFL number when larger than starting iteration */
     reduceCFL = linRes > 1.2*linTol && (config->GetOuterIter() > startingIter);
 

--- a/SU2_CFD/src/solvers/CSolver.cpp
+++ b/SU2_CFD/src/solvers/CSolver.cpp
@@ -1765,12 +1765,12 @@ void CSolver::AdaptCFLNumber(CGeometry **geometry,
 
     /* Check if we should decrease or if we can increase, the 20% is to avoid flip-flopping. */
     resetCFL = linRes > 0.99;
-unsigned long iter = config->GetMultizone_Problem() ? config->GetOuterIter() : config->GetInnerIter();
+    unsigned long iter = config->GetMultizone_Problem() ? config->GetOuterIter() : config->GetInnerIter();
 
     /* only change CFL number when larger than starting iteration */
-    reduceCFL = linRes > 1.2*linTol && (config->GetOuterIter() > startingIter);
+    reduceCFL = linRes > 1.2*linTol && (iter > startingIter);
 
-    canIncrease = (linRes < linTol) && (config->GetOuterIter() > startingIter);
+    canIncrease = (linRes < linTol) && (iter > startingIter);
 
     if ((iMesh == MESH_0) && (Res_Count > 0)) {
       Old_Func = New_Func;

--- a/SU2_CFD/src/solvers/CSolver.cpp
+++ b/SU2_CFD/src/solvers/CSolver.cpp
@@ -1768,9 +1768,9 @@ void CSolver::AdaptCFLNumber(CGeometry **geometry,
     unsigned long iter = config->GetMultizone_Problem() ? config->GetOuterIter() : config->GetInnerIter();
 
     /* only change CFL number when larger than starting iteration */
-    reduceCFL = linRes > 1.2*linTol && (iter > startingIter);
+    reduceCFL = (linRes > 1.2*linTol) && (iter >= startingIter);
 
-    canIncrease = (linRes < linTol) && (iter > startingIter);
+    canIncrease = (linRes < linTol) && (iter >= startingIter);
 
     if ((iMesh == MESH_0) && (Res_Count > 0)) {
       Old_Func = New_Func;

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -1390,8 +1390,8 @@ CFL_ADAPT= NO
 %
 % Parameters of the adaptive CFL number (factor-down, factor-up, CFL min value,
 %                                        CFL max value, acceptable linear solver convergence, starting iteration)
-% After the starting iteration has passed, local CFL increases by factor-up until max if the solution rate of change is not limited,
-% and acceptable linear convergence is achieved. It is reduced if rate is limited, or if there
+% After the starting iteration has passed, local CFL increases by factor-up until max if the solution rate of
+% change is not limited, and acceptable linear convergence is achieved. It is reduced if rate is limited, or if there
 % is not enough linear convergence, or if the nonlinear residuals are stagnant and oscillatory.
 % It is reset back to min when linear solvers diverge, or if nonlinear residuals increase too much.
 CFL_ADAPT_PARAM= ( 0.1, 2.0, 10.0, 1e10, 0.001, 0)

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -1389,12 +1389,12 @@ CFL_NUMBER= 15.0
 CFL_ADAPT= NO
 %
 % Parameters of the adaptive CFL number (factor-down, factor-up, CFL min value,
-%                                        CFL max value, acceptable linear solver convergence)
-% Local CFL increases by factor-up until max if the solution rate of change is not limited,
+%                                        CFL max value, acceptable linear solver convergence, starting iteration)
+% After the starting iteration has passed, local CFL increases by factor-up until max if the solution rate of change is not limited,
 % and acceptable linear convergence is achieved. It is reduced if rate is limited, or if there
 % is not enough linear convergence, or if the nonlinear residuals are stagnant and oscillatory.
 % It is reset back to min when linear solvers diverge, or if nonlinear residuals increase too much.
-CFL_ADAPT_PARAM= ( 0.1, 2.0, 10.0, 1e10, 0.001 )
+CFL_ADAPT_PARAM= ( 0.1, 2.0, 10.0, 1e10, 0.001, 1)
 %
 % Maximum Delta Time in local time stepping simulations
 MAX_DELTA_TIME= 1E6

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -1394,7 +1394,7 @@ CFL_ADAPT= NO
 % and acceptable linear convergence is achieved. It is reduced if rate is limited, or if there
 % is not enough linear convergence, or if the nonlinear residuals are stagnant and oscillatory.
 % It is reset back to min when linear solvers diverge, or if nonlinear residuals increase too much.
-CFL_ADAPT_PARAM= ( 0.1, 2.0, 10.0, 1e10, 0.001, 1)
+CFL_ADAPT_PARAM= ( 0.1, 2.0, 10.0, 1e10, 0.001, 0)
 %
 % Maximum Delta Time in local time stepping simulations
 MAX_DELTA_TIME= 1E6


### PR DESCRIPTION
A spark initialization was not possible with CFL adaptation, as the CFL number would increase too far before the spark initiates the combustion. This led to immediate flashback or blow-off. An additional parameter in the CFL adaptation defines the iteration, at which the CFL adaption should start. This allows the combustion to stabilize before the CFL number increases. Before the initial iterations has not started, the CFL number does not get adapted in either direction.