### PR TITLE
Fix CUSTOM_OBJFUNC support in Python layer

### DIFF
--- a/SU2_CFD/src/output/CFlowOutput.cpp
+++ b/SU2_CFD/src/output/CFlowOutput.cpp
@@ -1789,6 +1789,9 @@ void CFlowOutput::AddAerodynamicCoefficients(const CConfig* config) {
   AddHistoryOutput("AOA", "AoA", ScreenOutputFormat::FIXED, "AOA", "Angle of attack");
 
   AddHistoryOutput("COMBO", "ComboObj", ScreenOutputFormat::SCIENTIFIC, "COMBO", "Combined obj. function value.", HistoryFieldType::COEFFICIENT);
+  // CUSTOM_OBJFUNC is added here so historyMap.py knows how to get its
+  // value, the actual output is COMBO.
+  if (false) AddHistoryOutput("CUSTOM_OBJFUNC", "ComboObj", ScreenOutputFormat::SCIENTIFIC, "COMBO", "Custom obj. function value.", HistoryFieldType::COEFFICIENT);
 }
 
 void CFlowOutput::SetAerodynamicCoefficients(const CConfig* config, const CSolver* flow_solver){

--- a/SU2_PY/SU2/io/historyMap.py
+++ b/SU2_PY/SU2/io/historyMap.py
@@ -313,7 +313,7 @@ history_header_map = {
     "CUSTOM_OBJFUNC": {
         "DESCRIPTION": "Custom obj. function value.",
         "GROUP": "COMBO",
-        "HEADER": "ComboObj",
+        "HEADER": "CustomObj",
         "TYPE": "COEFFICIENT",
     },
     "DEFORM_ITER": {

--- a/SU2_PY/SU2/io/historyMap.py
+++ b/SU2_PY/SU2/io/historyMap.py
@@ -310,6 +310,12 @@ history_header_map = {
         "HEADER": "ComboObj",
         "TYPE": "COEFFICIENT",
     },
+    "CUSTOM_OBJFUNC": {
+        "DESCRIPTION": "Custom obj. function value.",
+        "GROUP": "COMBO",
+        "HEADER": "ComboObj",
+        "TYPE": "COEFFICIENT",
+    },
     "DEFORM_ITER": {
         "DESCRIPTION": "Linear solver iterations for the mesh " "deformation",
         "GROUP": "DEFORM",


### PR DESCRIPTION
This PR fixes the handling of CUSTOM_OBJFUNC in the Python interface.

Problem
-------
When evaluating custom objective functions, the Python layer could raise 
a KeyError because CUSTOM_OBJFUNC was missing from historyMap.py

Solution
--------
- Added if (false) AddHistoryOutput("CUSTOM_OBJFUNC", ...) in CFlowOutput.cpp 
  so updateHistoryMap.py registers it correctly
- Fixed updateHistoryMap.py parser to handle if (false) AddHistoryOutput pattern
- Fixed multi-line BGS_ENTHALPY call in CFlowIncOutput.cpp so parser works correctly
- Regenerated historyMap.py with CUSTOM_OBJFUNC correctly registered

Fixes #2586