### PR TITLE
Fix #2409: Add missing headers/defines for strict POSIX/Linux compilation

### DIFF
--- a/externals/cgns/adf/ADF_internals.c
+++ b/externals/cgns/adf/ADF_internals.c
@@ -171,6 +171,7 @@ bytes   start   end   description      range / format
 #endif
 #include <sys/types.h>
 #include <time.h>
+#define _POSIX_SOURCE
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>

--- a/externals/metis/GKlib/gkregex.c
+++ b/externals/metis/GKlib/gkregex.c
@@ -52,6 +52,7 @@ void gkfooo() { return; }
 # include "../locale/localeinfo.h"
 #endif
 
+#include <strings.h>
 #include "GKlib.h"
 
 


### PR DESCRIPTION
This PR resolves issue #2409. I added the #define _POSIX_SOURCE macro to ADF_internals.c and included <strings.h> in gkregex.c to fix the strict POSIX compilation errors on Linux systems.