### PR TITLE
Option to use inlet normal for compressible inlets

### DIFF
--- a/Common/include/CConfig.hpp
+++ b/Common/include/CConfig.hpp
@@ -627,7 +627,7 @@ private:
   unsigned short nInc_Outlet;      /*!< \brief Number of inlet boundary treatment types listed. */
   su2double Inc_Inlet_Damping;     /*!< \brief Damping factor applied to the iterative updates to the velocity at a pressure inlet in incompressible flow. */
   su2double Inc_Outlet_Damping;    /*!< \brief Damping factor applied to the iterative updates to the pressure at a mass flow outlet in incompressible flow. */
-  bool Inc_Inlet_UseNormal;        /*!< \brief Flag for whether to use the local normal as the flow direction for an incompressible pressure inlet. */
+  bool Inlet_UseNormal;        /*!< \brief Flag for whether to use the local normal as the flow direction for an (in)compressible pressure inlet. */
   su2double Linear_Solver_Error;   /*!< \brief Min error of the linear solver for the implicit formulation. */
   su2double Deform_Linear_Solver_Error;          /*!< \brief Min error of the linear solver for the implicit formulation. */
   su2double Linear_Solver_Smoother_Relaxation;   /*!< \brief Relaxation factor for iterative linear smoothers. */
@@ -5064,7 +5064,7 @@ public:
    * \brief Flag for whether the local boundary normal is used as the flow direction for an incompressible pressure inlet.
    * \return <code>FALSE</code> means the prescribed flow direction is used.
    */
-  bool GetInc_Inlet_UseNormal(void) const { return Inc_Inlet_UseNormal;}
+  bool Get_Inlet_UseNormal(void) const { return Inlet_UseNormal;}
 
   /*!
    * \brief Get the type of incompressible outlet from the list.

--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -1383,8 +1383,10 @@ void CConfig::SetConfig_Options() {
   addDoubleOption("INC_TEMPERATURE_INIT", Inc_Temperature_Init, 288.15);
   /*!\brief INC_NONDIM \n DESCRIPTION: Non-dimensionalization scheme for incompressible flows. \ingroup Config*/
   addEnumOption("INC_NONDIM", Ref_Inc_NonDim, NonDim_Map, INITIAL_VALUES);
-    /*!\brief INC_INLET_USENORMAL \n DESCRIPTION: Use the local boundary normal for the flow direction with the incompressible pressure inlet. \ingroup Config*/
-  addBoolOption("INC_INLET_USENORMAL", Inc_Inlet_UseNormal, false);
+    /*!\brief INLET_USENORMAL \n DESCRIPTION: Use the local boundary normal for the flow direction with the (in)compressible pressure inlet. \ingroup Config*/
+  addBoolOption("INLET_USENORMAL", Inlet_UseNormal, false);
+  /*--- INC_INLET_USENORMAL is deprecated, we now have INLET_USENORMAL ---*/
+  addBoolOption("INC_INLET_USENORMAL", Inlet_UseNormal, false);
   /*!\brief INC_INLET_DAMPING \n DESCRIPTION: Damping factor applied to the iterative updates to the velocity at a pressure inlet in incompressible flow (0.1 by default). \ingroup Config*/
   addDoubleOption("INC_INLET_DAMPING", Inc_Inlet_Damping, 0.1);
   /*!\brief INC_OUTLET_DAMPING \n DESCRIPTION: Damping factor applied to the iterative updates to the pressure at a mass flow outlet in incompressible flow (0.1 by default). \ingroup Config*/

--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -1383,10 +1383,13 @@ void CConfig::SetConfig_Options() {
   addDoubleOption("INC_TEMPERATURE_INIT", Inc_Temperature_Init, 288.15);
   /*!\brief INC_NONDIM \n DESCRIPTION: Non-dimensionalization scheme for incompressible flows. \ingroup Config*/
   addEnumOption("INC_NONDIM", Ref_Inc_NonDim, NonDim_Map, INITIAL_VALUES);
-    /*!\brief INLET_USENORMAL \n DESCRIPTION: Use the local boundary normal for the flow direction with the (in)compressible pressure inlet. \ingroup Config*/
-  addBoolOption("INLET_USENORMAL", Inlet_UseNormal, false);
+
   /*--- INC_INLET_USENORMAL is deprecated, we now have INLET_USENORMAL ---*/
-  addBoolOption("INC_INLET_USENORMAL", Inlet_UseNormal, false);
+  //addBoolOption("INC_INLET_USENORMAL", Inlet_UseNormal, false);
+
+  /*!\brief INLET_USENORMAL \n DESCRIPTION: Use the local boundary normal for the flow direction with the (in)compressible pressure inlet. \ingroup Config*/
+  addBoolOption("INLET_USENORMAL", Inlet_UseNormal, false);
+
   /*!\brief INC_INLET_DAMPING \n DESCRIPTION: Damping factor applied to the iterative updates to the velocity at a pressure inlet in incompressible flow (0.1 by default). \ingroup Config*/
   addDoubleOption("INC_INLET_DAMPING", Inc_Inlet_Damping, 0.1);
   /*!\brief INC_OUTLET_DAMPING \n DESCRIPTION: Damping factor applied to the iterative updates to the pressure at a mass flow outlet in incompressible flow (0.1 by default). \ingroup Config*/

--- a/SU2_CFD/src/solvers/CEulerSolver.cpp
+++ b/SU2_CFD/src/solvers/CEulerSolver.cpp
@@ -6954,8 +6954,18 @@ void CEulerSolver::BC_Inlet(CGeometry *geometry, CSolver **solver_container,
         T_Total = Inlet_Ttotal[val_marker][iVertex];
         const su2double* dir = Inlet_FlowDir[val_marker][iVertex];
         const su2double mag = GeometryToolbox::Norm(nDim, dir);
-        for (iDim = 0; iDim < nDim; iDim++) {
-          Flow_Dir[iDim] = dir[iDim] / mag;
+
+
+        /*--- Store the unit flow direction vector.
+         If requested, use the local boundary normal (negative),
+         instead of the prescribed flow direction in the config. ---*/
+
+        if (config->Get_Inlet_UseNormal()) {
+          for (iDim = 0; iDim < nDim; iDim++)
+            Flow_Dir[iDim] = -Normal[iDim]/Area;
+        } else {
+          for (iDim = 0; iDim < nDim; iDim++)
+            Flow_Dir[iDim] = dir[iDim]/mag;
         }
 
         /*--- Non-dim. the inputs if necessary. ---*/
@@ -6985,9 +6995,9 @@ void CEulerSolver::BC_Inlet(CGeometry *geometry, CSolver **solver_container,
             from the domain interior. ---*/
 
         Riemann   = 2.0*sqrt(SoundSpeed2)/Gamma_Minus_One;
-        for (iDim = 0; iDim < nDim; iDim++)
+        for (iDim = 0; iDim < nDim; iDim++) {
           Riemann += Velocity[iDim]*UnitNormal[iDim];
-
+        }
         /*--- Total speed of sound ---*/
 
         SoundSpeed_Total2 = Gamma_Minus_One*(H_Total - (Energy + Pressure/Density)+0.5*Velocity2) + SoundSpeed2;
@@ -7070,9 +7080,20 @@ void CEulerSolver::BC_Inlet(CGeometry *geometry, CSolver **solver_container,
         Vel_Mag  = Inlet_Ptotal[val_marker][iVertex];
         const su2double* dir = Inlet_FlowDir[val_marker][iVertex];
         const su2double mag = GeometryToolbox::Norm(nDim, dir);
-        for (iDim = 0; iDim < nDim; iDim++) {
-          Flow_Dir[iDim] = dir[iDim] / mag;
+
+
+        /*--- Store the unit flow direction vector.
+         If requested, use the local boundary normal (negative),
+         instead of the prescribed flow direction in the config. ---*/
+
+        if (config->Get_Inlet_UseNormal()) {
+          for (iDim = 0; iDim < nDim; iDim++)
+            Flow_Dir[iDim] = -Normal[iDim]/Area;
+        } else {
+          for (iDim = 0; iDim < nDim; iDim++)
+            Flow_Dir[iDim] = dir[iDim]/mag;
         }
+
 
         /*--- Non-dim. the inputs if necessary. ---*/
 

--- a/SU2_CFD/src/solvers/CIncEulerSolver.cpp
+++ b/SU2_CFD/src/solvers/CIncEulerSolver.cpp
@@ -2295,7 +2295,7 @@ void CIncEulerSolver::BC_Inlet(CGeometry *geometry, CSolver **solver_container,
      If requested, use the local boundary normal (negative),
      instead of the prescribed flow direction in the config. ---*/
 
-    if (config->GetInc_Inlet_UseNormal()) {
+    if (config->Get_Inlet_UseNormal()) {
       for (iDim = 0; iDim < nDim; iDim++)
         UnitFlowDir[iDim] = -Normal[iDim]/Area;
     } else {

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -290,8 +290,10 @@ INC_INLET_TYPE= VELOCITY_INLET
 % Damping coefficient for iterative updates at pressure inlets. (0.1 by default)
 INC_INLET_DAMPING= 0.1
 %
-% Impose inlet velocity magnitude in the direction of the normal of the inlet face
+% (Deprecated) Impose inlet velocity magnitude in the direction of the normal of the inlet face
 INC_INLET_USENORMAL= NO
+% Impose inlet velocity magnitude in the direction of the normal of the inlet face
+INLET_USENORMAL= NO
 %
 % List of outlet types for incompressible flows. List length must
 % match number of outlet markers. Options: PRESSURE_OUTLET, MASS_FLOW_OUTLET


### PR DESCRIPTION
## Proposed Changes
Use inlet normal for flow direction when INLET_USENORMAL=YES
This is an extension of INC_INLET_USENORMAL to compressible flow. 
INC_INLET_USENORMAL will then be removed.

## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [x] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [x] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
