### PR TITLE
fix bug in multigrid coloring

### DIFF
--- a/Common/include/toolboxes/graph_toolbox.hpp
+++ b/Common/include/toolboxes/graph_toolbox.hpp
@@ -479,13 +479,16 @@ T createNaturalColoring(Index_t numInnerIndexes) {
  *        pattern is returned.
  * \param[in] pattern - Sparse pattern to be colored.
  * \param[in] groupSize - Size of the outer index groups, default 1.
+ * \param[in] includeOuterIdx - If the outer indices are the same type of entity as
+ *            the inner indices this must be true. For example, when both are point
+ *            indices, i.e. the pattern is the adjacency matrix.
  * \param[in] balanceColors - Try to balance number of indexes per color,
  *            tends to result in worse locality (thus false by default).
  * \param[out] indexColor - Optional, vector with colors given to the outer indices.
  * \return Coloring in the same type of the input pattern.
  */
 template <typename Color_t = unsigned char, size_t MaxColors = 255, size_t MaxMB = 128, class T>
-T colorSparsePattern(const T& pattern, size_t groupSize = 1, bool balanceColors = false,
+T colorSparsePattern(const T& pattern, size_t groupSize = 1, bool includeOuterIdx = false, bool balanceColors = false,
                      std::vector<Color_t>* indexColor = nullptr) {
   static_assert(std::is_integral<Color_t>::value, "");
   static_assert(std::numeric_limits<Color_t>::max() >= MaxColors, "");
@@ -538,6 +541,11 @@ T colorSparsePattern(const T& pattern, size_t groupSize = 1, bool balanceColors 
 
       for (; it != searchOrder.end(); ++it) {
         bool free = true;
+        if (includeOuterIdx) {
+          for (Index_t k = iOuter; k < grpEnd && free; ++k) {
+            free = !innerInColor[*it][k];
+          }
+        }
         /*--- Traverse entire group as a large outer index. ---*/
         for (Index_t k = outerPtr[iOuter]; k < outerPtr[grpEnd] && free; ++k) {
           free = !innerInColor[*it][innerIdx[k] - minIdx];

--- a/Common/src/geometry/CGeometry.cpp
+++ b/Common/src/geometry/CGeometry.cpp
@@ -3772,7 +3772,7 @@ const CCompressedSparsePatternUL& CGeometry::GetEdgeColoring(su2double* efficien
       bool admissibleColoring = false; /* keep track wether the last tested coloring is admissible */
 
       while (true) {
-        edgeColoring = colorSparsePattern(pattern, nextEdgeColorGroupSize, balanceColors);
+        edgeColoring = colorSparsePattern(pattern, nextEdgeColorGroupSize, false, balanceColors);
 
         /*--- If the coloring fails, reduce the color group size. ---*/
         if (edgeColoring.empty()) {
@@ -3809,12 +3809,12 @@ const CCompressedSparsePatternUL& CGeometry::GetEdgeColoring(su2double* efficien
 
       /*--- If the last tested coloring was not admissible, recompute the final coloring. ---*/
       if (!admissibleColoring) {
-        edgeColoring = colorSparsePattern(pattern, edgeColorGroupSize, balanceColors);
+        edgeColoring = colorSparsePattern(pattern, edgeColorGroupSize, false, balanceColors);
       }
     }
     /*--- No adaptivity. ---*/
     else {
-      edgeColoring = colorSparsePattern(pattern, edgeColorGroupSize, balanceColors);
+      edgeColoring = colorSparsePattern(pattern, edgeColorGroupSize, false, balanceColors);
     }
 
     /*--- If the coloring fails use the natural coloring. This is a
@@ -3867,7 +3867,7 @@ const CCompressedSparsePatternUL& CGeometry::GetElementColoring(su2double* effic
 
     /*--- Color the elements. ---*/
     constexpr bool balanceColors = true;
-    elemColoring = colorSparsePattern(pattern, elemColorGroupSize, balanceColors);
+    elemColoring = colorSparsePattern(pattern, elemColorGroupSize, false, balanceColors);
 
     /*--- Same as for the edge coloring. ---*/
     if (elemColoring.empty()) SetNaturalElementColoring();
@@ -3896,7 +3896,7 @@ void CGeometry::ColorMGLevels(unsigned short nMGLevels, const CGeometry* const* 
     /*--- Color the coarse points. ---*/
     vector<tColor> color;
     const auto& adjacency = geometry[iMesh]->nodes->GetPoints();
-    if (colorSparsePattern<tColor, nColor>(adjacency, 1, false, &color).empty()) continue;
+    if (colorSparsePattern<tColor, nColor>(adjacency, 1, true, false, &color).empty()) continue;
 
     /*--- Propagate colors to fine mesh. ---*/
     for (auto step = 0u; step < iMesh; ++step) {
@@ -4042,8 +4042,8 @@ const CGeometry::CLineletInfo& CGeometry::GetLineletInfo(const CConfig* config) 
     }
   }
 
-  const auto coloring =
-      colorSparsePattern<uint8_t, std::numeric_limits<uint8_t>::max()>(CCompressedSparsePatternUL(adjacency), 1, true);
+  const auto coloring = colorSparsePattern<uint8_t, std::numeric_limits<uint8_t>::max()>(
+      CCompressedSparsePatternUL(adjacency), 1, false, true);
   const auto nColors = coloring.getOuterSize();
 
   /*--- Sort linelets by color. ---*/


### PR DESCRIPTION
## Proposed Changes
Nijso found it was wrong. The coloring function needed a mode to consider the outer index (rows) in the coloring (instead of just the inner indices, columns) for this application.
