### PR TITLE
Simplify OMP min/max reductions, cleanup raw indexing into CSysVector

### DIFF
--- a/Common/include/containers/C2DContainer.hpp
+++ b/Common/include/containers/C2DContainer.hpp
@@ -421,7 +421,7 @@ class C2DContainer
   template <class IndexSIMD_t>
   class CInnerIterGather {
    private:
-    static_assert(std::is_integral<typename IndexSIMD_t::Scalar>::value, "");
+    static_assert(std::is_integral<typename IndexSIMD_t::Scalar>::value);
     enum { Size = IndexSIMD_t::Size };
     IndexSIMD_t m_offsets;
     const Index m_increment;

--- a/Common/include/containers/CPyWrapperMatrixView.hpp
+++ b/Common/include/containers/CPyWrapperMatrixView.hpp
@@ -84,7 +84,7 @@
  */
 class CPyWrapperMatrixView {
  protected:
-  static_assert(su2activematrix::IsRowMajor, "");
+  static_assert(su2activematrix::IsRowMajor);
   su2double* data_ = nullptr;
   unsigned long rows_ = 0, cols_ = 0;
   std::string name_;
@@ -124,7 +124,7 @@ class CPyWrapperMatrixView {
  */
 class CPyWrapperMarkerMatrixView {
  private:
-  static_assert(su2activematrix::IsRowMajor, "");
+  static_assert(su2activematrix::IsRowMajor);
   su2double* data_ = nullptr;
   const CVertex* const* vertices_ = nullptr;
   unsigned long rows_ = 0, cols_ = 0;
@@ -175,7 +175,7 @@ class CPyWrapperMarkerMatrixView {
  */
 class CPyWrapper3DMatrixView {
  protected:
-  static_assert(su2activematrix::IsRowMajor, "");
+  static_assert(su2activematrix::IsRowMajor);
   su2double* data_ = nullptr;
   unsigned long rows_ = 0, cols_ = 0, dims_ = 0;
   std::string name_;

--- a/Common/include/linear_algebra/CSysMatrix.hpp
+++ b/Common/include/linear_algebra/CSysMatrix.hpp
@@ -816,10 +816,11 @@ class CSysMatrix {
   }
 
   /*!
-   * \brief Deletes the values of the row i of the sparse matrix.
-   * \param[in] i - Index of the row.
+   * \brief Deletes the values of a row of the sparse matrix.
+   * \param[in] block_i - Index of the block.
+   * \param[in] row - Row within the block.
    */
-  void DeleteValsRowi(unsigned long i);
+  void DeleteValsRowi(unsigned long block_i, unsigned long row);
 
   /*!
    * \brief Modifies this matrix (A) and a rhs vector (b) such that (A^-1 * b)_i = x_i.

--- a/Common/include/linear_algebra/CSysVector.hpp
+++ b/Common/include/linear_algebra/CSysVector.hpp
@@ -360,11 +360,10 @@ class CSysVector : public VecExpr::CVecExpr<CSysVector<ScalarType>, ScalarType> 
     BEGIN_SU2_OMP_SAFE_GLOBAL_ACCESS {
       /*--- Reduce over all threads in an ordered way to ensure a deterministic result. ---*/
       for (int i = 1; i < omp_get_num_threads(); ++i) sum += dot_scratch[i];
-#ifdef HAVE_MPI
+
       /*--- Reduce across all mpi ranks, only the master thread communicates. ---*/
       const auto mpi_type = (sizeof(ScalarType) < sizeof(double)) ? MPI_FLOAT : MPI_DOUBLE;
       SelectMPIWrapper<ScalarType>::W::Allreduce(&sum, &dot_scratch[0], 1, mpi_type, MPI_SUM, SU2_MPI::GetComm());
-#endif
     }
     /*--- Make view of result consistent across threads. ---*/
     END_SU2_OMP_SAFE_GLOBAL_ACCESS

--- a/Common/include/parallelization/mpi_structure.cpp
+++ b/Common/include/parallelization/mpi_structure.cpp
@@ -28,17 +28,18 @@
 #include "mpi_structure.hpp"
 #include <cstring>  // memcpy
 
-/* Initialise the MPI Communicator Rank and Size */
+/* Initialise the MPI Communicator Rank, Size, and default MPI Communicator */
+#ifdef HAVE_MPI
+int CBaseMPIWrapper::Rank = 0;
+int CBaseMPIWrapper::Size = 1;
+CBaseMPIWrapper::Comm CBaseMPIWrapper::currentComm = MPI_COMM_WORLD;
+#else
 template <typename ScalarType>
 int CBaseMPIWrapper<ScalarType>::Rank = 0;
 
 template <typename ScalarType>
 int CBaseMPIWrapper<ScalarType>::Size = 1;
 
-/* Set the default MPI Communicator */
-#ifdef HAVE_MPI
-CBaseMPIWrapper::Comm CBaseMPIWrapper::currentComm = MPI_COMM_WORLD;
-#else
 template <typename ScalarType>
 typename CBaseMPIWrapper<ScalarType>::Comm CBaseMPIWrapper<ScalarType>::currentComm = 0;  // dummy value
 #endif

--- a/Common/include/parallelization/mpi_structure.cpp
+++ b/Common/include/parallelization/mpi_structure.cpp
@@ -29,14 +29,18 @@
 #include <cstring>  // memcpy
 
 /* Initialise the MPI Communicator Rank and Size */
-int CBaseMPIWrapper::Rank = 0;
-int CBaseMPIWrapper::Size = 1;
+template <typename ScalarType>
+int CBaseMPIWrapper<ScalarType>::Rank = 0;
+
+template <typename ScalarType>
+int CBaseMPIWrapper<ScalarType>::Size = 1;
 
 /* Set the default MPI Communicator */
 #ifdef HAVE_MPI
 CBaseMPIWrapper::Comm CBaseMPIWrapper::currentComm = MPI_COMM_WORLD;
 #else
-CBaseMPIWrapper::Comm CBaseMPIWrapper::currentComm = 0;  // dummy value
+template <typename ScalarType>
+typename CBaseMPIWrapper<ScalarType>::Comm CBaseMPIWrapper<ScalarType>::currentComm = 0;  // dummy value
 #endif
 
 #ifdef HAVE_MPI
@@ -122,7 +126,8 @@ void CBaseMPIWrapper::CopyData(const void* sendbuf, void* recvbuf, int size, Dat
 }
 #else  // HAVE_MPI
 
-void CBaseMPIWrapper::Error(std::string ErrorMsg, std::string FunctionName) {
+template <typename ScalarType>
+void CBaseMPIWrapper<ScalarType>::Error(const std::string& ErrorMsg, const std::string& FunctionName) {
   if (Rank == 0) {
     std::cout << std::endl << std::endl;
     std::cout << "Error in \"" << FunctionName << "\": " << std::endl;
@@ -134,12 +139,13 @@ void CBaseMPIWrapper::Error(std::string ErrorMsg, std::string FunctionName) {
   Abort(currentComm, 0);
 }
 
-void CBaseMPIWrapper::CopyData(const void* sendbuf, void* recvbuf, int size, Datatype datatype, int recvshift,
-                               int sendshift) {
+template <typename ScalarType>
+void CBaseMPIWrapper<ScalarType>::CopyData(const void* sendbuf, void* recvbuf, int size, Datatype datatype,
+                                           int recvshift, int sendshift) {
   switch (datatype) {
     case MPI_DOUBLE:
       for (int i = 0; i < size; i++) {
-        static_cast<su2double*>(recvbuf)[i + recvshift] = static_cast<const su2double*>(sendbuf)[i + sendshift];
+        static_cast<ScalarType*>(recvbuf)[i + recvshift] = static_cast<const ScalarType*>(sendbuf)[i + sendshift];
       }
       break;
     case MPI_UNSIGNED_LONG:
@@ -178,7 +184,16 @@ void CBaseMPIWrapper::CopyData(const void* sendbuf, void* recvbuf, int size, Dat
       break;
   };
 }
+
+template class CBaseMPIWrapper<su2double>;
+#if defined CODI_REVERSE_TYPE
+template class CBaseMPIWrapper<passivedouble>;
 #endif
+#if defined USE_MIXED_PRECISION
+template class CBaseMPIWrapper<su2mixedfloat>;
+#endif
+
+#endif  // HAVE_MPI
 
 #ifdef HAVE_MPI
 #if defined CODI_REVERSE_TYPE || defined CODI_FORWARD_TYPE

--- a/Common/include/parallelization/mpi_structure.hpp
+++ b/Common/include/parallelization/mpi_structure.hpp
@@ -623,7 +623,7 @@ struct SelectMPIWrapper {
 #if defined CODI_REVERSE_TYPE
 template <>
 struct SelectMPIWrapper<passivedouble> {
-#if HAVE_MPI
+#if defined HAVE_MPI
   using W = CBaseMPIWrapper;
 #else
   using W = CBaseMPIWrapper<passivedouble>;
@@ -635,7 +635,7 @@ struct SelectMPIWrapper<passivedouble> {
 #if defined USE_MIXED_PRECISION
 template <>
 struct SelectMPIWrapper<su2mixedfloat> {
-#if HAVE_MPI
+#if defined HAVE_MPI
   using W = CBaseMPIWrapper;
 #else
   using W = CBaseMPIWrapper<su2mixedfloat>;

--- a/Common/include/parallelization/mpi_structure.hpp
+++ b/Common/include/parallelization/mpi_structure.hpp
@@ -489,6 +489,7 @@ class CMediMPIWrapper : public CBaseMPIWrapper {
  * \class CMPIWrapper
  * \brief Version for when there is no MPI.
  */
+template <typename ScalarType>
 class CBaseMPIWrapper {
  public:
   typedef int Comm;
@@ -510,7 +511,7 @@ class CBaseMPIWrapper {
   static void CopyData(const void* sendbuf, void* recvbuf, int size, Datatype datatype, int recvshift = 0,
                        int sendshift = 0);
 
-  static void Error(std::string ErrorMsg, std::string FunctionName);
+  static void Error(const std::string& ErrorMsg, const std::string& FunctionName);
 
   static inline int GetRank() { return Rank; }
 
@@ -607,27 +608,37 @@ class CBaseMPIWrapper {
 
   static inline passivedouble Wtime(void) { return omp_get_wtime(); }
 };
-typedef int SU2_Comm;
-typedef CBaseMPIWrapper SU2_MPI;
+using SU2_Comm = int;
+using SU2_MPI = CBaseMPIWrapper<su2double>;
 
 #endif
 
 /*--- Select the appropriate MPI wrapper based on datatype, to use in templated classes. ---*/
 template <class T>
 struct SelectMPIWrapper {
-  typedef SU2_MPI W;
+  using W = SU2_MPI;
 };
 
 /*--- In AD we specialize for the passive wrapper. ---*/
 #if defined CODI_REVERSE_TYPE
 template <>
 struct SelectMPIWrapper<passivedouble> {
-  typedef CBaseMPIWrapper W;
+#if HAVE_MPI
+  using W = CBaseMPIWrapper;
+#else
+  using W = CBaseMPIWrapper<passivedouble>;
+#endif
 };
+#endif
+
+/*--- Specialize for the low precision type. ---*/
 #if defined USE_MIXED_PRECISION
 template <>
 struct SelectMPIWrapper<su2mixedfloat> {
-  typedef CBaseMPIWrapper W;
-};
+#if HAVE_MPI
+  using W = CBaseMPIWrapper;
+#else
+  using W = CBaseMPIWrapper<su2mixedfloat>;
 #endif
+};
 #endif

--- a/Common/include/parallelization/omp_structure.hpp
+++ b/Common/include/parallelization/omp_structure.hpp
@@ -276,11 +276,13 @@ inline void atomicAdd(T rhs, T& lhs) {
   lhs += rhs;
 }
 
-/*--- GCC supported atomic compare (for min/max) before the official date. ---*/
-#ifdef __GNUC__
-#define ATOMIC_COMPARE_SINCE 201511
-#else
+/*--- GCC supported atomic compare (for min/max) before it was fully 5.1 compliant. ---*/
 #define ATOMIC_COMPARE_SINCE 202011
+#ifdef __GNUC__
+#if __GNUC__ > 11
+#undef ATOMIC_COMPARE_SINCE
+#define ATOMIC_COMPARE_SINCE 201511
+#endif
 #endif
 
 /*--- By default the min/max fallback to critical is required for all types. ---*/

--- a/Common/include/parallelization/omp_structure.hpp
+++ b/Common/include/parallelization/omp_structure.hpp
@@ -39,6 +39,7 @@
 #pragma once
 
 #include <cstddef>
+#include <algorithm>
 
 #include "../code_config.hpp"
 
@@ -274,3 +275,53 @@ inline void atomicAdd(T rhs, T& lhs) {
   SU2_OMP_ATOMIC
   lhs += rhs;
 }
+
+/*--- GCC supported atomic compare (for min/max) before the official date. ---*/
+#ifdef __GNUC__
+#define ATOMIC_COMPARE_SINCE 201511
+#else
+#define ATOMIC_COMPARE_SINCE 202011
+#endif
+
+/*--- By default the min/max fallback to critical is required for all types. ---*/
+#define ATOMIC_COMPARE_FALLBACK
+
+/*--- Atomic max, shared = max(shared, local). ---*/
+#ifdef _OPENMP
+#if _OPENMP >= ATOMIC_COMPARE_SINCE
+/*--- Atomic min/max are supported for arithmetic types. ---*/
+template <class T, su2enable_if<std::is_arithmetic<T>::value> = 0>
+inline void atomicMax(const T& local, T& shared) {
+#pragma omp atomic compare
+  shared = shared < local ? local : shared;
+}
+
+/*--- Redefine the fallback for non arithmetic types. ---*/
+#undef ATOMIC_COMPARE_FALLBACK
+#define ATOMIC_COMPARE_FALLBACK , su2enable_if<!std::is_arithmetic<T>::value> = 0
+#endif
+#endif
+template <class T ATOMIC_COMPARE_FALLBACK>
+inline void atomicMax(const T& local, T& shared) {
+  SU2_OMP_CRITICAL
+  shared = std::max(local, shared);
+  END_SU2_OMP_CRITICAL
+}
+
+/*--- Atomic min, shared = min(shared, local). ---*/
+#ifdef _OPENMP
+#if _OPENMP >= ATOMIC_COMPARE_SINCE
+template <class T, su2enable_if<std::is_arithmetic<T>::value> = 0>
+inline void atomicMin(const T& local, T& shared) {
+#pragma omp atomic compare
+  shared = shared > local ? local : shared;
+}
+#endif
+#endif
+template <class T ATOMIC_COMPARE_FALLBACK>
+inline void atomicMin(const T& local, T& shared) {
+  SU2_OMP_CRITICAL
+  shared = std::min(local, shared);
+  END_SU2_OMP_CRITICAL
+}
+#undef ATOMIC_COMPARE_FALLBACK

--- a/Common/include/toolboxes/graph_toolbox.hpp
+++ b/Common/include/toolboxes/graph_toolbox.hpp
@@ -56,7 +56,7 @@ enum class ConnectivityType { FiniteVolume = 0, FiniteElement = 1 };
  */
 template <typename Index_t>
 class CCompressedSparsePattern {
-  static_assert(std::is_integral<Index_t>::value, "");
+  static_assert(std::is_integral<Index_t>::value);
 
  private:
   su2vector<Index_t> m_outerPtr;       /*!< \brief Start positions of the inner indices for each outer index. */
@@ -490,8 +490,8 @@ T createNaturalColoring(Index_t numInnerIndexes) {
 template <typename Color_t = unsigned char, size_t MaxColors = 255, size_t MaxMB = 128, class T>
 T colorSparsePattern(const T& pattern, size_t groupSize = 1, bool includeOuterIdx = false, bool balanceColors = false,
                      std::vector<Color_t>* indexColor = nullptr) {
-  static_assert(std::is_integral<Color_t>::value, "");
-  static_assert(std::numeric_limits<Color_t>::max() >= MaxColors, "");
+  static_assert(std::is_integral<Color_t>::value);
+  static_assert(std::numeric_limits<Color_t>::max() >= MaxColors);
 
   using Index_t = typename T::IndexType;
 
@@ -607,7 +607,7 @@ T colorSparsePattern(const T& pattern, size_t groupSize = 1, bool includeOuterId
  */
 template <typename T = unsigned long>
 struct GridColor {
-  static_assert(std::is_integral<T>::value, "");
+  static_assert(std::is_integral<T>::value);
 
   const T size;
   T groupSize;
@@ -625,7 +625,7 @@ struct GridColor {
  */
 template <typename T = unsigned long>
 struct DummyGridColor {
-  static_assert(std::is_integral<T>::value, "");
+  static_assert(std::is_integral<T>::value);
 
   T size;
   struct {

--- a/Common/src/grid_movement/CLinearElasticity.cpp
+++ b/Common/src/grid_movement/CLinearElasticity.cpp
@@ -164,17 +164,12 @@ particular, the linear elasticity equations hold only for small deformations. --
 }
 
 void CLinearElasticity::UpdateGridCoord(CGeometry* geometry, CConfig* config) {
-  unsigned short iDim;
-  unsigned long iPoint, total_index;
-  su2double new_coord;
-
   /*--- Update the grid coordinates using the solution of the linear system
    after grid deformation (LinSysSol contains the x, y, z displacements). ---*/
 
-  for (iPoint = 0; iPoint < nPoint; iPoint++)
-    for (iDim = 0; iDim < nDim; iDim++) {
-      total_index = iPoint * nDim + iDim;
-      new_coord = geometry->nodes->GetCoord(iPoint, iDim) + LinSysSol[total_index];
+  for (auto iPoint = 0ul; iPoint < nPoint; iPoint++)
+    for (auto iDim = 0ul; iDim < nDim; iDim++) {
+      su2double new_coord = geometry->nodes->GetCoord(iPoint, iDim) + LinSysSol(iPoint, iDim);
       if (fabs(new_coord) < EPS * EPS) new_coord = 0.0;
       geometry->nodes->SetCoord(iPoint, iDim, new_coord);
     }
@@ -190,7 +185,7 @@ void CLinearElasticity::UpdateGridCoord(CGeometry* geometry, CConfig* config) {
 void CLinearElasticity::UpdateGridCoord_Derivatives(CGeometry* geometry, CConfig* config,
                                                     bool ForwardProjectionDerivative) {
   unsigned short iDim, iMarker;
-  unsigned long iPoint, total_index, iVertex;
+  unsigned long iPoint, iVertex;
 
   SU2_COMPONENT Kind_SU2 = config->GetKind_SU2();
 
@@ -200,9 +195,8 @@ void CLinearElasticity::UpdateGridCoord_Derivatives(CGeometry* geometry, CConfig
     for (iPoint = 0; iPoint < geometry->GetnPoint(); iPoint++) {
       su2double new_coord[3] = {};
       for (iDim = 0; iDim < nDim; iDim++) {
-        total_index = iPoint * nDim + iDim;
         new_coord[iDim] = geometry->nodes->GetCoord(iPoint, iDim);
-        SU2_TYPE::SetDerivative(new_coord[iDim], SU2_TYPE::GetValue(LinSysSol[total_index]));
+        SU2_TYPE::SetDerivative(new_coord[iDim], SU2_TYPE::GetValue(LinSysSol(iPoint, iDim)));
       }
       geometry->nodes->SetCoord(iPoint, new_coord);
     }
@@ -211,7 +205,6 @@ void CLinearElasticity::UpdateGridCoord_Derivatives(CGeometry* geometry, CConfig
     if (config->GetSmoothGradient()) {
       for (iPoint = 0; iPoint < geometry->GetnPoint(); iPoint++) {
         for (iDim = 0; iDim < nDim; iDim++) {
-          total_index = iPoint * nDim + iDim;
           geometry->SetSensitivity(iPoint, iDim, 0.0);
         }
       }
@@ -222,8 +215,7 @@ void CLinearElasticity::UpdateGridCoord_Derivatives(CGeometry* geometry, CConfig
           iPoint = geometry->vertex[iMarker][iVertex]->GetNode();
           if (geometry->nodes->GetDomain(iPoint)) {
             for (iDim = 0; iDim < nDim; iDim++) {
-              total_index = iPoint * nDim + iDim;
-              geometry->SetSensitivity(iPoint, iDim, LinSysSol[total_index]);
+              geometry->SetSensitivity(iPoint, iDim, LinSysSol(iPoint, iDim));
             }
           }
         }
@@ -232,8 +224,7 @@ void CLinearElasticity::UpdateGridCoord_Derivatives(CGeometry* geometry, CConfig
   } else if (config->GetSmoothGradient() && ForwardProjectionDerivative) {
     for (iPoint = 0; iPoint < geometry->GetnPoint(); iPoint++) {
       for (iDim = 0; iDim < nDim; iDim++) {
-        total_index = iPoint * nDim + iDim;
-        geometry->SetSensitivity(iPoint, iDim, LinSysSol[total_index]);
+        geometry->SetSensitivity(iPoint, iDim, LinSysSol(iPoint, iDim));
       }
     }
   }
@@ -1247,7 +1238,7 @@ su2double CLinearElasticity::ShapeFunc_Hexa(su2double Xi, su2double Eta, su2doub
 
 void CLinearElasticity::SetDomainDisplacements(CGeometry* geometry, CConfig* config) {
   unsigned short iDim, nDim = geometry->GetnDim();
-  unsigned long iPoint, total_index;
+  unsigned long iPoint;
 
   if (config->GetHold_GridFixed()) {
     auto MinCoordValues = config->GetHold_GridFixed_Coord();
@@ -1260,10 +1251,9 @@ void CLinearElasticity::SetDomainDisplacements(CGeometry* geometry, CConfig* con
       auto Coord = geometry->nodes->GetCoord(iPoint);
       for (iDim = 0; iDim < nDim; iDim++) {
         if ((Coord[iDim] < MinCoordValues[iDim]) || (Coord[iDim] > MaxCoordValues[iDim])) {
-          total_index = iPoint * nDim + iDim;
-          LinSysRes[total_index] = 0.0;
-          LinSysSol[total_index] = 0.0;
-          StiffMatrix.DeleteValsRowi(total_index);
+          LinSysRes(iPoint, iDim) = 0.0;
+          LinSysSol(iPoint, iDim) = 0.0;
+          StiffMatrix.DeleteValsRowi(iPoint, iDim);
         }
       }
     }
@@ -1276,10 +1266,9 @@ void CLinearElasticity::SetDomainDisplacements(CGeometry* geometry, CConfig* con
     for (iPoint = 0; iPoint < nPoint; iPoint++) {
       if (geometry->nodes->GetWall_Distance(iPoint) >= config->GetDeform_Limit()) {
         for (iDim = 0; iDim < nDim; iDim++) {
-          total_index = iPoint * nDim + iDim;
-          LinSysRes[total_index] = 0.0;
-          LinSysSol[total_index] = 0.0;
-          StiffMatrix.DeleteValsRowi(total_index);
+          LinSysRes(iPoint, iDim) = 0.0;
+          LinSysSol(iPoint, iDim) = 0.0;
+          StiffMatrix.DeleteValsRowi(iPoint, iDim);
         }
       }
     }
@@ -1288,7 +1277,7 @@ void CLinearElasticity::SetDomainDisplacements(CGeometry* geometry, CConfig* con
 
 void CLinearElasticity::SetBoundaryDisplacements(CGeometry* geometry, CConfig* config) {
   unsigned short iDim, nDim = geometry->GetnDim(), iMarker, axis = 0;
-  unsigned long iPoint, total_index, iVertex;
+  unsigned long iPoint, iVertex;
   su2double *VarCoord, MeanCoord[3] = {0.0, 0.0, 0.0}, VarIncrement = 1.0;
 
   /*--- If requested (no by default) impose the surface deflections in
@@ -1307,10 +1296,9 @@ void CLinearElasticity::SetBoundaryDisplacements(CGeometry* geometry, CConfig* c
       for (iVertex = 0; iVertex < geometry->nVertex[iMarker]; iVertex++) {
         iPoint = geometry->vertex[iMarker][iVertex]->GetNode();
         for (iDim = 0; iDim < nDim; iDim++) {
-          total_index = iPoint * nDim + iDim;
-          LinSysRes[total_index] = 0.0;
-          LinSysSol[total_index] = 0.0;
-          StiffMatrix.DeleteValsRowi(total_index);
+          LinSysRes(iPoint, iDim) = 0.0;
+          LinSysSol(iPoint, iDim) = 0.0;
+          StiffMatrix.DeleteValsRowi(iPoint, iDim);
         }
       }
     }
@@ -1327,10 +1315,9 @@ void CLinearElasticity::SetBoundaryDisplacements(CGeometry* geometry, CConfig* c
         VarCoord = geometry->vertex[iMarker][iVertex]->GetVarCoord();
 
         for (iDim = 0; iDim < nDim; iDim++) {
-          total_index = iPoint * nDim + iDim;
-          LinSysRes[total_index] = SU2_TYPE::GetValue(VarCoord[iDim] * VarIncrement);
-          LinSysSol[total_index] = SU2_TYPE::GetValue(VarCoord[iDim] * VarIncrement);
-          StiffMatrix.DeleteValsRowi(total_index);
+          LinSysRes(iPoint, iDim) = SU2_TYPE::GetValue(VarCoord[iDim] * VarIncrement);
+          LinSysSol(iPoint, iDim) = SU2_TYPE::GetValue(VarCoord[iDim] * VarIncrement);
+          StiffMatrix.DeleteValsRowi(iPoint, iDim);
         }
       }
     }
@@ -1367,10 +1354,9 @@ void CLinearElasticity::SetBoundaryDisplacements(CGeometry* geometry, CConfig* c
 
       for (iVertex = 0; iVertex < geometry->nVertex[iMarker]; iVertex++) {
         iPoint = geometry->vertex[iMarker][iVertex]->GetNode();
-        total_index = iPoint * nDim + axis;
-        LinSysRes[total_index] = 0.0;
-        LinSysSol[total_index] = 0.0;
-        StiffMatrix.DeleteValsRowi(total_index);
+        LinSysRes(iPoint, axis) = 0.0;
+        LinSysSol(iPoint, axis) = 0.0;
+        StiffMatrix.DeleteValsRowi(iPoint, axis);
       }
     }
   }
@@ -1382,10 +1368,9 @@ void CLinearElasticity::SetBoundaryDisplacements(CGeometry* geometry, CConfig* c
       for (iVertex = 0; iVertex < geometry->nVertex[iMarker]; iVertex++) {
         iPoint = geometry->vertex[iMarker][iVertex]->GetNode();
         for (iDim = 0; iDim < nDim; iDim++) {
-          total_index = iPoint * nDim + iDim;
-          LinSysRes[total_index] = 0.0;
-          LinSysSol[total_index] = 0.0;
-          StiffMatrix.DeleteValsRowi(total_index);
+          LinSysRes(iPoint, axis) = 0.0;
+          LinSysSol(iPoint, axis) = 0.0;
+          StiffMatrix.DeleteValsRowi(iPoint, axis);
         }
       }
     }
@@ -1399,10 +1384,9 @@ void CLinearElasticity::SetBoundaryDisplacements(CGeometry* geometry, CConfig* c
         iPoint = geometry->vertex[iMarker][iVertex]->GetNode();
         VarCoord = geometry->vertex[iMarker][iVertex]->GetVarCoord();
         for (iDim = 0; iDim < nDim; iDim++) {
-          total_index = iPoint * nDim + iDim;
-          LinSysRes[total_index] = SU2_TYPE::GetValue(VarCoord[iDim] * VarIncrement);
-          LinSysSol[total_index] = SU2_TYPE::GetValue(VarCoord[iDim] * VarIncrement);
-          StiffMatrix.DeleteValsRowi(total_index);
+          LinSysRes(iPoint, axis) = SU2_TYPE::GetValue(VarCoord[iDim] * VarIncrement);
+          LinSysSol(iPoint, axis) = SU2_TYPE::GetValue(VarCoord[iDim] * VarIncrement);
+          StiffMatrix.DeleteValsRowi(iPoint, axis);
         }
       }
     }
@@ -1411,7 +1395,7 @@ void CLinearElasticity::SetBoundaryDisplacements(CGeometry* geometry, CConfig* c
 
 void CLinearElasticity::SetBoundaryDerivatives(CGeometry* geometry, CConfig* config, bool ForwardProjectionDerivative) {
   unsigned short iDim, iMarker;
-  unsigned long iPoint, total_index, iVertex;
+  unsigned long iPoint, iVertex;
 
   su2double* VarCoord;
   SU2_COMPONENT Kind_SU2 = config->GetKind_SU2();
@@ -1422,9 +1406,8 @@ void CLinearElasticity::SetBoundaryDerivatives(CGeometry* geometry, CConfig* con
           iPoint = geometry->vertex[iMarker][iVertex]->GetNode();
           VarCoord = geometry->vertex[iMarker][iVertex]->GetVarCoord();
           for (iDim = 0; iDim < nDim; iDim++) {
-            total_index = iPoint * nDim + iDim;
-            LinSysRes[total_index] = SU2_TYPE::GetDerivative(VarCoord[iDim]);
-            LinSysSol[total_index] = SU2_TYPE::GetDerivative(VarCoord[iDim]);
+            LinSysRes(iPoint, iDim) = SU2_TYPE::GetDerivative(VarCoord[iDim]);
+            LinSysSol(iPoint, iDim) = SU2_TYPE::GetDerivative(VarCoord[iDim]);
           }
         }
       }
@@ -1433,9 +1416,8 @@ void CLinearElasticity::SetBoundaryDerivatives(CGeometry* geometry, CConfig* con
   } else if ((Kind_SU2 == SU2_COMPONENT::SU2_DOT) && !ForwardProjectionDerivative) {
     for (iPoint = 0; iPoint < nPoint; iPoint++) {
       for (iDim = 0; iDim < nDim; iDim++) {
-        total_index = iPoint * nDim + iDim;
-        LinSysRes[total_index] = SU2_TYPE::GetValue(geometry->GetSensitivity(iPoint, iDim));
-        LinSysSol[total_index] = SU2_TYPE::GetValue(geometry->GetSensitivity(iPoint, iDim));
+        LinSysRes(iPoint, iDim) = SU2_TYPE::GetValue(geometry->GetSensitivity(iPoint, iDim));
+        LinSysSol(iPoint, iDim) = SU2_TYPE::GetValue(geometry->GetSensitivity(iPoint, iDim));
       }
     }
   } else if (config->GetSmoothGradient() && ForwardProjectionDerivative) {
@@ -1444,9 +1426,8 @@ void CLinearElasticity::SetBoundaryDerivatives(CGeometry* geometry, CConfig* con
         for (iVertex = 0; iVertex < geometry->nVertex[iMarker]; iVertex++) {
           iPoint = geometry->vertex[iMarker][iVertex]->GetNode();
           for (iDim = 0; iDim < nDim; iDim++) {
-            total_index = iPoint * nDim + iDim;
-            LinSysRes[total_index] = SU2_TYPE::GetValue(geometry->GetSensitivity(iPoint, iDim));
-            LinSysSol[total_index] = SU2_TYPE::GetValue(geometry->GetSensitivity(iPoint, iDim));
+            LinSysRes(iPoint, iDim) = SU2_TYPE::GetValue(geometry->GetSensitivity(iPoint, iDim));
+            LinSysSol(iPoint, iDim) = SU2_TYPE::GetValue(geometry->GetSensitivity(iPoint, iDim));
           }
         }
       }

--- a/Common/src/grid_movement/CLinearElasticity.cpp
+++ b/Common/src/grid_movement/CLinearElasticity.cpp
@@ -1384,9 +1384,9 @@ void CLinearElasticity::SetBoundaryDisplacements(CGeometry* geometry, CConfig* c
         iPoint = geometry->vertex[iMarker][iVertex]->GetNode();
         VarCoord = geometry->vertex[iMarker][iVertex]->GetVarCoord();
         for (iDim = 0; iDim < nDim; iDim++) {
-          LinSysRes(iPoint, axis) = SU2_TYPE::GetValue(VarCoord[iDim] * VarIncrement);
-          LinSysSol(iPoint, axis) = SU2_TYPE::GetValue(VarCoord[iDim] * VarIncrement);
-          StiffMatrix.DeleteValsRowi(iPoint, axis);
+          LinSysRes(iPoint, iDim) = SU2_TYPE::GetValue(VarCoord[iDim] * VarIncrement);
+          LinSysSol(iPoint, iDim) = SU2_TYPE::GetValue(VarCoord[iDim] * VarIncrement);
+          StiffMatrix.DeleteValsRowi(iPoint, iDim);
         }
       }
     }

--- a/Common/src/interface_interpolation/CIsoparametric.cpp
+++ b/Common/src/interface_interpolation/CIsoparametric.cpp
@@ -245,12 +245,9 @@ void CIsoparametric::SetTransferCoeff(const CConfig* const* config) {
         }
       }
       END_SU2_OMP_FOR
-      SU2_OMP_CRITICAL {
-        MaxDistance = max(MaxDistance, maxDist);
-        ErrorCounter += errorCount;
-        nGlobalVertexTarget += totalCount;
-      }
-      END_SU2_OMP_CRITICAL
+      atomicMax(maxDist, MaxDistance);
+      atomicAdd(errorCount, ErrorCounter);
+      atomicAdd(totalCount, nGlobalVertexTarget);
     }
     END_SU2_OMP_PARALLEL
 

--- a/Common/src/interface_interpolation/CNearestNeighbor.cpp
+++ b/Common/src/interface_interpolation/CNearestNeighbor.cpp
@@ -153,12 +153,9 @@ void CNearestNeighbor::SetTransferCoeff(const CConfig* const* config) {
         }
       }
       END_SU2_OMP_FOR
-      SU2_OMP_CRITICAL {
-        totalTargetPoints += numTarget;
-        AvgDistance += avgDist;
-        MaxDistance = max(MaxDistance, maxDist);
-      }
-      END_SU2_OMP_CRITICAL
+      atomicAdd(numTarget, totalTargetPoints);
+      atomicAdd(avgDist, AvgDistance);
+      atomicMax(maxDist, MaxDistance);
     }
     END_SU2_OMP_PARALLEL
   }

--- a/Common/src/interface_interpolation/CRadialBasisFunction.cpp
+++ b/Common/src/interface_interpolation/CRadialBasisFunction.cpp
@@ -373,14 +373,11 @@ void CRadialBasisFunction::SetTransferCoeff(const CConfig* const* config) {
         }
       }  // end target vertex loop
       END_SU2_OMP_FOR
-      SU2_OMP_CRITICAL {
-        totalDonorPoints += totalDonors;
-        MinDonors = min(MinDonors, minDonors);
-        MaxDonors = max(MaxDonors, maxDonors);
-        AvgCorrection += sumCorr;
-        MaxCorrection = max(MaxCorrection, maxCorr);
-      }
-      END_SU2_OMP_CRITICAL
+      atomicAdd(totalDonors, totalDonorPoints);
+      atomicMin(minDonors, MinDonors);
+      atomicMax(maxDonors, MaxDonors);
+      atomicAdd(sumCorr, AvgCorrection);
+      atomicMax(maxCorr, MaxCorrection);
     }
     END_SU2_OMP_PARALLEL
 

--- a/Common/src/linear_algebra/CSysMatrix.cpp
+++ b/Common/src/linear_algebra/CSysMatrix.cpp
@@ -601,10 +601,7 @@ void CSysMatrix<ScalarType>::MatrixInverse(ScalarType* matrix, ScalarType* inver
 }
 
 template <class ScalarType>
-void CSysMatrix<ScalarType>::DeleteValsRowi(unsigned long i) {
-  const auto block_i = i / nVar;
-  const auto row = i % nVar;
-
+void CSysMatrix<ScalarType>::DeleteValsRowi(unsigned long block_i, unsigned long row) {
   for (auto index = row_ptr[block_i]; index < row_ptr[block_i + 1]; index++) {
     for (auto iVar = 0u; iVar < nVar; iVar++)
       matrix[index * nVar * nVar + row * nVar + iVar] = 0.0;  // Delete row values in the block

--- a/SU2_CFD/include/limiters/CLimiterDetails.hpp
+++ b/SU2_CFD/include/limiters/CLimiterDetails.hpp
@@ -369,13 +369,11 @@ struct CLimiterDetails<LIMITER::VENKATAKRISHNAN_WANG>
 
     /*--- Per rank reduction. ---*/
 
-    SU2_OMP_CRITICAL
     for(size_t iVar = varBegin; iVar < varEnd; ++iVar)
     {
-      sharedMin(iVar) = min(sharedMin(iVar), localMin(iVar));
-      sharedMax(iVar) = max(sharedMax(iVar), localMax(iVar));
+      atomicMin(localMin(iVar), sharedMin(iVar));
+      atomicMax(localMax(iVar), sharedMax(iVar));
     }
-    END_SU2_OMP_CRITICAL
 
     /*--- Global reduction. ---*/
 

--- a/SU2_CFD/include/numerics_simd/flow/convection/common.hpp
+++ b/SU2_CFD/include/numerics_simd/flow/convection/common.hpp
@@ -406,7 +406,7 @@ template<class PrimVarType, class ConsVarType, size_t nDim>
 FORCEINLINE VectorDbl<nDim+2> inviscidProjFlux(const PrimVarType& V,
                                                const ConsVarType& U,
                                                const VectorDbl<nDim>& normal) {
-  static_assert(ConsVarType::nVar == nDim+2,"");
+  static_assert(ConsVarType::nVar == nDim+2);
   Double mdot = dot(U.momentum(), normal);
   VectorDbl<nDim+2> flux;
   flux(0) = mdot;

--- a/SU2_CFD/include/numerics_simd/flow/diffusion/viscous_fluxes.hpp
+++ b/SU2_CFD/include/numerics_simd/flow/diffusion/viscous_fluxes.hpp
@@ -127,7 +127,7 @@ protected:
                                 MatrixDbl<nVar>& jac_i,
                                 MatrixDbl<nVar>& jac_j) const {
 
-    static_assert(PrimVarType::nVar <= Derived::nPrimVar,"");
+    static_assert(PrimVarType::nVar <= Derived::nPrimVar);
 
     /*--- Pointer on which to call the "compile-time virtual" methods. ---*/
 

--- a/SU2_CFD/include/solvers/CFVMFlowSolverBase.hpp
+++ b/SU2_CFD/include/solvers/CFVMFlowSolverBase.hpp
@@ -524,14 +524,10 @@ class CFVMFlowSolverBase : public CSolver {
         }
       }
       END_SU2_OMP_FOR
+
       /*--- Min/max over threads. ---*/
-      SU2_OMP_CRITICAL
-      {
-        Min_Delta_Time = min(Min_Delta_Time, minDt);
-        Max_Delta_Time = max(Max_Delta_Time, maxDt);
-        Global_Delta_Time = Min_Delta_Time;
-      }
-      END_SU2_OMP_CRITICAL
+      atomicMin(minDt, Min_Delta_Time);
+      atomicMax(maxDt, Max_Delta_Time);
     }
 
     /*--- Compute the min/max dt (in parallel, now over mpi ranks). ---*/
@@ -545,6 +541,7 @@ class CFVMFlowSolverBase : public CSolver {
         SU2_MPI::Allreduce(&Max_Delta_Time, &rbuf_time, 1, MPI_DOUBLE, MPI_MAX, SU2_MPI::GetComm());
         Max_Delta_Time = rbuf_time;
       }
+      Global_Delta_Time = Min_Delta_Time;
     } END_SU2_OMP_SAFE_GLOBAL_ACCESS
 
     /*--- For exact time solution use the minimum delta time of the whole mesh. ---*/
@@ -591,9 +588,7 @@ class CFVMFlowSolverBase : public CSolver {
         glbDtND = min(glbDtND, config->GetUnst_CFL()*Global_Delta_Time / nodes->GetLocalCFL(iPoint));
       }
       END_SU2_OMP_FOR
-      SU2_OMP_CRITICAL
-      Global_Delta_UnstTimeND = min(Global_Delta_UnstTimeND, glbDtND);
-      END_SU2_OMP_CRITICAL
+      atomicMin(glbDtND, Global_Delta_UnstTimeND);
 
       BEGIN_SU2_OMP_SAFE_GLOBAL_ACCESS
       {
@@ -811,7 +806,7 @@ class CFVMFlowSolverBase : public CSolver {
 
     static_assert(IntegrationType == CLASSICAL_RK4_EXPLICIT ||
                   IntegrationType == RUNGE_KUTTA_EXPLICIT ||
-                  IntegrationType == EULER_EXPLICIT, "");
+                  IntegrationType == EULER_EXPLICIT);
 
     const bool adjoint = config->GetContinuous_Adjoint();
 
@@ -968,12 +963,11 @@ class CFVMFlowSolverBase : public CSolver {
       }
 
       for (unsigned short iVar = 0; iVar < nVar; iVar++) {
-        unsigned long total_index = iPoint*nVar + iVar;
-        LinSysRes[total_index] = - (LinSysRes[total_index] + local_Res_TruncError[iVar]);
-        LinSysSol[total_index] = 0.0;
+        LinSysRes(iPoint, iVar) = -(LinSysRes(iPoint, iVar) + local_Res_TruncError[iVar]);
+        LinSysSol(iPoint, iVar) = 0.0;
 
         /*--- "Add" residual at (iPoint,iVar) to local residual variables. ---*/
-        ResidualReductions_PerThread(iPoint, iVar, LinSysRes[total_index], resRMS, resMax, idxMax);
+        ResidualReductions_PerThread(iPoint, iVar, LinSysRes(iPoint, iVar), resRMS, resMax, idxMax);
       }
     }
     END_SU2_OMP_FOR

--- a/SU2_CFD/include/solvers/CFVMFlowSolverBase.inl
+++ b/SU2_CFD/include/solvers/CFVMFlowSolverBase.inl
@@ -684,11 +684,8 @@ void CFVMFlowSolverBase<V, R>::ComputeVorticityAndStrainMag(const CConfig& confi
   END_SU2_OMP_FOR
 
   if ((iMesh == MESH_0) && (config.GetComm_Level() == COMM_FULL)) {
-    SU2_OMP_CRITICAL {
-      StrainMag_Max = max(StrainMag_Max, strainMax);
-      Omega_Max = max(Omega_Max, omegaMax);
-    }
-    END_SU2_OMP_CRITICAL
+    atomicMax(strainMax, StrainMag_Max);
+    atomicMax(omegaMax, Omega_Max);
 
     BEGIN_SU2_OMP_SAFE_GLOBAL_ACCESS
     {
@@ -1458,7 +1455,7 @@ void CFVMFlowSolverBase<V, R>::BC_Custom(CGeometry* geometry, CSolver** solver_c
 
   if (VerificationSolution) {
     unsigned short iVar;
-    unsigned long iVertex, iPoint, total_index;
+    unsigned long iVertex, iPoint;
 
     bool implicit = (config->GetKind_TimeIntScheme() == EULER_IMPLICIT);
 
@@ -1500,8 +1497,7 @@ void CFVMFlowSolverBase<V, R>::BC_Custom(CGeometry* geometry, CSolver** solver_c
 
         if (implicit) {
           for (iVar = 0; iVar < nVar; iVar++) {
-            total_index = iPoint * nVar + iVar;
-            Jacobian.DeleteValsRowi(total_index);
+            Jacobian.DeleteValsRowi(iPoint, iVar);
           }
         }
       }

--- a/SU2_CFD/include/solvers/CNEMOEulerSolver.hpp
+++ b/SU2_CFD/include/solvers/CNEMOEulerSolver.hpp
@@ -56,9 +56,6 @@ protected:
 
   unsigned long ErrorCounter = 0; /*!< \brief Counter for number of un-physical states. */
 
-  su2double Global_Delta_Time = 0.0, /*!< \brief Time-step for TIME_STEPPING time marching strategy. */
-  Global_Delta_UnstTimeND = 0.0;     /*!< \brief Unsteady time step for the dual time strategy. */
-
   CNEMOGas  *FluidModel;          /*!< \brief fluid model used in the solver */
 
   CNEMOEulerVariable* node_infty = nullptr;

--- a/SU2_CFD/include/solvers/CScalarSolver.inl
+++ b/SU2_CFD/include/solvers/CScalarSolver.inl
@@ -481,12 +481,11 @@ void CScalarSolver<VariableType>::PrepareImplicitIteration(CGeometry* geometry, 
     /*--- Right hand side of the system (-Residual) and initial guess (x = 0) ---*/
 
     for (unsigned short iVar = 0; iVar < nVar; iVar++) {
-      unsigned long total_index = iPoint * nVar + iVar;
-      LinSysRes[total_index] = -LinSysRes[total_index];
-      LinSysSol[total_index] = 0.0;
+      LinSysRes(iPoint, iVar) = -LinSysRes(iPoint, iVar);
+      LinSysSol(iPoint, iVar) = 0.0;
 
       /*--- "Add" residual at (iPoint,iVar) to local residual variables. ---*/
-      ResidualReductions_PerThread(iPoint, iVar, LinSysRes[total_index], resRMS, resMax, idxMax);
+      ResidualReductions_PerThread(iPoint, iVar, LinSysRes(iPoint, iVar), resRMS, resMax, idxMax);
     }
   }
   END_SU2_OMP_FOR

--- a/SU2_CFD/include/variables/CPrimitiveIndices.hpp
+++ b/SU2_CFD/include/variables/CPrimitiveIndices.hpp
@@ -90,7 +90,7 @@ struct CPrimitiveIndices {
   template <class ConcreteIndices>
   void Construct(IndexType nDim, IndexType nSpecies) {
     /*--- Build the indices object in the static buffer owned by this class. ---*/
-    static_assert(sizeof(ConcreteIndices) <= 2 * sizeof(IndexType), "");
+    static_assert(sizeof(ConcreteIndices) <= 2 * sizeof(IndexType));
     new(data_) ConcreteIndices(nDim, nSpecies);
   }
 

--- a/SU2_CFD/src/interfaces/CInterface.cpp
+++ b/SU2_CFD/src/interfaces/CInterface.cpp
@@ -63,7 +63,7 @@ void CInterface::BroadcastData(const CInterpolator& interpolator,
                                CSolver *donor_solution, CSolver *target_solution,
                                CGeometry *donor_geometry, CGeometry *target_geometry,
                                const CConfig *donor_config, const CConfig *target_config) {
-  static_assert(su2activematrix::Storage == StorageType::RowMajor,"");
+  static_assert(su2activematrix::Storage == StorageType::RowMajor);
 
   GetPhysical_Constants(donor_solution, target_solution, donor_geometry, target_geometry,
                         donor_config, target_config);
@@ -110,7 +110,7 @@ void CInterface::BroadcastData(const CInterpolator& interpolator,
     if (markDonor >= 0) {
 
       /*--- Apply contact resistance if specified. ---*/
-      
+
       SetContactResistance(donor_config->GetContactResistance(iMarkerInt));
 
       for (auto iVertex = 0ul, iSend = 0ul; iVertex < donor_geometry->GetnVertex(markDonor); iVertex++) {
@@ -235,7 +235,7 @@ void CInterface::PreprocessAverage(CGeometry *donor_geometry, CGeometry *target_
           /*--- If the tag hasn't matched any tag within the donor markers ---*/
       Marker_Donor = -1;
       Donor_Flag   = -1;
-   
+
   }
 
 #ifdef HAVE_MPI
@@ -423,7 +423,7 @@ void CInterface::AllgatherAverage(CSolver *donor_solution, CSolver *target_solut
     }
           /*--- If the tag hasn't matched any tag within the donor markers ---*/
       Marker_Donor = -1;
-   
+
   }
   /*--- Here we want to make available the quantities for all the processors and collect them in a buffer
    * for each span of the donor the span-wise height vector also so
@@ -538,7 +538,7 @@ void CInterface::AllgatherAverage(CSolver *donor_solution, CSolver *target_solut
     }
           /*--- If the tag hasn't matched any tag within the Flow markers ---*/
       Marker_Target = -1;
-   
+
   }
 
 

--- a/SU2_CFD/src/output/CFlowOutput.cpp
+++ b/SU2_CFD/src/output/CFlowOutput.cpp
@@ -979,12 +979,8 @@ void CFlowOutput::SetCustomOutputs(const CSolver* const* solver, const CGeometry
         }
         END_SU2_OMP_FOR
       }
-
-      SU2_OMP_CRITICAL {
-        integral[0] += local_integral[0];
-        integral[1] += local_integral[1];
-      }
-      END_SU2_OMP_CRITICAL
+      atomicAdd(local_integral[0], integral[0]);
+      atomicAdd(local_integral[1], integral[1]);
     }
     END_SU2_OMP_PARALLEL
 

--- a/SU2_CFD/src/solvers/CAdjEulerSolver.cpp
+++ b/SU2_CFD/src/solvers/CAdjEulerSolver.cpp
@@ -1422,7 +1422,7 @@ void CAdjEulerSolver::ExplicitEuler_Iteration(CGeometry *geometry, CSolver **sol
 void CAdjEulerSolver::ImplicitEuler_Iteration(CGeometry *geometry, CSolver **solver_container, CConfig *config) {
 
   unsigned short iVar;
-  unsigned long iPoint, total_index;
+  unsigned long iPoint;
   su2double Delta, *local_Res_TruncError, Vol;
 
   /*--- Set maximum residual to zero ---*/
@@ -1450,8 +1450,7 @@ void CAdjEulerSolver::ImplicitEuler_Iteration(CGeometry *geometry, CSolver **sol
     else {
       Jacobian.SetVal2Diag(iPoint, 1.0);
       for (iVar = 0; iVar < nVar; iVar++) {
-        total_index = iPoint*nVar + iVar;
-        LinSysRes[total_index] = 0.0;
+        LinSysRes(iPoint, iVar) = 0.0;
         local_Res_TruncError[iVar] = 0.0;
       }
     }
@@ -1459,11 +1458,10 @@ void CAdjEulerSolver::ImplicitEuler_Iteration(CGeometry *geometry, CSolver **sol
     /*--- Right hand side of the system (-Residual) and initial guess (x = 0) ---*/
 
     for (iVar = 0; iVar < nVar; iVar++) {
-      total_index = iPoint*nVar+iVar;
-      LinSysRes[total_index] = -(LinSysRes[total_index] + local_Res_TruncError[iVar]);
-      LinSysSol[total_index] = 0.0;
-      Residual_RMS[iVar] += LinSysRes[total_index]*LinSysRes[total_index];
-      AddRes_Max(iVar, fabs(LinSysRes[total_index]), geometry->nodes->GetGlobalIndex(iPoint), geometry->nodes->GetCoord(iPoint));
+      LinSysRes(iPoint, iVar) = -(LinSysRes(iPoint, iVar) + local_Res_TruncError[iVar]);
+      LinSysSol(iPoint, iVar) = 0.0;
+      Residual_RMS[iVar] += LinSysRes(iPoint, iVar)*LinSysRes(iPoint, iVar);
+      AddRes_Max(iVar, fabs(LinSysRes(iPoint, iVar)), geometry->nodes->GetGlobalIndex(iPoint), geometry->nodes->GetCoord(iPoint));
     }
 
   }
@@ -1472,9 +1470,8 @@ void CAdjEulerSolver::ImplicitEuler_Iteration(CGeometry *geometry, CSolver **sol
 
   for (iPoint = nPointDomain; iPoint < nPoint; iPoint++) {
     for (iVar = 0; iVar < nVar; iVar++) {
-      total_index = iPoint*nVar + iVar;
-      LinSysRes[total_index] = 0.0;
-      LinSysSol[total_index] = 0.0;
+      LinSysRes(iPoint, iVar) = 0.0;
+      LinSysSol(iPoint, iVar) = 0.0;
     }
   }
 

--- a/SU2_CFD/src/solvers/CAdjNSSolver.cpp
+++ b/SU2_CFD/src/solvers/CAdjNSSolver.cpp
@@ -1165,7 +1165,7 @@ void CAdjNSSolver::Viscous_Sensitivity(CGeometry *geometry, CSolver **solver_con
 void CAdjNSSolver::BC_HeatFlux_Wall(CGeometry *geometry, CSolver **solver_container, CNumerics *conv_numerics, CNumerics *visc_numerics, CConfig *config, unsigned short val_marker) {
 
   unsigned short iDim, iVar, jVar, jDim;
-  unsigned long iVertex, iPoint, total_index, Point_Normal;
+  unsigned long iVertex, iPoint, Point_Normal;
 
   su2double *d, l1psi, vartheta, Sigma_5, phi[3] = {};
   su2double sq_vel, ProjGridVel, Enthalpy = 0.0, *GridVel;
@@ -1501,8 +1501,7 @@ void CAdjNSSolver::BC_HeatFlux_Wall(CGeometry *geometry, CSolver **solver_contai
       if (implicit) {
         Jacobian.SubtractBlock2Diag(iPoint, Jacobian_ii);
         for (iVar = 1; iVar <= nDim; iVar++) {
-          total_index = iPoint*nVar+iVar;
-          Jacobian.DeleteValsRowi(total_index);
+          Jacobian.DeleteValsRowi(iPoint, iVar);
         }
       }
 
@@ -1527,7 +1526,7 @@ void CAdjNSSolver::BC_HeatFlux_Wall(CGeometry *geometry, CSolver **solver_contai
 
 void CAdjNSSolver::BC_Isothermal_Wall(CGeometry *geometry, CSolver **solver_container, CNumerics *conv_numerics, CNumerics *visc_numerics, CConfig *config, unsigned short val_marker) {
 
-  unsigned long iVertex, iPoint, total_index;
+  unsigned long iVertex, iPoint;
   unsigned short iDim, iVar, jVar, jDim;
   su2double *d, q, *U, dVisc_T, rho, pressure, div_phi,
   force_stress, Sigma_5, phi[3] = {0.0,0.0,0.0};
@@ -1632,8 +1631,7 @@ void CAdjNSSolver::BC_Isothermal_Wall(CGeometry *geometry, CSolver **solver_cont
         nodes->SetSolution_Old(iPoint,iDim+1, phi[iDim]);
       if (implicit) {
         for (iVar = 1; iVar <= nDim; iVar++) {
-          total_index = iPoint*nVar+iVar;
-          Jacobian.DeleteValsRowi(total_index);
+          Jacobian.DeleteValsRowi(iPoint, iVar);
         }
       }
 
@@ -1673,8 +1671,7 @@ void CAdjNSSolver::BC_Isothermal_Wall(CGeometry *geometry, CSolver **solver_cont
       nodes->SetSolution_Old(iPoint,nDim+1, q);
       if (implicit) {
         iVar = nDim+1;
-        total_index = iPoint*nVar+iVar;
-        Jacobian.DeleteValsRowi(total_index);
+        Jacobian.DeleteValsRowi(iPoint, iVar);
       }
 
       /*--- Additional contributions to adjoint density (weak imposition) ---*/

--- a/SU2_CFD/src/solvers/CAdjTurbSolver.cpp
+++ b/SU2_CFD/src/solvers/CAdjTurbSolver.cpp
@@ -184,7 +184,7 @@ void CAdjTurbSolver::BC_HeatFlux_Wall(CGeometry *geometry, CSolver **solver_cont
       LinSysRes.SetBlock_Zero(iPoint);
 
       /*--- Change rows of the Jacobian (includes 1 in the diagonal) ---*/
-      Jacobian.DeleteValsRowi(iPoint);
+      Jacobian.DeleteValsRowi(iPoint, 0);
 
     }
   }
@@ -208,7 +208,7 @@ void CAdjTurbSolver::BC_Isothermal_Wall(CGeometry *geometry, CSolver **solver_co
       LinSysRes.SetBlock_Zero(iPoint);
 
       /*--- Change rows of the Jacobian (includes 1 in the diagonal) ---*/
-      Jacobian.DeleteValsRowi(iPoint);
+      Jacobian.DeleteValsRowi(iPoint, 0);
 
     }
   }
@@ -455,7 +455,7 @@ void CAdjTurbSolver::Source_Residual(CGeometry *geometry, CSolver **solver_conta
 void CAdjTurbSolver::ImplicitEuler_Iteration(CGeometry *geometry, CSolver **solver_container, CConfig *config) {
 
   unsigned short iVar;
-  unsigned long iPoint, total_index;
+  unsigned long iPoint;
   su2double Delta, Vol;
 
   /*--- Set maximum residual to zero ---*/
@@ -479,11 +479,10 @@ void CAdjTurbSolver::ImplicitEuler_Iteration(CGeometry *geometry, CSolver **solv
     /*--- Right hand side of the system (-Residual) and initial guess (x = 0) ---*/
 
     for (iVar = 0; iVar < nVar; iVar++) {
-      total_index = iPoint*nVar+iVar;
-      LinSysRes[total_index] = -LinSysRes[total_index];
-      LinSysSol[total_index] = 0.0;
-      Residual_RMS[iVar] += LinSysRes[total_index]*LinSysRes[total_index];
-      AddRes_Max(iVar, fabs(LinSysRes[total_index]), geometry->nodes->GetGlobalIndex(iPoint), geometry->nodes->GetCoord(iPoint));
+      LinSysRes(iPoint, iVar) = -LinSysRes(iPoint, iVar);
+      LinSysSol(iPoint, iVar) = 0.0;
+      Residual_RMS[iVar] += LinSysRes(iPoint, iVar)*LinSysRes(iPoint, iVar);
+      AddRes_Max(iVar, fabs(LinSysRes(iPoint, iVar)), geometry->nodes->GetGlobalIndex(iPoint), geometry->nodes->GetCoord(iPoint));
     }
 
   }
@@ -492,9 +491,8 @@ void CAdjTurbSolver::ImplicitEuler_Iteration(CGeometry *geometry, CSolver **solv
 
   for (iPoint = nPointDomain; iPoint < nPoint; iPoint++) {
     for (iVar = 0; iVar < nVar; iVar++) {
-      total_index = iPoint*nVar + iVar;
-      LinSysRes[total_index] = 0.0;
-      LinSysSol[total_index] = 0.0;
+      LinSysRes(iPoint, iVar) = 0.0;
+      LinSysSol(iPoint, iVar) = 0.0;
     }
   }
 

--- a/SU2_CFD/src/solvers/CFEASolver.cpp
+++ b/SU2_CFD/src/solvers/CFEASolver.cpp
@@ -1296,9 +1296,7 @@ void CFEASolver::Compute_NodalStress(CGeometry *geometry, CNumerics **numerics, 
       maxVonMises = max(maxVonMises, vms);
     }
     END_SU2_OMP_FOR
-    SU2_OMP_CRITICAL
-    MaxVonMises_Stress = max(MaxVonMises_Stress, maxVonMises);
-    END_SU2_OMP_CRITICAL
+    atomicMax(maxVonMises, MaxVonMises_Stress);
 
     AD::EndPassive(wasActive);
 

--- a/SU2_CFD/src/solvers/CHeatSolver.cpp
+++ b/SU2_CFD/src/solvers/CHeatSolver.cpp
@@ -566,7 +566,7 @@ void CHeatSolver::BC_ConjugateHeat_Interface(CGeometry *geometry, CSolver **solv
         LinSysRes(iPoint, 0) = 0.0;
         nodes->SetRes_TruncErrorZero(iPoint);
 
-        if (implicit) Jacobian.DeleteValsRowi(iPoint);
+        if (implicit) Jacobian.DeleteValsRowi(iPoint, 0);
       }
     }
     END_SU2_OMP_FOR
@@ -848,13 +848,8 @@ void CHeatSolver::SetTime_Step(CGeometry *geometry, CSolver **solver_container, 
     }
     END_SU2_OMP_FOR
     /*--- Min/max over threads. ---*/
-    SU2_OMP_CRITICAL
-    {
-      Min_Delta_Time = min(Min_Delta_Time, minDt);
-      Max_Delta_Time = max(Max_Delta_Time, maxDt);
-      Global_Delta_Time = Min_Delta_Time;
-    }
-    END_SU2_OMP_CRITICAL
+    atomicMin(minDt, Min_Delta_Time);
+    atomicMax(maxDt, Max_Delta_Time);
   }
 
   /*--- Compute the min/max dt (in parallel, now over mpi ranks). ---*/
@@ -868,6 +863,7 @@ void CHeatSolver::SetTime_Step(CGeometry *geometry, CSolver **solver_container, 
       SU2_MPI::Allreduce(&Max_Delta_Time, &rbuf_time, 1, MPI_DOUBLE, MPI_MAX, SU2_MPI::GetComm());
       Max_Delta_Time = rbuf_time;
     }
+    Global_Delta_Time = Min_Delta_Time;
   } END_SU2_OMP_SAFE_GLOBAL_ACCESS
 
   /*--- For exact time solution use the minimum delta time of the whole mesh. ---*/
@@ -914,9 +910,7 @@ void CHeatSolver::SetTime_Step(CGeometry *geometry, CSolver **solver_container, 
       glbDtND = min(glbDtND, config->GetUnst_CFL()*Global_Delta_Time / nodes->GetLocalCFL(iPoint));
     }
     END_SU2_OMP_FOR
-    SU2_OMP_CRITICAL
-    Global_Delta_UnstTimeND = min(Global_Delta_UnstTimeND, glbDtND);
-    END_SU2_OMP_CRITICAL
+    atomicMin(glbDtND, Global_Delta_UnstTimeND);
 
     BEGIN_SU2_OMP_SAFE_GLOBAL_ACCESS
     {

--- a/SU2_CFD/src/solvers/CIncEulerSolver.cpp
+++ b/SU2_CFD/src/solvers/CIncEulerSolver.cpp
@@ -2006,9 +2006,7 @@ void CIncEulerSolver::SetBeta_Parameter(CGeometry *geometry, CSolver **solver_co
       maxVel2 = max(maxVel2, nodes->GetVelocity2(iPoint));
     END_SU2_OMP_FOR
 
-    SU2_OMP_CRITICAL
-    MaxVel2 = max(MaxVel2, maxVel2);
-    END_SU2_OMP_CRITICAL
+    atomicMax(maxVel2, MaxVel2);
 
     BEGIN_SU2_OMP_SAFE_GLOBAL_ACCESS
     {
@@ -2051,14 +2049,10 @@ void CIncEulerSolver::SetRangePressure(CGeometry *geometry, CSolver **solver_con
     }
     END_SU2_OMP_FOR
 
-    SU2_OMP_CRITICAL {
-      MinP = min(MinP, minP);
-      MaxP = max(MaxP, maxP);
-    }
-    END_SU2_OMP_CRITICAL
+    atomicMin(minP, MinP);
+    atomicMax(maxP, MaxP);
 
-    BEGIN_SU2_OMP_SAFE_GLOBAL_ACCESS
-    {
+    BEGIN_SU2_OMP_SAFE_GLOBAL_ACCESS {
       minP = MinP;
       SU2_MPI::Allreduce(&minP, &MinP, 1, MPI_DOUBLE, MPI_MAX, SU2_MPI::GetComm());
       maxP = MaxP;

--- a/SU2_CFD/src/solvers/CIncNSSolver.cpp
+++ b/SU2_CFD/src/solvers/CIncNSSolver.cpp
@@ -492,7 +492,7 @@ void CIncNSSolver::BC_Wall_Generic(const CGeometry *geometry, const CConfig *con
 
     if (implicit) {
       for (unsigned short iVar = 1; iVar <= nDim; iVar++)
-        Jacobian.DeleteValsRowi(iPoint*nVar+iVar);
+        Jacobian.DeleteValsRowi(iPoint, iVar);
     }
 
     if (!energy) continue;
@@ -644,8 +644,8 @@ void CIncNSSolver::BC_ConjugateHeat_Interface(CGeometry *geometry, CSolver **sol
 
     if (implicit) {
       for (unsigned short iVar = 1; iVar <= nDim; iVar++)
-        Jacobian.DeleteValsRowi(iPoint*nVar+iVar);
-      if (energy) Jacobian.DeleteValsRowi(iPoint*nVar+nDim+1);
+        Jacobian.DeleteValsRowi(iPoint, iVar);
+      if (energy) Jacobian.DeleteValsRowi(iPoint, nDim + 1);
     }
 
     if (!energy) continue;

--- a/SU2_CFD/src/solvers/CMeshSolver.cpp
+++ b/SU2_CFD/src/solvers/CMeshSolver.cpp
@@ -232,13 +232,9 @@ void CMeshSolver::SetMinMaxVolume(CGeometry *geometry, CConfig *config, bool upd
     if (ElemVolume <= 0.0) elCount++;
   }
   END_SU2_OMP_FOR
-  SU2_OMP_CRITICAL
-  {
-    MaxVolume = max(MaxVolume, maxVol);
-    MinVolume = min(MinVolume, minVol);
-    ElemCounter += elCount;
-  }
-  END_SU2_OMP_CRITICAL
+  atomicMax(maxVol, MaxVolume);
+  atomicMin(minVol, MinVolume);
+  atomicAdd(elCount, ElemCounter);
 
   BEGIN_SU2_OMP_SAFE_GLOBAL_ACCESS
   {
@@ -367,12 +363,9 @@ void CMeshSolver::SetWallDistance(CGeometry *geometry, CConfig *config) {
 
     }
     END_SU2_OMP_FOR
-    SU2_OMP_CRITICAL
-    {
-      MaxDistance = max(MaxDistance, MaxDistance_Local);
-      MinDistance = min(MinDistance, MinDistance_Local);
-    }
-    END_SU2_OMP_CRITICAL
+
+    atomicMax(MaxDistance_Local, MaxDistance);
+    atomicMin(MinDistance_Local, MinDistance);
 
     BEGIN_SU2_OMP_SAFE_GLOBAL_ACCESS
     {

--- a/SU2_CFD/src/solvers/CNEMONSSolver.cpp
+++ b/SU2_CFD/src/solvers/CNEMONSSolver.cpp
@@ -313,8 +313,7 @@ void CNEMONSSolver::BC_HeatFluxNonCatalytic_Wall(CGeometry *geometry,
     if (implicit) {
       /*--- Enforce the no-slip boundary condition in a strong way ---*/
       for (int iVar = nSpecies; iVar < nSpecies+nDim; iVar++) {
-        auto total_index = iPoint*nVar+iVar;
-        Jacobian.DeleteValsRowi(total_index);
+        Jacobian.DeleteValsRowi(iPoint, iVar);
       }
     }
 
@@ -349,7 +348,7 @@ void CNEMONSSolver::BC_HeatFluxCatalytic_Wall(CGeometry *geometry,
   SU2_MPI::Error("BC_HEATFLUX with catalytic wall: Not operational in NEMO.", CURRENT_FUNCTION);
   //TODO: SCALE WITH EDDY VISC
   /*--- Local variables ---*/
-  unsigned long iPoint, total_index;
+  unsigned long iPoint;
   su2double rho, Ys;
   su2double *Normal, Area;
   su2double *Ds, *dYdn, SdYdn;
@@ -493,8 +492,7 @@ void CNEMONSSolver::BC_HeatFluxCatalytic_Wall(CGeometry *geometry,
       if (implicit) {
         /*--- Enforce the no-slip boundary condition in a strong way ---*/
         for (auto iVar = nSpecies; iVar < nSpecies+nDim; iVar++) {
-          total_index = iPoint*nVar+iVar;
-          Jacobian.DeleteValsRowi(total_index);
+          Jacobian.DeleteValsRowi(iPoint, iVar);
         }
       }
 
@@ -632,8 +630,7 @@ void CNEMONSSolver::BC_IsothermalNonCatalytic_Wall(CGeometry *geometry,
       Jacobian.SubtractBlock2Diag(iPoint, Jacobian_i);
 
       for (auto iVar = 1u; iVar <= nDim; iVar++) {
-        auto total_index = iPoint*nVar+iVar;
-        Jacobian.DeleteValsRowi(total_index);
+        Jacobian.DeleteValsRowi(iPoint, iVar);
       }
     }
   }

--- a/SU2_CFD/src/solvers/CNSSolver.cpp
+++ b/SU2_CFD/src/solvers/CNSSolver.cpp
@@ -563,8 +563,7 @@ void CNSSolver::BC_HeatFlux_Wall_Generic(const CGeometry* geometry, const CConfi
       }
 
       for (auto iVar = 1u; iVar <= nDim; iVar++) {
-        auto total_index = iPoint*nVar+iVar;
-        Jacobian.DeleteValsRowi(total_index);
+        Jacobian.DeleteValsRowi(iPoint, iVar);
       }
     }
   }
@@ -755,8 +754,7 @@ void CNSSolver::BC_Isothermal_Wall_Generic(CGeometry *geometry, CSolver **solver
       Jacobian.AddBlock2Diag(iPoint, Jacobian_i);
 
       for (auto iVar = 1u; iVar <= nDim; iVar++) {
-        auto total_index = iPoint*nVar+iVar;
-        Jacobian.DeleteValsRowi(total_index);
+        Jacobian.DeleteValsRowi(iPoint, iVar);
       }
     }
   }

--- a/SU2_CFD/src/solvers/CRadP1Solver.cpp
+++ b/SU2_CFD/src/solvers/CRadP1Solver.cpp
@@ -491,7 +491,7 @@ void CRadP1Solver::BC_Marshak(CGeometry *geometry, CSolver **solver_container, C
 void CRadP1Solver::ImplicitEuler_Iteration(CGeometry *geometry, CSolver **solver_container, CConfig *config) {
 
   unsigned short iVar;
-  unsigned long iPoint, total_index, IterLinSol = 0;
+  unsigned long iPoint, IterLinSol = 0;
   su2double Vol;
   su2double Delta;
 
@@ -516,19 +516,17 @@ void CRadP1Solver::ImplicitEuler_Iteration(CGeometry *geometry, CSolver **solver
     else {
       Jacobian.SetVal2Diag(iPoint, 1.0);
       for (iVar = 0; iVar < nVar; iVar++) {
-        total_index = iPoint*nVar + iVar;
-        LinSysRes[total_index] = 0.0;
+        LinSysRes(iPoint, iVar) = 0.0;
       }
     }
 
     /*--- Right hand side of the system (-Residual) and initial guess (x = 0) ---*/
 
     for (iVar = 0; iVar < nVar; iVar++) {
-      total_index = iPoint*nVar+iVar;
-      LinSysRes[total_index] = - (LinSysRes[total_index]);
-      LinSysSol[total_index] = 0.0;
-      Residual_RMS[iVar] += LinSysRes[total_index]*LinSysRes[total_index];
-      AddRes_Max(iVar, fabs(LinSysRes[total_index]), geometry->nodes->GetGlobalIndex(iPoint), geometry->nodes->GetCoord(iPoint));
+      LinSysRes(iPoint, iVar) = -LinSysRes(iPoint, iVar);
+      LinSysSol(iPoint, iVar) = 0.0;
+      Residual_RMS[iVar] += LinSysRes(iPoint, iVar)*LinSysRes(iPoint, iVar);
+      AddRes_Max(iVar, fabs(LinSysRes(iPoint, iVar)), geometry->nodes->GetGlobalIndex(iPoint), geometry->nodes->GetCoord(iPoint));
     }
   }
 
@@ -536,9 +534,8 @@ void CRadP1Solver::ImplicitEuler_Iteration(CGeometry *geometry, CSolver **solver
 
   for (iPoint = nPointDomain; iPoint < nPoint; iPoint++) {
     for (iVar = 0; iVar < nVar; iVar++) {
-      total_index = iPoint*nVar + iVar;
-      LinSysRes[total_index] = 0.0;
-      LinSysSol[total_index] = 0.0;
+      LinSysRes(iPoint, iVar) = 0.0;
+      LinSysSol(iPoint, iVar) = 0.0;
     }
   }
 

--- a/SU2_CFD/src/solvers/CSolver.cpp
+++ b/SU2_CFD/src/solvers/CSolver.cpp
@@ -1014,7 +1014,7 @@ void CSolver::CompletePeriodicComms(CGeometry *geometry,
   unsigned short nPeriodic = config->GetnMarker_Periodic();
   unsigned short iDim, jDim, iVar, jVar, iPeriodic, nNeighbor;
 
-  unsigned long iPoint, iRecv, nRecv, msg_offset, buf_offset, total_index;
+  unsigned long iPoint, iRecv, nRecv, msg_offset, buf_offset;
 
   int source, iMessage, jRecv;
 
@@ -1159,8 +1159,7 @@ void CSolver::CompletePeriodicComms(CGeometry *geometry,
                 if (iPeriodic == val_periodic_index + nPeriodic/2) {
                   for (iVar = 0; iVar < nVar; iVar++) {
                     LinSysRes(iPoint, iVar) = 0.0;
-                    total_index = iPoint*nVar+iVar;
-                    Jacobian.DeleteValsRowi(total_index);
+                    Jacobian.DeleteValsRowi(iPoint, iVar);
                   }
                 }
 
@@ -1932,13 +1931,9 @@ void CSolver::AdaptCFLNumber(CGeometry **geometry,
     /* Reduce the min/max/avg local CFL numbers. */
 
     if ((iMesh == MESH_0) && fullComms) {
-      SU2_OMP_CRITICAL
-      { /* OpenMP reduction. */
-        Min_CFL_Local = min(Min_CFL_Local,myCFLMin);
-        Max_CFL_Local = max(Max_CFL_Local,myCFLMax);
-        Avg_CFL_Local += myCFLSum;
-      }
-      END_SU2_OMP_CRITICAL
+      atomicMin(myCFLMin, Min_CFL_Local);
+      atomicMax(myCFLMax, Max_CFL_Local);
+      atomicAdd(myCFLSum, Avg_CFL_Local);
 
       BEGIN_SU2_OMP_SAFE_GLOBAL_ACCESS
       { /* MPI reduction. */

--- a/SU2_CFD/src/solvers/CSpeciesFlameletSolver.cpp
+++ b/SU2_CFD/src/solvers/CSpeciesFlameletSolver.cpp
@@ -214,7 +214,7 @@ void CSpeciesFlameletSolver::SetInitialCondition(CGeometry** geometry, CSolver**
     for (unsigned long i_mesh = 0; i_mesh <= config->GetnMGLevels(); i_mesh++) {
       fluid_model_local = solver_container[i_mesh][FLOW_SOL]->GetFluidModel();
       if (flame_front_ignition) prog_burnt = GetBurntProgressVariable(fluid_model_local, scalar_init);
-      
+
       for (auto iVar = 0u; iVar < nVar; iVar++) scalar_init[iVar] = config->GetSpecies_Init()[iVar];
 
       /*--- Set enthalpy based on initial temperature and scalars. ---*/
@@ -460,8 +460,7 @@ void CSpeciesFlameletSolver::BC_Isothermal_Wall_Generic(CGeometry* geometry, CSo
         nodes->SetVal_ResTruncError_Zero(iPoint, I_ENTH);
 
         if (implicit) {
-          unsigned long total_index = iPoint * nVar + I_ENTH;
-          Jacobian.DeleteValsRowi(total_index);
+          Jacobian.DeleteValsRowi(iPoint, I_ENTH);
         }
       } else {
         /*--- Weak BC formulation. ---*/

--- a/SU2_CFD/src/solvers/CSpeciesSolver.cpp
+++ b/SU2_CFD/src/solvers/CSpeciesSolver.cpp
@@ -357,15 +357,14 @@ void CSpeciesSolver::BC_Inlet(CGeometry* geometry, CSolver** solver_container, C
 
     if (!geometry->nodes->GetDomain(iPoint)) continue;
 
-    if (config->GetMarker_StrongBC(Marker_Tag)==true) {
+    if (config->GetMarker_StrongBC(Marker_Tag)) {
       nodes->SetSolution_Old(iPoint, Inlet_SpeciesVars[val_marker][iVertex]);
 
       LinSysRes.SetBlock_Zero(iPoint);
 
       /*--- Includes 1 in the diagonal ---*/
       for (auto iVar = 0u; iVar < nVar; iVar++) {
-        auto total_index = iPoint * nVar + iVar;
-        Jacobian.DeleteValsRowi(total_index);
+        Jacobian.DeleteValsRowi(iPoint, iVar);
       }
     } else {  // weak BC
       /*--- Normal vector for this vertex (negate for outward convention) ---*/
@@ -473,8 +472,7 @@ void CSpeciesSolver::BC_Wall_Generic(CGeometry* geometry, CSolver** solver_conta
           nodes->SetSolution_Old(iPoint, iVar, WallSpecies);
           LinSysRes(iPoint, iVar) = 0.0;
           if (implicit) {
-            unsigned long total_index = iPoint * nVar + iVar;
-            Jacobian.DeleteValsRowi(total_index);
+            Jacobian.DeleteValsRowi(iPoint, iVar);
           }
         break;
       }
@@ -547,8 +545,7 @@ void CSpeciesSolver::BC_Outlet(CGeometry* geometry, CSolver** solver_container, 
 
       /*--- Includes 1 on the diagonal ---*/
       for (auto iVar = 0u; iVar < nVar; iVar++) {
-        auto total_index = iPoint * nVar + iVar;
-        Jacobian.DeleteValsRowi(total_index);
+        Jacobian.DeleteValsRowi(iPoint, iVar);
       }
     } else {  // weak BC
 

--- a/SU2_CFD/src/solvers/CTurbSASolver.cpp
+++ b/SU2_CFD/src/solvers/CTurbSASolver.cpp
@@ -301,7 +301,7 @@ void CTurbSASolver::Viscous_Residual(const unsigned long iEdge, const CGeometry*
     /*--- Roughness heights. ---*/
     numerics->SetRoughness(geometry->nodes->GetRoughnessHeight(iPoint), geometry->nodes->GetRoughnessHeight(jPoint));
   };
-  
+
   /*--- Now instantiate the generic non-conservative implementation with the functor above. ---*/
   Viscous_Residual_NonCons(iEdge, geometry, solver_container, numerics, config, SolverSpecificNumerics);
 
@@ -479,7 +479,7 @@ void CTurbSASolver::BC_HeatFlux_Wall(CGeometry *geometry, CSolver **solver_conta
 
         /*--- Includes 1 in the diagonal ---*/
 
-        if (implicit) Jacobian.DeleteValsRowi(iPoint);
+        if (implicit) Jacobian.DeleteValsRowi(iPoint, 0);
        } else {
          /*--- For rough walls, the boundary condition is given by
           * (\frac{\partial \nu}{\partial n})_wall = \frac{\nu}{0.03*k_s}
@@ -1342,7 +1342,7 @@ void CTurbSASolver::SetTurbVars_WF(CGeometry *geometry, CSolver **solver_contain
 
       /*--- includes 1 in the diagonal ---*/
 
-      if (implicit) Jacobian.DeleteValsRowi(iPoint_Neighbor);
+      if (implicit) Jacobian.DeleteValsRowi(iPoint_Neighbor, 0);
     }
   }
 }

--- a/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
+++ b/SU2_CFD/src/solvers/CTurbSSTSolver.cpp
@@ -505,8 +505,8 @@ void CTurbSSTSolver::BC_HeatFlux_Wall(CGeometry *geometry, CSolver **solver_cont
 
     if (implicit) {
       /*--- Change rows of the Jacobian (includes 1 in the diagonal) ---*/
-      Jacobian.DeleteValsRowi(iPoint*nVar);
-      Jacobian.DeleteValsRowi(iPoint*nVar+1);
+      Jacobian.DeleteValsRowi(iPoint, 0);
+      Jacobian.DeleteValsRowi(iPoint, 1);
     }
   }
   END_SU2_OMP_FOR
@@ -568,8 +568,8 @@ void CTurbSSTSolver::SetTurbVars_WF(CGeometry *geometry, CSolver **solver_contai
 
     if (implicit) {
       /*--- includes 1 in the diagonal ---*/
-      Jacobian.DeleteValsRowi(iPoint_Neighbor*nVar);
-      Jacobian.DeleteValsRowi(iPoint_Neighbor*nVar+1);
+      Jacobian.DeleteValsRowi(iPoint_Neighbor, 0);
+      Jacobian.DeleteValsRowi(iPoint_Neighbor, 1);
     }
   }
 }

--- a/SU2_CFD/src/solvers/CTurbSolver.cpp
+++ b/SU2_CFD/src/solvers/CTurbSolver.cpp
@@ -229,7 +229,7 @@ void CTurbSolver::Impose_Fixed_Values(const CGeometry *geometry, const CConfig *
         if (implicit) {
           /*--- Change rows of the Jacobian (includes 1 in the diagonal) ---*/
           for(unsigned long iVar=0; iVar<nVar; iVar++)
-            Jacobian.DeleteValsRowi(iPoint*nVar+iVar);
+            Jacobian.DeleteValsRowi(iPoint, iVar);
         }
       }
     }


### PR DESCRIPTION
## Proposed Changes
OpenMP 5.1 allows more efficient min/max than how we were doing them.
Also cleaned up `CSysVector[i * n + j]` to just `CSysVector(i, j)`


## PR Checklist
- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [X] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [X] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [X] I have added a test case that demonstrates my contribution, if necessary.
- [X] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
