### PR TITLE
 Fix CUSTOM_OBJFUNC and TAVG_CUSTOM_OBJFUNC missing from historyMap

### DIFF
--- a/SU2_PY/SU2/io/historyMap.py
+++ b/SU2_PY/SU2/io/historyMap.py
@@ -310,6 +310,20 @@ history_header_map = {
         "HEADER": "ComboObj",
         "TYPE": "COEFFICIENT",
     },
+    # Steady adjoint fix
+    "CUSTOM_OBJFUNC": {
+        "DESCRIPTION": "Custom objective function.",
+        "GROUP": "COMBO",
+        "HEADER": "ComboObj",
+        "TYPE": "COEFFICIENT",
+    },
+    # Unsteady adjoint fix
+    "TAVG_CUSTOM_OBJFUNC": {
+        "DESCRIPTION": "weighted time average value",
+        "GROUP": "TAVG_COMBO",
+        "HEADER": "tavg[ComboObj]",
+        "TYPE": "TAVG_COEFFICIENT",
+    },
     "DEFORM_ITER": {
         "DESCRIPTION": "Linear solver iterations for the mesh " "deformation",
         "GROUP": "DEFORM",

--- a/TestCases/optimization_euler/steady_naca0012/inv_NACA0012_basic.cfg
+++ b/TestCases/optimization_euler/steady_naca0012/inv_NACA0012_basic.cfg
@@ -130,10 +130,15 @@ OUTPUT_WRT_FREQ= 250
 
 % --------------------- OPTIMAL SHAPE DESIGN DEFINITION -----------------------%
 %
-OPT_OBJECTIVE= DRAG * 0.001
+CUSTOM_OUTPUTS= 'P50_avg : AreaAvg{pow(PRESSURE,50)}[airfoil]; P_pnorm50 : Function{pow(P50_avg, 1.0/50.0)}'
+CUSTOM_OBJFUNC= 'P_pnorm50'
+OBJECTIVE_FUNCTION= CUSTOM_OBJFUNC
+OPT_OBJECTIVE= CUSTOM_OBJFUNC * 1.0
 OPT_CONSTRAINT= NONE
-OPT_ITERATIONS= 100
+OPT_ITERATIONS= 2
 OPT_ACCURACY= 1E-6
 OPT_BOUND_UPPER= 0.1
 OPT_BOUND_LOWER= -0.1
 DEFINITION_DV= ( 30, 1.0 | airfoil | 0, 0.05 ); ( 30, 1.0 | airfoil | 0, 0.10 ); ( 30, 1.0 | airfoil | 0, 0.15 ); ( 30, 1.0 | airfoil | 0, 0.20 ); ( 30, 1.0 | airfoil | 0, 0.25 ); ( 30, 1.0 | airfoil | 0, 0.30 ); ( 30, 1.0 | airfoil | 0, 0.35 ); ( 30, 1.0 | airfoil | 0, 0.40 ); ( 30, 1.0 | airfoil | 0, 0.45 ); ( 30, 1.0 | airfoil | 0, 0.50 ); ( 30, 1.0 | airfoil | 0, 0.55 ); ( 30, 1.0 | airfoil | 0, 0.60 ); ( 30, 1.0 | airfoil | 0, 0.65 ); ( 30, 1.0 | airfoil | 0, 0.70 ); ( 30, 1.0 | airfoil | 0, 0.75 ); ( 30, 1.0 | airfoil | 0, 0.80 ); ( 30, 1.0 | airfoil | 0, 0.85 ); ( 30, 1.0 | airfoil | 0, 0.90 ); ( 30, 1.0 | airfoil | 0, 0.95 ); ( 30, 1.0 | airfoil | 1, 0.05 ); ( 30, 1.0 | airfoil | 1, 0.10 ); ( 30, 1.0 | airfoil | 1, 0.15 ); ( 30, 1.0 | airfoil | 1, 0.20 ); ( 30, 1.0 | airfoil | 1, 0.25 ); ( 30, 1.0 | airfoil | 1, 0.30 ); ( 30, 1.0 | airfoil | 1, 0.35 ); ( 30, 1.0 | airfoil | 1, 0.40 ); ( 30, 1.0 | airfoil | 1, 0.45 ); ( 30, 1.0 | airfoil | 1, 0.50 ); ( 30, 1.0 | airfoil | 1, 0.55 ); ( 30, 1.0 | airfoil | 1, 0.60 ); ( 30, 1.0 | airfoil | 1, 0.65 ); ( 30, 1.0 | airfoil | 1, 0.70 ); ( 30, 1.0 | airfoil | 1, 0.75 ); ( 30, 1.0 | airfoil | 1, 0.80 ); ( 30, 1.0 | airfoil | 1, 0.85 ); ( 30, 1.0 | airfoil | 1, 0.90 ); ( 30, 1.0 | airfoil | 1, 0.95 )
+RESTART_SOL= NO
+READ_BINARY_RESTART= NO


### PR DESCRIPTION
# Fix: Add CUSTOM_OBJFUNC and TAVG_CUSTOM_OBJFUNC to historyMap.py

## Fixes Issue
 #2586 — _Custom Objective Function Does not Work with shape_optimization.py_

---

## Root Cause

`historyMap.py` is the bridge between the C++ solver output and the Python
optimization framework. Every objective function used in `shape_optimization.py`
must have a corresponding entry in this map. The entry tells Python:

- Which **GROUP** to look in (e.g. `COMBO`, `AERO_COEFF`)
- Which **HEADER** column to read from the history CSV file
- What **TYPE** the field is

`CUSTOM_OBJFUNC` was never added to this map, despite being fully implemented
in C++ since v7.0.

---

## Test Case

Tested using `TestCases/optimization_euler/steady_naca0012/inv_NACA0012_basic.cfg`
with the following custom objective (p-norm of surface pressure):

```cfg
CUSTOM_OUTPUTS= 'P50_avg : AreaAvg{pow(PRESSURE,50)}[airfoil]; P_pnorm50 : Function{pow(P50_avg, 1.0/50.0)}'
CUSTOM_OBJFUNC= 'P_pnorm50'
OBJECTIVE_FUNCTION= CUSTOM_OBJFUNC
OPT_OBJECTIVE= CUSTOM_OBJFUNC * 1.0
```
---

## How to Run

```bash
cd TestCases/optimization_euler/steady_naca0012/

python SU2_PY/shape_optimization.py -g DISCRETE_ADJOINT -f inv_NACA0012_basic.cfg
```

### Before Fix
<img width="755" height="224" alt="Screenshot 2026-03-07 173836" src="https://github.com/user-attachments/assets/7cf1ff64-2060-49ad-b8a9-2c70ba732f4a" />

Crashes immediately — no simulation runs at all.

### After Fix

<img width="1849" height="470" alt="Screenshot 2026-03-07 174010" src="https://github.com/user-attachments/assets/3b43a9c3-b62c-4514-b270-d73fe8937ac5" />

Full optimization loop completes successfully. 

---

## Related Issues
- Fixes #2586
- Related to #2489  - resolved by above fix
- Related to #889
