### PR TITLE
FIX: Corrected integer division in set_ffd_design_var.py for Python 3…

### DIFF
--- a/SU2_PY/set_ffd_design_var.py
+++ b/SU2_PY/set_ffd_design_var.py
@@ -214,7 +214,7 @@ if options.dim == 3:
     iVariable = 0
     dvList = "DEFINITION_DV= "
     for kIndex in range(options.kOrder):
-        for jIndex in range(1 + options.jOrder / 2):
+        for jIndex in range(1 + options.jOrder // 2):
             for iIndex in range(options.iOrder):
                 iVariable = iVariable + 1
                 dvList = (
@@ -237,7 +237,7 @@ if options.dim == 3:
                     + ", 1.0, 0.0 )"
                 )
                 if iVariable < (
-                    options.iOrder * (1 + options.jOrder / 2) * options.kOrder
+                    options.iOrder * (1 + options.jOrder // 2) * options.kOrder
                 ):
                     dvList = dvList + "; "
 
@@ -249,7 +249,7 @@ if options.dim == 3:
     iVariable = 0
     dvList = "DEFINITION_DV= "
     for kIndex in range(options.kOrder):
-        for jIndex in range(1 + options.jOrder / 2):
+        for jIndex in range(1 + options.jOrder // 2):
             for iIndex in range(options.iOrder):
                 iVariable = iVariable + 1
                 dvList = (
@@ -272,7 +272,7 @@ if options.dim == 3:
                     + ", 0.0, 1.0 )"
                 )
                 if iVariable < (
-                    options.iOrder * (1 + options.jOrder / 2) * options.kOrder
+                    options.iOrder * (1 + options.jOrder // 2) * options.kOrder
                 ):
                     dvList = dvList + "; "
 


### PR DESCRIPTION
## Proposed Changes
This pull request addresses a TypeError in the set_ffd_design_var.py script. The change replaces a floating-point division (/) with integer division (//) to ensure that the arguments passed to the range() function are of the correct type.
This change fixes a bug where the script would fail with the error TypeError: 'float' object cannot be interpreted as an integer. This issue occurs in Python 3 environments because the / operator always produces a float, even when the division result is a whole number. 


## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [X] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [X] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
y