### PR TITLE
[WIP] Thermal stress computation for Neo-Hookean material model

### DIFF
--- a/SU2_CFD/src/numerics/elasticity/nonlinear_models.cpp
+++ b/SU2_CFD/src/numerics/elasticity/nonlinear_models.cpp
@@ -109,10 +109,18 @@ void CFEM_NeoHookean_Comp::Compute_Stress_Tensor(CElement *element, const CConfi
     Lambda_J = Lambda/J_F;
   }
 
+ /*--- Thermal stress parameters ---*/
+  su2double alpha = config->GetThermal_Expansion_Coeff(); // Coefficient of thermal expansion
+  su2double delta_T = element->GetTemperature() - config->GetTemperature_Ref(); // Temperature difference
+  su2double thermal_stress = (Lambda + 2 * Mu) * alpha * delta_T; // Thermal stress contribution
+
   for (iVar = 0; iVar < 3; iVar++) {
     for (jVar = 0; jVar < 3; jVar++) {
       su2double dij = deltaij(iVar,jVar);
       Stress_Tensor[iVar][jVar] = Mu_J * (b_Mat[iVar][jVar] - dij) + Lambda_J * log(J_F) * dij;
+      if (iVar == jVar) {
+        Stress_Tensor[iVar][jVar] -= thermal_stress; // Subtract isotropic thermal stress
+      }
     }
   }
 


### PR DESCRIPTION
## Proposed Changes
This pull request adds the capability to compute thermal stresses in Neo-Hookean materials in SU2. It includes:
- Updates to the `CFEM_NeoHookean_Comp` class to incorporate thermal stress contributions under CFEM_NeoHookean_Comp::Compute_Stress_Tensor.
- Extensions to the `CElement` class for handling temperature at the element and nodal levels.
- Used integration of configuration parameters (`Thermal Expansion Coefficient`, `Reference Temperature`) to update stress tensor
- Pending: Add test case for *Single-Element Thermoelastic Test* to test implementation.

## Related Work
This feature addresses thermal stress computation for the nonlinear elasticity module. It sets the groundwork for future problems, such as thermoelasticity in bimetallic strips. No specific issues or PRs are related.

## PR Checklist

- [ X ] I am submitting my contribution to the develop branch.
- [ ] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [ X ] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [ ] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
