### PR TITLE
Fix #2203 : Improve Spanwise Section Error Handling in Turbomachinery Simulations

### DIFF
--- a/Common/src/geometry/CPhysicalGeometry.cpp
+++ b/Common/src/geometry/CPhysicalGeometry.cpp
@@ -4986,9 +4986,9 @@ void CPhysicalGeometry::ComputeNSpan(CConfig* config, unsigned short val_iZone, 
         SPRINTF(buf, "nSpan inflow %u, nSpan outflow %u", nSpanWiseSections[INFLOW - 1],
                 nSpanWiseSections[OUTFLOW - 1]);
         SU2_MPI::Error(
-        string("Turbomachinery simulation requires equal spanwise sections at INFLOW and OUTFLOW. ") + buf +
-        "\nThis is likely a mesh issue. Ensure that the periodic boundaries from hub to shroud are consistently defined in the mesh.",
-        CURRENT_FUNCTION);
+            string("Turbomachinery simulation requires equal spanwise sections at INFLOW and OUTFLOW. ") + buf +
+            "\nThis is likely a mesh issue. Ensure that the periodic boundaries from hub to shroud are consistently defined in the mesh.",
+            CURRENT_FUNCTION);
       } else {
         config->SetnSpanWiseSections(nSpanWiseSections[OUTFLOW - 1]);
       }

--- a/Common/src/geometry/CPhysicalGeometry.cpp
+++ b/Common/src/geometry/CPhysicalGeometry.cpp
@@ -4803,6 +4803,13 @@ void CPhysicalGeometry::ComputeNSpan(CConfig* config, unsigned short val_iZone, 
       nSpan_loc = nSpan;
       SU2_MPI::Allreduce(&nSpan_loc, &nSpan, 1, MPI_INT, MPI_SUM, SU2_MPI::GetComm());
       SU2_MPI::Allreduce(&nSpan_loc, &nSpan_max, 1, MPI_INT, MPI_MAX, SU2_MPI::GetComm());
+      if (nSpan < 2) {
+        string marker_name = (marker_flag == INFLOW) ? "INFLOW" : "OUTFLOW";
+        SU2_MPI::Error("Failed to compute spanwise sections for " + marker_name + 
+                       ". Found " + to_string(nSpan) + " nodes along the periodic boundary edge from hub to shroud. " +
+                       "At least 2 nodes are required. Check your mesh for correct hub-to-shroud edge definition.",
+                       CURRENT_FUNCTION);
+      }
 
       /*--- initialize the vector that will contain the disordered values span-wise ---*/
       nSpanWiseSections[marker_flag - 1] = nSpan;
@@ -4979,9 +4986,9 @@ void CPhysicalGeometry::ComputeNSpan(CConfig* config, unsigned short val_iZone, 
         SPRINTF(buf, "nSpan inflow %u, nSpan outflow %u", nSpanWiseSections[INFLOW - 1],
                 nSpanWiseSections[OUTFLOW - 1]);
         SU2_MPI::Error(
-            string(" At the moment only turbomachinery with the same amount of span-wise section can be simulated\n") +
-                buf,
-            CURRENT_FUNCTION);
+        string("Turbomachinery simulation requires equal spanwise sections at INFLOW and OUTFLOW. ") + buf +
+        "\nThis is likely a mesh issue. Ensure that the periodic boundaries from hub to shroud are consistently defined in the mesh.",
+        CURRENT_FUNCTION);
       } else {
         config->SetnSpanWiseSections(nSpanWiseSections[OUTFLOW - 1]);
       }


### PR DESCRIPTION
## Proposed Changes

This PR aims to:
- Modify ComputeNSpan in CPhysicalGeometry.cpp to throw a detailed error if fewer than 2 spanwise sections are detected, prompting users to verify hub-to-shroud edge definitions in their mesh.
- Improve the error message for unequal inflow and outflow spanwise sections, clarifying it’s likely a mesh issue and recommending mesh regeneration.



## Related Work
- Fixes #2203 : Wrong spanwise sections calculation in Turbomachinery simulation.



## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [X] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [X] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
