### PR TITLE
fix(SU2_PY): replace Python 2 string.join() with str.join() in polarSweepLib.py

### DIFF
--- a/SU2_PY/SU2/util/polarSweepLib.py
+++ b/SU2_PY/SU2/util/polarSweepLib.py
@@ -147,7 +147,6 @@ def readParameter(dataFile, nLines, keyWord, iDoNot, verbose):
 def setContribution(dataFile, nLines, keyWord, iDoNot, verbose):
 
     from numpy import size
-    import string
 
     #
     # default values
@@ -176,7 +175,7 @@ def setContribution(dataFile, nLines, keyWord, iDoNot, verbose):
 
         # now find out where the standard text ends
         iBF = firstPart.lower().index("family") + 6
-        nameText = string.join(firstPart[iBF:].split(), "")
+        nameText = "".join(firstPart[iBF:].split())
 
         # component name located. Now check about its contribution
         try:


### PR DESCRIPTION
## Proposed Changes

`string.join()` was removed in Python 3, causing an immediate`AttributeError: module 'string' has no attribute 'join'` when running polar sweep analysis on any modern Python installation. Replaces `string.join(x.split(), "")` with `"".join(x.split())` — identical behavior, Python 3 compatible. Also removes the now-unused `import string` statement.

## Related Work

Part of the Python 3 modernization of SU2_PY scripts (see PR #2758).

## PR Checklist

- [x] I am submitting my contribution to the develop branch.
- [ ] My contribution generates no new compiler warnings.
- [x] My contribution is commented and consistent with SU2 style.
- [x] I used the pre-commit hook to prevent dirty commits.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation, if necessary.