### PR TITLE
Add SU2.io.fwh: Python reader for FWH binary surface data

### DIFF
--- a/SU2_PY/SU2/util/polarSweepLib.py
+++ b/SU2_PY/SU2/util/polarSweepLib.py
@@ -147,7 +147,6 @@ def readParameter(dataFile, nLines, keyWord, iDoNot, verbose):
 def setContribution(dataFile, nLines, keyWord, iDoNot, verbose):
 
     from numpy import size
-    import string
 
     #
     # default values
@@ -176,7 +175,7 @@ def setContribution(dataFile, nLines, keyWord, iDoNot, verbose):
 
         # now find out where the standard text ends
         iBF = firstPart.lower().index("family") + 6
-        nameText = string.join(firstPart[iBF:].split(), "")
+        nameText = "".join(firstPart[iBF:].split())
 
         # component name located. Now check about its contribution
         try:


### PR DESCRIPTION
## Proposed Changes

Adds `SU2.io.fwh` module with a pure-Python reader for the FWH binary surface data format used by SU2PY_FWH. The reference file `TestCases/unsteady/square_cylinder/fwh_bin.dat` had no corresponding Python reader in the repository.

## Related Work

Related to the SU2PY_FWH aeroacoustics post-processor. No related PRs.

## PR Checklist

- [x] I am submitting my contribution to the develop branch.
- [ ] My contribution generates no new compiler warnings.
- [x] My contribution is commented and consistent with SU2 style.
- [x] I used the pre-commit hook to prevent dirty commits.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation, if necessary.