### PR TITLE
Fix for combined objective

### DIFF
--- a/SU2_PY/SU2/eval/functions.py
+++ b/SU2_PY/SU2/eval/functions.py
@@ -179,6 +179,9 @@ def aerodynamics(config, state=None):
     if not "AERO_COEFF" in config["HISTORY_OUTPUT"]:
         config["HISTORY_OUTPUT"].append("AERO_COEFF")
 
+    if not "COMBO" in config["HISTORY_OUTPUT"]:
+        config["HISTORY_OUTPUT"].append("COMBO")
+
     if not "MESH" in state.FILES:
         state.FILES.MESH = config["MESH_FILENAME"]
     special_cases = su2io.get_specialCases(config)


### PR DESCRIPTION
## Proposed Changes

The tutorial did not work out of the box without putting COMBO in the history output, since we do that for AERO_COEFFS in the scrips we can do it for COMBO too.
