### PR TITLE
fix(SU2_PY,SU2_CFD): Fix division-by-zero and logic bugs

### DIFF
--- a/SU2_CFD/src/numerics/flow/flow_diffusion.cpp
+++ b/SU2_CFD/src/numerics/flow/flow_diffusion.cpp
@@ -163,7 +163,7 @@ void CAvgGrad_Base::AddTauWall(const su2double *UnitNormal,
   GeometryToolbox::TangentProjection(nDim, tau, UnitNormal, TauTangent);
 
   su2double WallShearStress = GeometryToolbox::Norm(nDim, TauTangent);
-  su2double Scale = TauWall / WallShearStress;
+  su2double Scale = TauWall / fmax(WallShearStress, EPS);
 
   /*--- Scale the stress tensor by the ratio of the wall shear stress
    (from wall functions) to the one computed above. ---*/

--- a/SU2_CFD/src/solvers/CRadP1Solver.cpp
+++ b/SU2_CFD/src/solvers/CRadP1Solver.cpp
@@ -575,7 +575,7 @@ void CRadP1Solver::SetTime_Step(CGeometry *geometry, CSolver **solver_container,
   su2double Area, Vol, Lambda;
   su2double Global_Delta_Time = 1E6, Local_Delta_Time = 0.0, K_v = 0.25;
   su2double CFL = config->GetCFL_Rad();
-  su2double GammaP1 = 1.0 / (3.0*(Absorption_Coeff + Scattering_Coeff));
+  su2double GammaP1 = 1.0 / (3.0*fmax(Absorption_Coeff + Scattering_Coeff, EPS));
   const su2double* Normal;
 
   /*--- Compute spectral radius based on thermal conductivity ---*/

--- a/SU2_PY/SU2/eval/gradients.py
+++ b/SU2_PY/SU2/eval/gradients.py
@@ -259,7 +259,7 @@ def adjoint(func_name, config, state=None):
             name = files["RESTART_FILE_1"]
             name = su2io.expand_part(name, config)
             link.extend(name)
-        if "RESTART_FILE_1" in files:  # not the case for 1st order time stepping
+        if "RESTART_FILE_2" in files:  # not the case for 1st order time stepping
             name = files["RESTART_FILE_2"]
             name = su2io.expand_part(name, config)
             link.extend(name)

--- a/SU2_PY/SU2/io/tools.py
+++ b/SU2_PY/SU2/io/tools.py
@@ -1064,9 +1064,11 @@ def expand_time(name, config):
             name_pat = add_suffix(name, "%05d")
             names = [name_pat % i for i in range(n_start_time, n_time)]
         else:
+            names = []  # Initialize empty list before loop
             for n in range(len(name)):
                 name_pat = add_suffix(name[n], "%05d")
-                names = [name_pat % i for i in range(n_start_time, n_time)]
+                # Use extend() to accumulate all filenames (consistent with expand_zones)
+                names.extend([name_pat % i for i in range(n_start_time, n_time)])
     else:
         if not isinstance(name, list):
             names = [name]


### PR DESCRIPTION
## Proposed Changes

This PR fixes four bugs - two in Python and two in C++:

| # | File | Issue | Fix |
|---|------|-------|-----|
| 1 | `SU2_PY/SU2/io/tools.py` | `expand_time()` loses multi-zone filenames | Use `extend()` instead of reassignment |
| 2 | `SU2_PY/SU2/eval/gradients.py` | Wrong key check (`RESTART_FILE_1` vs `_2`) | Check correct key before access |
| 3 | `SU2_CFD/.../flow_diffusion.cpp` | Division by zero in `AddTauWall` | `fmax(WallShearStress, EPS)` |
| 4 | `SU2_CFD/.../CRadP1Solver.cpp` | Division by zero in `SetTime_Step` | `fmax(Absorption + Scattering, EPS)` |

## Related Work

- Verified all bugs still exist in upstream/develop after PR #2636 merge
- C++ fixes follow existing `fmax(..., EPS)` pattern in codebase

## PR Checklist

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings.
- [x] My contribution is commented and consistent with SU2 style.
- [x] I used the pre-commit hook to prevent dirty commits.
- [x] I have updated appropriate documentation, if necessary.
