### PR TITLE
Made sure the CGNS reader works again for high order grids

### DIFF
--- a/Common/src/geometry/meshreader/CCGNSMeshReaderBase.cpp
+++ b/Common/src/geometry/meshreader/CCGNSMeshReaderBase.cpp
@@ -320,21 +320,32 @@ void CCGNSMeshReaderBase::ReadCGNSSectionMetadata() {
     /* Check for 1D elements in 2D problems, or for 2D elements in
      3D problems. If found, mark the section as a boundary section. */
 
-    if(dimension == 2) {
-      switch( elemType ) {
-        case BAR_2: case BAR_3: case BAR_4: case BAR_5:
+    if (dimension == 2) {
+      switch (elemType) {
+        case BAR_2:
+        case BAR_3:
+        case BAR_4:
+        case BAR_5:
           isInterior[s] = false;
           break;
         default:  // To avoid a compiler warning.
           break;
       }
-    }
-    else {
-      switch( elemType ) {
-        case TRI_3:  case TRI_6:   case TRI_9:   case TRI_10:
-        case TRI_12: case TRI_15:
-        case QUAD_4:  case QUAD_8:     case QUAD_9:  case QUAD_12:
-        case QUAD_16: case QUAD_P4_16: case QUAD_25:
+    } else {
+      switch (elemType) {
+        case TRI_3:
+        case TRI_6:
+        case TRI_9:
+        case TRI_10:
+        case TRI_12:
+        case TRI_15:
+        case QUAD_4:
+        case QUAD_8:
+        case QUAD_9:
+        case QUAD_12:
+        case QUAD_16:
+        case QUAD_P4_16:
+        case QUAD_25:
           isInterior[s] = false;
           break;
         default:  // To avoid a compiler warning.

--- a/Common/src/geometry/meshreader/CCGNSMeshReaderBase.cpp
+++ b/Common/src/geometry/meshreader/CCGNSMeshReaderBase.cpp
@@ -320,8 +320,27 @@ void CCGNSMeshReaderBase::ReadCGNSSectionMetadata() {
     /* Check for 1D elements in 2D problems, or for 2D elements in
      3D problems. If found, mark the section as a boundary section. */
 
-    if ((dimension == 2) && (elemType == BAR_2 || elemType == BAR_3)) isInterior[s] = false;
-    if ((dimension == 3) && (elemType == TRI_3 || elemType == QUAD_4)) isInterior[s] = false;
+    if(dimension == 2) {
+      switch( elemType ) {
+        case BAR_2: case BAR_3: case BAR_4: case BAR_5:
+          isInterior[s] = false;
+          break;
+        default:  // To avoid a compiler warning.
+          break;
+      }
+    }
+    else {
+      switch( elemType ) {
+        case TRI_3:  case TRI_6:   case TRI_9:   case TRI_10:
+        case TRI_12: case TRI_15:
+        case QUAD_4:  case QUAD_8:     case QUAD_9:  case QUAD_12:
+        case QUAD_16: case QUAD_P4_16: case QUAD_25:
+          isInterior[s] = false;
+          break;
+        default:  // To avoid a compiler warning.
+          break;
+      }
+    }
 
     /*--- Increment the global element offset for each section
      based on whether or not this is a surface or volume section.

--- a/Common/src/geometry/meshreader/CCGNSMeshReaderFEM.cpp
+++ b/Common/src/geometry/meshreader/CCGNSMeshReaderFEM.cpp
@@ -39,6 +39,9 @@ CCGNSMeshReaderFEM::CCGNSMeshReaderFEM(const CConfig* val_config, unsigned short
   ReadCGNSDatabaseMetadata();
   ReadCGNSZoneMetadata();
 
+  /*--- Read the basic information about the sections. ---*/
+  ReadCGNSSectionMetadata();
+
   /*--- Read the volume connectivity and distribute it
         linearly over the MPI ranks. ---*/
   ReadCGNSVolumeElementConnectivity();


### PR DESCRIPTION
## Proposed Changes
I forgot to push the last commit in a previous PR, which fixed the reading of high order CGNS grid files.



## Related Work
Bug fix for PR #2440 



## PR Checklist

- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [X] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [X] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
