### PR TITLE
Fix use of DESTDIR with PREFIX in meson

### DIFF
--- a/SU2_PY/pySU2/install.sh
+++ b/SU2_PY/pySU2/install.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-cp "$1/$2" "${MESON_INSTALL_PREFIX}/bin/$2"
+cp "$1/$2" "${MESON_INSTALL_DESTDIR_PREFIX}/bin/$2"


### PR DESCRIPTION
## Proposed Changes
I had to package SU2 by rpm. Doing so I used DESTDIR and PREFIX : 
```
./meson.py build --prefix=%{_prefix}
DESTDIR=%{buildroot} ./ninja -C build install
```
Everything works fine except I had to do a small fix in this file :` SU2_PY/pySU2/install.sh `

## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [x] I am submitting my contribution to the develop branch.
- [ ] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [ ] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [ ] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
