### PR TITLE
cpp version increase for CoDiPack

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,6 @@ project('SU2', 'c', 'cpp',
                           'c_std=c99',
                           'cpp_std=c++17'])
 
-
 fsmod = import('fs')
 if not fsmod.exists('su2preconfig.timestamp')
   error('SU2 must be (pre-)configured with the extended Meson script (./meson.py) or with the ./preconfigure.py script in the SU2 root directory.')

--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,8 @@ project('SU2', 'c', 'cpp',
         default_options: ['buildtype=release',
                           'warning_level=0',
                           'c_std=c99',
-                          'cpp_std=c++11'])
+                          'cpp_std=c++17'])
+
 
 fsmod = import('fs')
 if not fsmod.exists('su2preconfig.timestamp')


### PR DESCRIPTION
## Proposed Changes
Change the basic cpp version of SU2 to Cpp17 for CoDiPack v3.

## Related Work
For the next release of CoDiPack we want to change the Cpp version of CoDiPack to Cpp17.

# Other options
I tried not to change the global cpp version of SU2, but all attempts did not work.
 - Using override options for the SU2_CFD_AD exec. Meson still used cpp11
 ```
diff --git a/SU2_CFD/src/meson.build b/SU2_CFD/src/meson.build
index 3b40822a34..a7246bcbf1 100644
--- a/SU2_CFD/src/meson.build
+++ b/SU2_CFD/src/meson.build
@@ -214,8 +214,9 @@ if get_option('enable-autodiff')
   su2_cfd_lib_ad = static_library('SU2core_AD',
                                su2_cfd_src,
                                install : false,
-		               dependencies : [su2_deps, codi_dep, commonAD_dep],
-                               cpp_args: [default_warning_flags, su2_cpp_args, codi_rev_args])
+                               dependencies : [su2_deps, codi_dep, commonAD_dep],
+                               cpp_args: [default_warning_flags, su2_cpp_args, codi_rev_args],
+                               override_options: ['cpp_std=c++17'])
   su2_cfd_dep_ad = declare_dependency(link_with: su2_cfd_lib_ad,
                                    include_directories: su2_cfd_include)
   su2_cfd_ad = executable('SU2_CFD_AD',
@@ -223,6 +224,7 @@ if get_option('enable-autodiff')
                           install : true,
                           dependencies : [su2_cfd_dep_ad, su2_deps, codi_dep, commonAD_dep],
                           cpp_args: ['-fPIC'] + [default_warning_flags, su2_cpp_args, codi_rev_args] + profiling_args,
+                          override_options: ['cpp_std=c++17'],
                           link_args: profiling_args)
 endif

```
- Adding and if before the project: Not allowed
- Using a ternarry in the project: Command line arguments are not available yet.
- Changing these default project options afterwards is not possible.
- Leaving the cpp option and adding compiler flags afterwards: This would probably work but does not allow the user anymore to overwrite it via the command line.

Maybe I missed something, but changing the version globally has currently the least headaches. 

Is there some documentation that needs to be changed?

## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [ X] I am submitting my contribution to the develop branch.
- [ X] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [ X] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [ X] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [ X] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
