### PR TITLE
option to duplicate markers, to simplify thermoelastic simulations

### DIFF
--- a/Common/include/CConfig.hpp
+++ b/Common/include/CConfig.hpp
@@ -740,6 +740,7 @@ private:
   nMarker_ZoneInterface,              /*!< \brief Number of markers in the zone interface. */
   nMarker_Plotting,                   /*!< \brief Number of markers to plot. */
   nMarker_Analyze,                    /*!< \brief Number of markers to analyze. */
+  nMarker_Create_Copy,                /*!< \brief Number of markers to duplicate. */
   nMarker_Moving,                     /*!< \brief Number of markers in motion (DEFORMING, MOVING_WALL). */
   nMarker_PyCustom,                   /*!< \brief Number of markers that are customizable in Python. */
   nMarker_DV,                         /*!< \brief Number of markers affected by the design variables. */
@@ -751,6 +752,7 @@ private:
   *Marker_GeoEval,                    /*!< \brief Markers to evaluate geometry. */
   *Marker_Plotting,                   /*!< \brief Markers to plot. */
   *Marker_Analyze,                    /*!< \brief Markers to analyze. */
+  *Marker_Create_Copy,                /*!< \brief Markers to duplicate. */
   *Marker_ZoneInterface,              /*!< \brief Markers in the FSI interface. */
   *Marker_Moving,                     /*!< \brief Markers in motion (DEFORMING, MOVING_WALL). */
   *Marker_PyCustom,                   /*!< \brief Markers that are customizable in Python. */
@@ -3452,12 +3454,19 @@ public:
   string GetMarker_HeatFlux_TagBound(unsigned short val_marker) const { return Marker_HeatFlux[val_marker]; }
 
   /*!
+   * \brief Get the list of markers for which to create copies.
+   */
+  std::vector<string> GetMarkerCreateCopy() const {
+    return { Marker_Create_Copy, Marker_Create_Copy + nMarker_Create_Copy };
+  }
+
+  /*!
    * \brief Get the tag if the iMarker defined in the geometry file.
    * \param[in] val_tag - Value of the tag in which we are interested.
    * \return Value of the marker <i>val_marker</i> that is in the geometry file
    *         for the surface that has the tag.
    */
-  short GetMarker_All_TagBound(string val_tag)  {
+  short GetMarker_All_TagBound(const string& val_tag)  {
     for (unsigned short iMarker = 0; iMarker < nMarker_All; iMarker++) {
       if (val_tag == Marker_All_TagBound[iMarker]) return iMarker;
     }

--- a/Common/include/geometry/meshreader/CMeshReaderBase.hpp
+++ b/Common/include/geometry/meshreader/CMeshReaderBase.hpp
@@ -89,6 +89,12 @@ class CMeshReaderBase {
   void GetCornerPointsAllFaces(const unsigned long* elemInfo, unsigned short& numFaces, unsigned short nPointsPerFace[],
                                unsigned long faceConn[6][4]);
 
+  /*!
+   * \brief Creates copies of some markers.
+   * \param[in] srcDstMarkers - List of marker names [src_1, dst_1, ..., src_n, dst_n].
+   */
+  void CopyMarkers(const std::vector<std::string>& srcDstMarkers);
+
  public:
   /*!
    * \brief Constructor of the CMeshReaderBase class.

--- a/Common/include/linear_algebra/CSysMatrix.hpp
+++ b/Common/include/linear_algebra/CSysMatrix.hpp
@@ -148,7 +148,7 @@ class CSysMatrix {
   ScalarType* d_matrix;           /*!< \brief Device Pointer to store the matrix values on the GPU. */
   const unsigned long* d_row_ptr; /*!< \brief Device Pointers to the first element in each row. */
   const unsigned long* d_col_ind; /*!< \brief Device Column index for each of the elements in val(). */
-  bool useCuda;                   /*!< \brief Boolean that indicates whether user has enabled CUDA or not.
+  bool useCuda = false;           /*!< \brief Boolean that indicates whether user has enabled CUDA or not.
                                      Mainly used to conditionally free GPU memory in the class destructor. */
 
   ScalarType* ILU_matrix;           /*!< \brief Entries of the ILU sparse matrix. */

--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -869,7 +869,7 @@ void CConfig::SetPointersNull() {
   Marker_Designing            = nullptr;   Marker_GeoEval           = nullptr;    Marker_Plotting   = nullptr;
   Marker_Analyze              = nullptr;   Marker_PyCustom          = nullptr;    Marker_WallFunctions        = nullptr;
   Marker_CfgFile_KindBC       = nullptr;   Marker_All_KindBC        = nullptr;    Marker_SobolevBC  = nullptr;
-  Marker_StrongBC             = nullptr;
+  Marker_StrongBC             = nullptr;   Marker_Create_Copy       = nullptr;
 
   Kind_WallFunctions       = nullptr;
   IntInfo_WallFunctions    = nullptr;
@@ -1528,6 +1528,9 @@ void CConfig::SetConfig_Options() {
   addStringListOption("MARKER_PLOTTING", nMarker_Plotting, Marker_Plotting);
   /*!\brief MARKER_MONITORING\n DESCRIPTION: Marker(s) of the surface where evaluate the non-dimensional coefficients \ingroup Config*/
   addStringListOption("MARKER_MONITORING", nMarker_Monitoring, Marker_Monitoring);
+
+  /*!\brief MARKER_CREATE_COPY\n DESCRIPTION: Marker(s) for which to create copies when reading the mesh \ingroup Config*/
+  addStringListOption("MARKER_CREATE_COPY", nMarker_Create_Copy, Marker_Create_Copy);
 
   /*!\brief MARKER_CONTROL_VOLUME\n DESCRIPTION: Marker(s) of the surface in the surface flow solution file  \ingroup Config*/
   addStringListOption("MARKER_ANALYZE", nMarker_Analyze, Marker_Analyze);

--- a/Common/src/geometry/meshreader/CBoxMeshReaderFEM.cpp
+++ b/Common/src/geometry/meshreader/CBoxMeshReaderFEM.cpp
@@ -61,6 +61,9 @@ CBoxMeshReaderFEM::CBoxMeshReaderFEM(const CConfig* val_config, unsigned short v
   ComputeBoxVolumeConnectivity();
   ComputeBoxPointCoordinates();
   ComputeBoxSurfaceConnectivity();
+
+  /*--- Duplicate some markers if requested. ---*/
+  CopyMarkers(val_config->GetMarkerCreateCopy());
 }
 
 CBoxMeshReaderFEM::~CBoxMeshReaderFEM() = default;

--- a/Common/src/geometry/meshreader/CBoxMeshReaderFVM.cpp
+++ b/Common/src/geometry/meshreader/CBoxMeshReaderFVM.cpp
@@ -61,6 +61,9 @@ CBoxMeshReaderFVM::CBoxMeshReaderFVM(const CConfig* val_config, unsigned short v
   ComputeBoxPointCoordinates();
   ComputeBoxVolumeConnectivity();
   ComputeBoxSurfaceConnectivity();
+
+  /*--- Duplicate some markers if requested. ---*/
+  CopyMarkers(val_config->GetMarkerCreateCopy());
 }
 
 CBoxMeshReaderFVM::~CBoxMeshReaderFVM() = default;

--- a/Common/src/geometry/meshreader/CCGNSMeshReaderFEM.cpp
+++ b/Common/src/geometry/meshreader/CCGNSMeshReaderFEM.cpp
@@ -58,6 +58,9 @@ CCGNSMeshReaderFEM::CCGNSMeshReaderFEM(const CConfig* val_config, unsigned short
   /*--- We have extracted all CGNS data. Close the CGNS file. ---*/
   if (cg_close(cgnsFileID)) cg_error_exit();
 
+  /*--- Duplicate some markers if requested. ---*/
+  CopyMarkers(val_config->GetMarkerCreateCopy());
+
 #else
   SU2_MPI::Error(string(" SU2 built without CGNS support. \n") + string(" To use CGNS, build SU2 accordingly."),
                  CURRENT_FUNCTION);

--- a/Common/src/geometry/meshreader/CCGNSMeshReaderFVM.cpp
+++ b/Common/src/geometry/meshreader/CCGNSMeshReaderFVM.cpp
@@ -65,6 +65,9 @@ CCGNSMeshReaderFVM::CCGNSMeshReaderFVM(const CConfig* val_config, unsigned short
   ReformatCGNSVolumeConnectivity();
   ReformatCGNSSurfaceConnectivity();
 
+  /*--- Duplicate some markers if requested. ---*/
+  CopyMarkers(val_config->GetMarkerCreateCopy());
+
 #else
   SU2_MPI::Error(string(" SU2 built without CGNS support. \n") + string(" To use CGNS, build SU2 accordingly."),
                  CURRENT_FUNCTION);

--- a/Common/src/geometry/meshreader/CMeshReaderBase.cpp
+++ b/Common/src/geometry/meshreader/CMeshReaderBase.cpp
@@ -93,3 +93,25 @@ void CMeshReaderBase::GetCornerPointsAllFaces(const unsigned long* elemInfo, uns
     }
   }
 }
+
+void CMeshReaderBase::CopyMarkers(const std::vector<std::string>& srcDstMarkers) {
+  for (size_t i = 0; i < srcDstMarkers.size(); i += 2) {
+    const auto& src = srcDstMarkers[i];
+    const auto& dst = srcDstMarkers[i + 1];
+
+    if (const auto it = std::find(markerNames.begin(), markerNames.end(), src); it != markerNames.end()) {
+      const auto j = std::distance(markerNames.begin(), it);
+
+      numberOfMarkers += 1;
+      markerNames.push_back(dst);
+      surfaceElementConnectivity.push_back(surfaceElementConnectivity[j]);
+
+      /*--- Only the FEM readers populate this vector. ---*/
+      if (!numberOfLocalSurfaceElements.empty()) {
+        numberOfLocalSurfaceElements.push_back(numberOfLocalSurfaceElements[j]);
+      }
+    } else if (rank == MASTER_NODE) {
+      std::cout << "WARNING: Not duplicating marker " << src << " because it was not found.\n";
+    }
+  }
+}

--- a/Common/src/geometry/meshreader/CRectangularMeshReaderFEM.cpp
+++ b/Common/src/geometry/meshreader/CRectangularMeshReaderFEM.cpp
@@ -59,6 +59,9 @@ CRectangularMeshReaderFEM::CRectangularMeshReaderFEM(const CConfig* val_config, 
   ComputeRectangularVolumeConnectivity();
   ComputeRectangularPointCoordinates();
   ComputeRectangularSurfaceConnectivity();
+
+  /*--- Duplicate some markers if requested. ---*/
+  CopyMarkers(val_config->GetMarkerCreateCopy());
 }
 
 CRectangularMeshReaderFEM::~CRectangularMeshReaderFEM() = default;

--- a/Common/src/geometry/meshreader/CRectangularMeshReaderFVM.cpp
+++ b/Common/src/geometry/meshreader/CRectangularMeshReaderFVM.cpp
@@ -59,6 +59,9 @@ CRectangularMeshReaderFVM::CRectangularMeshReaderFVM(const CConfig* val_config, 
   ComputeRectangularPointCoordinates();
   ComputeRectangularVolumeConnectivity();
   ComputeRectangularSurfaceConnectivity();
+
+  /*--- Duplicate some markers if requested. ---*/
+  CopyMarkers(val_config->GetMarkerCreateCopy());
 }
 
 CRectangularMeshReaderFVM::~CRectangularMeshReaderFVM() = default;

--- a/Common/src/geometry/meshreader/CSU2ASCIIMeshReaderFEM.cpp
+++ b/Common/src/geometry/meshreader/CSU2ASCIIMeshReaderFEM.cpp
@@ -46,6 +46,9 @@ CSU2ASCIIMeshReaderFEM::CSU2ASCIIMeshReaderFEM(CConfig* val_config, unsigned sho
   /*--- Read the surface connectivity and store the surface elements whose
         corresponding volume element is stored on this MPI rank. ---*/
   ReadSurfaceElementConnectivity({});
+
+  /*--- Duplicate some markers if requested. ---*/
+  CopyMarkers(val_config->GetMarkerCreateCopy());
 }
 
 CSU2ASCIIMeshReaderFEM::~CSU2ASCIIMeshReaderFEM() = default;

--- a/Common/src/geometry/meshreader/CSU2ASCIIMeshReaderFVM.cpp
+++ b/Common/src/geometry/meshreader/CSU2ASCIIMeshReaderFVM.cpp
@@ -69,6 +69,9 @@ CSU2ASCIIMeshReaderFVM::CSU2ASCIIMeshReaderFVM(CConfig* val_config, unsigned sho
     }
   }
   mesh_file.close();
+
+  /*--- Duplicate some markers if requested. ---*/
+  CopyMarkers(val_config->GetMarkerCreateCopy());
 }
 
 CSU2ASCIIMeshReaderFVM::~CSU2ASCIIMeshReaderFVM() = default;

--- a/TestCases/fea_fsi/ThermalBeam_3d/configBeam_3d.cfg
+++ b/TestCases/fea_fsi/ThermalBeam_3d/configBeam_3d.cfg
@@ -8,7 +8,7 @@ SOLVER= ELASTICITY
 MATH_PROBLEM= DIRECT
 GEOMETRIC_CONDITIONS= SMALL_DEFORMATIONS
 MATERIAL_MODEL= LINEAR_ELASTIC
-MESH_FILENAME= meshBeam_3d.su2
+MESH_FILENAME= ../StatBeam_3d/meshBeam_3d.su2
 ELASTICITY_MODULUS=3E7
 POISSON_RATIO=0.3
 MATERIAL_THERMAL_EXPANSION_COEFF= 2e-5
@@ -28,15 +28,17 @@ VOLUME_FILENAME= beam
 RESTART_FILENAME= restart_beam
 SOLUTION_FILENAME= restart_beam
 OUTPUT_WRT_FREQ= 1
-INNER_ITER=1
+INNER_ITER= 1
 
 % Coupling with heat solver.
 WEAKLY_COUPLED_HEAT_EQUATION= YES
 FREESTREAM_TEMPERATURE= 300
 SPECIFIC_HEAT_CP= 460
 THERMAL_CONDUCTIVITY_CONSTANT= 45
-% NOTE: These markers a duplicates of "left" and "right" to allow specifying
-% boundary conditions for both solvers. This is work in progress.
+
+% Copy markers to allow specifying boundary conditions for both solvers on the
+% same markers.
+MARKER_CREATE_COPY= ( left, left_heat, right, right_heat )
 MARKER_ISOTHERMAL= ( left_heat, 400, right_heat, 300 )
 
 NUM_METHOD_GRAD= GREEN_GAUSS

--- a/TestCases/parallel_regression.py
+++ b/TestCases/parallel_regression.py
@@ -298,7 +298,7 @@ def main():
     ramp_msw.cfg_dir = "euler/ramp"
     ramp_msw.cfg_file = "inv_ramp_msw.cfg"
     ramp_msw.test_iter = 100
-    ramp_msw.test_vals = [-7.522451, -1.791193, -0.077520, 0.054427]
+    ramp_msw.test_vals = [-7.478332, -1.740068, -0.077520, 0.054427]
     test_list.append(ramp_msw)
 
     ##########################

--- a/TestCases/parallel_regression.py
+++ b/TestCases/parallel_regression.py
@@ -298,7 +298,7 @@ def main():
     ramp_msw.cfg_dir = "euler/ramp"
     ramp_msw.cfg_file = "inv_ramp_msw.cfg"
     ramp_msw.test_iter = 100
-    ramp_msw.test_vals = [-7.478332, -1.740068, -0.077520, 0.054427]
+    ramp_msw.test_vals = [-7.522451, -1.791193, -0.077520, 0.054427]
     test_list.append(ramp_msw)
 
     ##########################

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -1416,6 +1416,10 @@ MARKER_ANALYZE = ( airfoil )
 %
 % Method to compute the average value in MARKER_ANALYZE (AREA, MASSFLUX).
 MARKER_ANALYZE_AVERAGE = MASSFLUX
+%
+% Duplicate markers while reading the mesh. Currently this is only used for thermoelastic simulations
+% to allow specifying two boundary conditions (thermal and structural) on the same boundary.
+MARKER_CREATE_COPY= ( original_1, copy_1, ..., original_n, copy_n )
 
 % ------------- COMMON PARAMETERS DEFINING THE NUMERICAL METHOD ---------------%
 %


### PR DESCRIPTION
## Proposed Changes
Allows duplicating markers while reading the mesh.


## PR Checklist

- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [X] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [X] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [X] I have added a test case that demonstrates my contribution, if necessary.
- [X] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
