### PR TITLE
Feature: Add Iteration Wall-Clock Timing (ITER_TIME)

### DIFF
--- a/SU2_CFD/include/output/COutput.hpp
+++ b/SU2_CFD/include/output/COutput.hpp
@@ -93,6 +93,8 @@ protected:
   curOuterIter,                   /*!< \brief Current value of the outer iteration index */
   curInnerIter;                   /*!< \brief Current value of the inner iteration index */
 
+  su2double PrevStopTime;         /*!< \brief Previous stop time for iteration timing. */
+
   string historyFilename;   /*!< \brief The history filename*/
   ofstream histFile;        /*!< \brief Output file stream for the history */
 

--- a/SU2_CFD/src/output/COutput.cpp
+++ b/SU2_CFD/src/output/COutput.cpp
@@ -2088,8 +2088,6 @@ void COutput::SetCommonHistoryFields() {
   AddHistoryOutput("OUTER_ITER", "Outer_Iter", ScreenOutputFormat::INTEGER, "ITER", "Outer iteration index");
   /// DESCRIPTION: The inner iteration index.
   AddHistoryOutput("INNER_ITER", "Inner_Iter", ScreenOutputFormat::INTEGER,  "ITER", "Inner iteration index");
-  /// DESCRIPTION: The current iteration calculation time.
-  AddHistoryOutput("ITER_TIME", "Time(s)", ScreenOutputFormat::FIXED, "ITER", "Time per iteration (s)");
   /// END_GROUP
 
   /// BEGIN_GROUP: TIME_DOMAIN, DESCRIPTION: Time integration information
@@ -2098,8 +2096,12 @@ void COutput::SetCommonHistoryFields() {
   /// Description: The current time step
   AddHistoryOutput("TIME_STEP", "Time_Step", ScreenOutputFormat::SCIENTIFIC, "TIME_DOMAIN", "Current time step (s)");
 
+  /// BEGIN_GROUP: WALL_TIME, DESCRIPTION: Wall-clock timing information.
+  /// DESCRIPTION: The current iteration wall-clock time.
+  AddHistoryOutput("ITER_TIME", "Time(sec)", ScreenOutputFormat::FIXED, "WALL_TIME", "Time per iteration (s)");
   /// DESCRIPTION: Currently used wall-clock time.
   AddHistoryOutput("WALL_TIME", "Time(sec)", ScreenOutputFormat::SCIENTIFIC, "WALL_TIME", "Average wall-clock time since the start of inner iterations.");
+  /// END_GROUP
 
   AddHistoryOutput("NONPHYSICAL_POINTS", "Nonphysical_Points", ScreenOutputFormat::INTEGER, "NONPHYSICAL_POINTS", "The number of non-physical points in the solution");
 

--- a/SU2_CFD/src/output/COutput.cpp
+++ b/SU2_CFD/src/output/COutput.cpp
@@ -71,6 +71,7 @@ COutput::COutput(const CConfig *config, unsigned short ndim, bool fem_output):
 
   cauchyTimeConverged = false;
   maxTimeDelayActive = false;
+  PrevStopTime = 0.0;
 
   convergenceTable = new PrintingToolbox::CTablePrinter(&std::cout);
   multiZoneHeaderTable = new PrintingToolbox::CTablePrinter(&std::cout);
@@ -2087,6 +2088,8 @@ void COutput::SetCommonHistoryFields() {
   AddHistoryOutput("OUTER_ITER", "Outer_Iter", ScreenOutputFormat::INTEGER, "ITER", "Outer iteration index");
   /// DESCRIPTION: The inner iteration index.
   AddHistoryOutput("INNER_ITER", "Inner_Iter", ScreenOutputFormat::INTEGER,  "ITER", "Inner iteration index");
+  /// DESCRIPTION: The current iteration calculation time.
+  AddHistoryOutput("ITER_TIME", "Time(s)", ScreenOutputFormat::FIXED, "ITER", "Time per iteration (s)");
   /// END_GROUP
 
   /// BEGIN_GROUP: TIME_DOMAIN, DESCRIPTION: Time integration information
@@ -2288,13 +2291,21 @@ void COutput::LoadCommonHistoryData(const CConfig *config) {
   SetHistoryOutputValue("INNER_ITER", curInnerIter);
   SetHistoryOutputValue("OUTER_ITER", curOuterIter);
 
-  su2double StopTime, UsedTime;
+  su2double StopTime, UsedTime, IterTime;
 
   StopTime = SU2_MPI::Wtime();
 
   UsedTime = (StopTime - config->Get_StartTime())/(curInnerIter+1);
 
+  if (curInnerIter == 0) {
+    IterTime = StopTime - config->Get_StartTime(); // First iteration measured from start
+  } else {
+    IterTime = StopTime - PrevStopTime;
+  }
+  PrevStopTime = StopTime;
+
   SetHistoryOutputValue("WALL_TIME", UsedTime);
+  SetHistoryOutputValue("ITER_TIME", IterTime);
 
   SetHistoryOutputValue("NONPHYSICAL_POINTS", config->GetNonphysical_Points());
 }

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -2366,7 +2366,7 @@ GRAD_LINEAR_SOLVER_ERROR= 1E-14
 % ------------------------- SCREEN/HISTORY VOLUME OUTPUT --------------------------%
 %
 % Screen output fields (use 'SU2_CFD -d <config_file>' to view list of available fields)
-SCREEN_OUTPUT= (INNER_ITER, RMS_DENSITY, RMS_MOMENTUM-X, RMS_MOMENTUM-Y, RMS_ENERGY)
+SCREEN_OUTPUT= (INNER_ITER, ITER_TIME, RMS_DENSITY, RMS_MOMENTUM-X, RMS_MOMENTUM-Y, RMS_ENERGY)
 %
 % History output groups (use 'SU2_CFD -d <config_file>' to view list of available fields)
 HISTORY_OUTPUT= (ITER, RMS_RES)


### PR DESCRIPTION
## Proposed Changes
This pull request introduces the `ITER_TIME` field, which prints the physical wall-clock time elapsed during the inner iteration step as an optional diagnostic column.
- Uses `SU2_MPI::Wtime()` synchronously across ranks to capture precise delta times between iteration steps.
- Designed as an opt-in metric via `SCREEN_OUTPUT` or `HISTORY_OUTPUT` configuration properties. It does not clutter the default console arrays, protecting the `TestCases` baseline reference setups in the CI pipeline.
- Handles padding organically aligned to `ScreenOutputFormat::FIXED` to retain the tight aesthetic tracking without jitter.

## Related Work
N/A

## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [x] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [x] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [x] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
