### PR TITLE
Species mass fractions at inlets not being set correctly when Supersonic inlets are used

### DIFF
--- a/SU2_CFD/src/solvers/CSpeciesSolver.cpp
+++ b/SU2_CFD/src/solvers/CSpeciesSolver.cpp
@@ -427,7 +427,7 @@ su2double CSpeciesSolver::GetInletAtVertex(unsigned short iMarker, unsigned long
 
 void CSpeciesSolver::SetUniformInlet(const CConfig* config, unsigned short iMarker) {
   /*--- Find BC string to the numeric-identifier. ---*/
-  if (config->GetMarker_All_KindBC(iMarker) == INLET_FLOW) {
+  if (config->GetMarker_All_KindBC(iMarker) == INLET_FLOW || config->GetMarker_All_KindBC(iMarker) == SUPERSONIC_INLET) {
     const string Marker_Tag = config->GetMarker_All_TagBound(iMarker);
     for (unsigned long iVertex = 0; iVertex < nVertex[iMarker]; iVertex++) {
       for (unsigned short iVar = 0; iVar < nVar; iVar++) {


### PR DESCRIPTION
## Proposed Changes
Species mass fractions at inlet not being set correctly when Supersonic inlets are used.

Develop:
<img width="1161" height="425" alt="image" src="https://github.com/user-attachments/assets/e780943a-f582-422a-82c0-da47c04d5227" />

Proposed fix:

<img width="1147" height="427" alt="image" src="https://github.com/user-attachments/assets/4a96a538-f499-489c-ac37-8dd05a5ac2d8" />

I have run the swbli vandv case (https://su2code.github.io/vandv/swbli/) adding the following options:

**MARKER_INLET_SPECIES= (inlet, 0.5,0.4)**

**SPECIES_INIT= 0.4,0.3**

in develop, the initial solution is considered at the inlet independently of the values of the species mass fractions given at this marker.
I can add a test case if it is needed.

## Related Work
*Resolve any issues (bug fix or feature request), note any related PRs, or mention interactions with the work of others, if any.*



## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [X] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [ ] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
