### PR TITLE
Axisymmetric near-axis fixes using L’Hôpital-consistent formulations

### DIFF
--- a/SU2_CFD/src/numerics/flow/flow_sources.cpp
+++ b/SU2_CFD/src/numerics/flow/flow_sources.cpp
@@ -241,7 +241,7 @@ CNumerics::ResidualType<> CSourceGeneralAxisymmetric_Flow::ComputeResidual(const
     residual[3] = Volume * rho * Enthalpy_i * dv_dr;  // ρH(∂v/∂r)
 
     if (implicit) {
-      /* For now, set Jacobian to zero at axis (can be improved later). */
+      /* For now, set Jacobian to zero at axis (can be improved later to help with convergence). */
       for (iVar = 0; iVar < nVar; iVar++) {
         for (jVar = 0; jVar < nVar; jVar++)
           jacobian[iVar][jVar] = 0.0;

--- a/SU2_CFD/src/numerics/flow/flow_sources.cpp
+++ b/SU2_CFD/src/numerics/flow/flow_sources.cpp
@@ -66,7 +66,6 @@ CNumerics::ResidualType<> CSourceAxisymmetric_Flow::ComputeResidual(const CConfi
   /*--- Common calculations for both branches ---*/
   su2double rho = U_i[0];                     // density
   su2double u = U_i[1]/U_i[0];                // u-velocity
-  su2double v = U_i[2]/U_i[0];                // v-velocity
   su2double r = Coord_i[1];                   // radial coordinate
   su2double dv_dr = PrimVar_Grad_i[2][1];     // ∂v/∂r (radial velocity gradient)
   


### PR DESCRIPTION
## Proposed Changes
*Give a brief overview of your contribution here in a few sentences.*

- Improve axisymmetric source-term behavior near the symmetry axis by smoothly transitioning between the standard v/r formulation and a L’Hôpital-consistent ∂v/∂r formulation as r→0.
- Apply a L’Hôpital-consistent treatment for axisymmetric auxiliary gradient terms at the axis instead of zeroing them.


## Related Work
*Resolve any issues (bug fix or feature request), note any related PRs, or mention interactions with the work of others, if any.*

- Addresses nonphysical behavior observed in axisymmetric stagnation-region solutions where the 1/r terms become singular near the axis. This PR was prepared for review/discussion with SU2 developers. 
- The standard formulation is preserved away from the axis; the near-axis modification only affects the r→0 limit.

## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [X] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [ ] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
