### PR TITLE
Fix cli11 cstdint

### DIFF
--- a/externals/CLI11/CLI11.hpp
+++ b/externals/CLI11/CLI11.hpp
@@ -62,6 +62,7 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
+#include <cstdint>
 
 
 // Verbatim copy from CLI/Version.hpp:


### PR DESCRIPTION
## Proposed Changes
Add a missing <cstdint> include to the vendored CLI11 header. 

GCC 14+ no longer permits transitive inclusion of fixed-width integer types. CLI11.hpp uses uint64_t without including \<cstdint\>, which causes build failures with GCC 15.

## Related Work
None


## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [X] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [ ] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
