### PR TITLE
Fix build on GCC 13+ by explicitly declaring <cstdint> to CLI11   ;

### DIFF
--- a/externals/CLI11/CLI11.hpp
+++ b/externals/CLI11/CLI11.hpp
@@ -40,6 +40,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <deque>
 #include <exception>
 #include <fstream>


### PR DESCRIPTION
## Proposed Changes
GCC 13 and newer removed implicit includes of `<cstdint>` from standard library headers. This causes the build to fail on modern compilers (like GCC 15 on Arch Linux) when compiling the vendorized CLI11 library due to `uint64_t` not being defined. This patch explicitly includes `<cstdint>` in `externals/CLI11/CLI11.hpp` to restore compatibility without breaking older compilers.

## Related Work
Resolves local build failures on rolling-release Linux distributions. 

**System Information:**
* OS: Arch Linux (Kernel 6.18.13-arch1-1)
* Compiler: GCC 15.2.1

**Error Log Addressed:**
`../externals/CLI11/CLI11.hpp:2412:22: error: ‘uint64_t’ does not name a type`
`2412 |     using result_t = uint64_t;`
`     |                      ^~~~~~~~`
`../externals/CLI11/CLI11.hpp:152:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’`

## PR Checklist
- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [x] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [ ] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits. *(Note: Skipped as this is a 1-line fix to a 3rd-party vendor file)*
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary;