### PR TITLE
Allow FSI+CHT (aerothermoelasticity)

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -233,7 +233,7 @@ jobs:
         uses: docker://ghcr.io/su2code/su2/test-su2:260405-0054
         with:
           # -t <Tutorials-branch> -c <Testcases-branch>
-          args: -b ${{github.ref}} -t develop -c pedro/fea_fsi -s ${{matrix.testscript}}
+          args: -b ${{github.ref}} -t develop -c pedro/fsi_cht -s ${{matrix.testscript}}
       - name: Cleanup
         uses: docker://ghcr.io/su2code/su2/test-su2:260405-0054
         with:
@@ -282,7 +282,7 @@ jobs:
         uses: docker://ghcr.io/su2code/su2/test-su2:260405-0054
         with:
           # -t <Tutorials-branch> -c <Testcases-branch>
-          args: -b ${{github.ref}} -t develop -c pedro/fea_fsi -s ${{matrix.testscript}} -a "--tapetests"
+          args: -b ${{github.ref}} -t develop -c pedro/fsi_cht -s ${{matrix.testscript}} -a "--tapetests"
       - name: Cleanup
         uses: docker://ghcr.io/su2code/su2/test-su2:260405-0054
         with:
@@ -330,7 +330,7 @@ jobs:
           PMIX_MCA_gds: hash
         with:
           # -t <Tutorials-branch> -c <Testcases-branch>
-          args: -b ${{github.ref}} -t develop -c pedro/fea_fsi -s ${{matrix.testscript}} -a "--tsan"
+          args: -b ${{github.ref}} -t develop -c pedro/fsi_cht -s ${{matrix.testscript}} -a "--tsan"
       - name: Cleanup
         uses: docker://ghcr.io/su2code/su2/test-su2-tsan:260405-0054
         with:
@@ -375,7 +375,7 @@ jobs:
         uses: docker://ghcr.io/su2code/su2/test-su2-asan:260405-0054
         with:
           # -t <Tutorials-branch> -c <Testcases-branch>
-          args: -b ${{github.ref}} -t develop -c pedro/fea_fsi -s ${{matrix.testscript}} -a "--asan"
+          args: -b ${{github.ref}} -t develop -c pedro/fsi_cht -s ${{matrix.testscript}} -a "--asan"
       - name: Cleanup
         uses: docker://ghcr.io/su2code/su2/test-su2-asan:260405-0054
         with:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -233,7 +233,7 @@ jobs:
         uses: docker://ghcr.io/su2code/su2/test-su2:260405-0054
         with:
           # -t <Tutorials-branch> -c <Testcases-branch>
-          args: -b ${{github.ref}} -t develop -c pedro/fsi_cht -s ${{matrix.testscript}}
+          args: -b ${{github.ref}} -t develop -c develop -s ${{matrix.testscript}}
       - name: Cleanup
         uses: docker://ghcr.io/su2code/su2/test-su2:260405-0054
         with:
@@ -282,7 +282,7 @@ jobs:
         uses: docker://ghcr.io/su2code/su2/test-su2:260405-0054
         with:
           # -t <Tutorials-branch> -c <Testcases-branch>
-          args: -b ${{github.ref}} -t develop -c pedro/fsi_cht -s ${{matrix.testscript}} -a "--tapetests"
+          args: -b ${{github.ref}} -t develop -c develop -s ${{matrix.testscript}} -a "--tapetests"
       - name: Cleanup
         uses: docker://ghcr.io/su2code/su2/test-su2:260405-0054
         with:
@@ -330,7 +330,7 @@ jobs:
           PMIX_MCA_gds: hash
         with:
           # -t <Tutorials-branch> -c <Testcases-branch>
-          args: -b ${{github.ref}} -t develop -c pedro/fsi_cht -s ${{matrix.testscript}} -a "--tsan"
+          args: -b ${{github.ref}} -t develop -c develop -s ${{matrix.testscript}} -a "--tsan"
       - name: Cleanup
         uses: docker://ghcr.io/su2code/su2/test-su2-tsan:260405-0054
         with:
@@ -375,7 +375,7 @@ jobs:
         uses: docker://ghcr.io/su2code/su2/test-su2-asan:260405-0054
         with:
           # -t <Tutorials-branch> -c <Testcases-branch>
-          args: -b ${{github.ref}} -t develop -c pedro/fsi_cht -s ${{matrix.testscript}} -a "--asan"
+          args: -b ${{github.ref}} -t develop -c develop -s ${{matrix.testscript}} -a "--asan"
       - name: Cleanup
         uses: docker://ghcr.io/su2code/su2/test-su2-asan:260405-0054
         with:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -233,7 +233,7 @@ jobs:
         uses: docker://ghcr.io/su2code/su2/test-su2:260405-0054
         with:
           # -t <Tutorials-branch> -c <Testcases-branch>
-          args: -b ${{github.ref}} -t develop -c develop -s ${{matrix.testscript}}
+          args: -b ${{github.ref}} -t develop -c pedro/fea_fsi -s ${{matrix.testscript}}
       - name: Cleanup
         uses: docker://ghcr.io/su2code/su2/test-su2:260405-0054
         with:
@@ -282,7 +282,7 @@ jobs:
         uses: docker://ghcr.io/su2code/su2/test-su2:260405-0054
         with:
           # -t <Tutorials-branch> -c <Testcases-branch>
-          args: -b ${{github.ref}} -t develop -c develop -s ${{matrix.testscript}} -a "--tapetests"
+          args: -b ${{github.ref}} -t develop -c pedro/fea_fsi -s ${{matrix.testscript}} -a "--tapetests"
       - name: Cleanup
         uses: docker://ghcr.io/su2code/su2/test-su2:260405-0054
         with:
@@ -330,7 +330,7 @@ jobs:
           PMIX_MCA_gds: hash
         with:
           # -t <Tutorials-branch> -c <Testcases-branch>
-          args: -b ${{github.ref}} -t develop -c develop -s ${{matrix.testscript}} -a "--tsan"
+          args: -b ${{github.ref}} -t develop -c pedro/fea_fsi -s ${{matrix.testscript}} -a "--tsan"
       - name: Cleanup
         uses: docker://ghcr.io/su2code/su2/test-su2-tsan:260405-0054
         with:
@@ -375,7 +375,7 @@ jobs:
         uses: docker://ghcr.io/su2code/su2/test-su2-asan:260405-0054
         with:
           # -t <Tutorials-branch> -c <Testcases-branch>
-          args: -b ${{github.ref}} -t develop -c develop -s ${{matrix.testscript}} -a "--asan"
+          args: -b ${{github.ref}} -t develop -c pedro/fea_fsi -s ${{matrix.testscript}} -a "--asan"
       - name: Cleanup
         uses: docker://ghcr.io/su2code/su2/test-su2-asan:260405-0054
         with:

--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -1311,9 +1311,9 @@ void CConfig::SetConfig_Options() {
   /* DESCRIPTION: Definition of the turbulent thermal conductivity model (CONSTANT_PRANDTL_TURB (default), NONE). */
   addEnumOption("TURBULENT_CONDUCTIVITY_MODEL", Kind_ConductivityModel_Turb, TurbConductivityModel_Map, CONDUCTIVITYMODEL_TURB::CONSTANT_PRANDTL);
 
- /*--- Options related to Constant Thermal Conductivity Model ---*/
+  /*--- Options related to Constant Thermal Conductivity Model ---*/
 
- /* DESCRIPTION: default value for AIR */
+  /* DESCRIPTION: default value for AIR */
   addDoubleListOption("THERMAL_CONDUCTIVITY_CONSTANT", nThermal_Conductivity_Constant , Thermal_Conductivity_Constant);
 
   /*--- Options related to temperature polynomial coefficients for fluid models. ---*/

--- a/SU2_CFD/include/interfaces/CInterface.hpp
+++ b/SU2_CFD/include/interfaces/CInterface.hpp
@@ -29,6 +29,7 @@
 #pragma once
 
 #include "../../../Common/include/parallelization/mpi_structure.hpp"
+#include "../../../Common/include/option_structure.hpp"
 
 #include <cmath>
 #include <string>
@@ -77,7 +78,7 @@ public:
   /*!
    * \brief Constructor of the class.
    */
-  CInterface(void);
+  CInterface();
 
   /*!
    * \overload
@@ -89,7 +90,7 @@ public:
   /*!
    * \brief Destructor of the class.
    */
-  virtual ~CInterface(void);
+  virtual ~CInterface();
 
   /*!
    * \brief Interpolate data and broadcast it into all processors, for nonmatching meshes.
@@ -224,4 +225,11 @@ public:
    * \param[in] val_contact_resistance - Contact resistance value in m^2/W
    */
   inline virtual void SetContactResistance(su2double val_contact_resistance) {};
+
+  /*!
+   * \brief These can be used to chain interfaces between the same zones but for other variables,
+   * without having to mix physics in the interface classes. Currently this is used for FSI+CHT.
+   */
+  ENUM_TRANSFER NextInterfaceType = ENUM_TRANSFER::NO_TRANSFER;
+  CInterface* NextInterface = nullptr;
 };

--- a/SU2_CFD/src/drivers/CDriver.cpp
+++ b/SU2_CFD/src/drivers/CDriver.cpp
@@ -2443,6 +2443,31 @@ void CDriver::InitializeInterface(CConfig **config, CSolver***** solver, CGeomet
         interpolation[donor][target] = unique_ptr<CInterpolator>(CInterpolatorFactory::CreateInterpolator(
                                        geometry, config, interpolation[target][donor].get(), donor, target));
 
+        /*--- Helpers with logic to create CHT interfaces. ---*/
+
+        auto GetChtInterfaceType = [donor, target, config](bool heat_donor, bool heat_target) {
+          if (heat_donor && heat_target) return CONJUGATE_HEAT_SS;
+
+          const auto fluidZone = heat_target ? donor : target;
+          if (config[fluidZone]->GetEnergy_Equation() ||
+              config[fluidZone]->GetKind_Regime() == ENUM_REGIME::COMPRESSIBLE ||
+              config[fluidZone]->GetKind_FluidModel() == ENUM_FLUIDMODEL::FLUID_FLAMELET) {
+            return heat_target ? CONJUGATE_HEAT_FS : CONJUGATE_HEAT_SF;
+          } else if (config[fluidZone]->GetWeakly_Coupled_Heat()) {
+            return heat_target ? CONJUGATE_HEAT_WEAKLY_FS : CONJUGATE_HEAT_WEAKLY_SF;
+          }
+          return NO_TRANSFER;
+        };
+
+        auto MakeChtInterface = [&](const auto type) {
+          if (type != NO_TRANSFER) {
+            if (rank == MASTER_NODE) cout << " Conjugate heat variables." << endl;
+            return new CConjugateHeatInterface(4, 0);
+          }
+          if (rank == MASTER_NODE) cout << " NO heat variables." << endl;
+          return static_cast<CConjugateHeatInterface*>(nullptr);
+        };
+
         /*--- The type of variables transferred depends on the donor/target physics. ---*/
 
         const bool heat_target = config[target]->GetHeatProblem();
@@ -2467,6 +2492,11 @@ void CDriver::InitializeInterface(CConfig **config, CSolver***** solver, CGeomet
             interface[donor][target] = new CDiscAdjFlowTractionInterface(nDim, nConst, config[donor], conservative);
           }
           if (rank == MASTER_NODE) cout << "fluid " << (conservative? "forces." : "tractions.") << endl;
+
+          if (config[target]->GetWeakly_Coupled_Heat()) {
+            interface[donor][target]->NextInterfaceType = GetChtInterfaceType(false, true);
+            interface[donor][target]->NextInterface = MakeChtInterface(interface[donor][target]->NextInterfaceType);
+          }
         }
         else if (structural_donor && (fluid_target || heat_target)) {
           if (solver_container[target][INST_0][MESH_0][MESH_SOL] == nullptr) {
@@ -2474,9 +2504,14 @@ void CDriver::InitializeInterface(CConfig **config, CSolver***** solver, CGeomet
                            "Use DEFORM_MESH=YES, and setup MARKER_DEFORM_MESH=(...)", CURRENT_FUNCTION);
           }
           interface_type = BOUNDARY_DISPLACEMENTS;
-          if (!config[donor]->GetTime_Domain()) interface[donor][target] = new CDisplacementsInterface(nDim, 0);
-          else interface[donor][target] = new CDisplacementsInterface(2*nDim, 0);
+          const auto nVar = config[donor]->GetTime_Domain() ? 2 * nDim : nDim;
+          interface[donor][target] = new CDisplacementsInterface(nVar, 0);
           if (rank == MASTER_NODE) cout << "boundary displacements from the structural solver." << endl;
+
+          if (fluid_target && config[donor]->GetWeakly_Coupled_Heat()) {
+            interface[donor][target]->NextInterfaceType = GetChtInterfaceType(true, false);
+            interface[donor][target]->NextInterface = MakeChtInterface(interface[donor][target]->NextInterfaceType);
+          }
         }
         else if (fluid_donor && fluid_target) {
           /*--- Interface handling for turbomachinery applications. ---*/
@@ -2487,14 +2522,14 @@ void CDriver::InitializeInterface(CConfig **config, CSolver***** solver, CGeomet
                 interface_type = MIXING_PLANE;
                 auto nVar = solver[donor][INST_0][MESH_0][FLOW_SOL]->GetnVar();
                 interface[donor][target] = new CMixingPlaneInterface(nVar, 0);
-                if (rank == MASTER_NODE) cout << "using a mixing-plane interface from donor zone " << donor << " to target zone " << target << "." << endl;
+                if (rank == MASTER_NODE) cout << " Using a mixing-plane interface from donor zone " << donor << " to target zone " << target << "." << endl;
                 break;
               }
               case TURBO_INTERFACE_KIND::FROZEN_ROTOR: {
                 auto nVar = solver[donor][INST_0][MESH_0][FLOW_SOL]->GetnPrimVar();
                 interface_type = SLIDING_INTERFACE;
                 interface[donor][target] = new CSlidingInterface(nVar, 0);
-                if (rank == MASTER_NODE) cout << "using a fluid interface interface from donor zone " << donor << " to target zone " << target << "." << endl;
+                if (rank == MASTER_NODE) cout << " Using a fluid interface interface from donor zone " << donor << " to target zone " << target << "." << endl;
               }
             }
           }
@@ -2502,33 +2537,12 @@ void CDriver::InitializeInterface(CConfig **config, CSolver***** solver, CGeomet
             auto nVar = solver[donor][INST_0][MESH_0][FLOW_SOL]->GetnPrimVar();
               interface_type = SLIDING_INTERFACE;
               interface[donor][target] = new CSlidingInterface(nVar, 0);
-              if (rank == MASTER_NODE) cout << "sliding interface." << endl;
+              if (rank == MASTER_NODE) cout << " Sliding interface." << endl;
           }
         }
         else if (heat_donor || heat_target) {
-          if (heat_donor && heat_target){
-            interface_type = CONJUGATE_HEAT_SS;
-
-          } else {
-
-            const auto fluidZone = heat_target? donor : target;
-            if (config[fluidZone]->GetEnergy_Equation() || (config[fluidZone]->GetKind_Regime() == ENUM_REGIME::COMPRESSIBLE)
-                || (config[fluidZone]->GetKind_FluidModel() == ENUM_FLUIDMODEL::FLUID_FLAMELET))
-              interface_type = heat_target? CONJUGATE_HEAT_FS : CONJUGATE_HEAT_SF;
-            else if (config[fluidZone]->GetWeakly_Coupled_Heat())
-              interface_type = heat_target? CONJUGATE_HEAT_WEAKLY_FS : CONJUGATE_HEAT_WEAKLY_SF;
-            else
-              interface_type = NO_TRANSFER;
-          }
-
-          if (interface_type != NO_TRANSFER) {
-            auto nVar = 4;
-            interface[donor][target] = new CConjugateHeatInterface(nVar, 0);
-            if (rank == MASTER_NODE) cout << "conjugate heat variables." << endl;
-          }
-          else {
-            if (rank == MASTER_NODE) cout << "NO heat variables." << endl;
-          }
+          interface_type = GetChtInterfaceType(heat_donor, heat_target);
+          interface[donor][target] = MakeChtInterface(interface_type);
         }
         else {
           if (solver[donor][INST_0][MESH_0][FLOW_SOL] == nullptr)
@@ -2537,7 +2551,7 @@ void CDriver::InitializeInterface(CConfig **config, CSolver***** solver, CGeomet
           auto nVar = solver[donor][INST_0][MESH_0][FLOW_SOL]->GetnVar();
           interface_type = CONSERVATIVE_VARIABLES;
           interface[donor][target] = new CConservativeVarsInterface(nVar, 0);
-          if (rank == MASTER_NODE) cout << "generic conservative variables." << endl;
+          if (rank == MASTER_NODE) cout << " Generic conservative variables." << endl;
         }
       }
 

--- a/SU2_CFD/src/drivers/CMultizoneDriver.cpp
+++ b/SU2_CFD/src/drivers/CMultizoneDriver.cpp
@@ -549,19 +549,19 @@ bool CMultizoneDriver::TransferData(unsigned short donorZone, unsigned short tar
 
   /*--- Select the transfer method according to the magnitudes being transferred ---*/
 
-  auto BroadcastData = [&](int donorSol, int targetSol) {
-    interface_container[donorZone][targetZone]->BroadcastData(
-      *interpolator_container[donorZone][targetZone].get(),
-      solver_container[donorZone][INST_0][MESH_0][donorSol],
-      solver_container[targetZone][INST_0][MESH_0][targetSol],
-      geometry_container[donorZone][INST_0][MESH_0],
-      geometry_container[targetZone][INST_0][MESH_0],
-      config_container[donorZone],
-      config_container[targetZone]);
-  };
+  auto HandleInterfaceType = [&] (const auto interface_type, auto* interface) {
+    auto BroadcastData = [&](int donorSol, int targetSol) {
+      interface->BroadcastData(
+        *interpolator_container[donorZone][targetZone],
+        solver_container[donorZone][INST_0][MESH_0][donorSol],
+        solver_container[targetZone][INST_0][MESH_0][targetSol],
+        geometry_container[donorZone][INST_0][MESH_0],
+        geometry_container[targetZone][INST_0][MESH_0],
+        config_container[donorZone],
+        config_container[targetZone]);
+    };
 
-  switch (interface_types[donorZone][targetZone]) {
-
+    switch (interface_type) {
     case SLIDING_INTERFACE:
       BroadcastData(FLOW_SOL, FLOW_SOL);
 
@@ -598,35 +598,49 @@ bool CMultizoneDriver::TransferData(unsigned short donorZone, unsigned short tar
     case FLOW_TRACTION:
       BroadcastData(FLOW_SOL, FEA_SOL);
       break;
-    case MIXING_PLANE:
-    {
+    case MIXING_PLANE: {
       const auto nMarkerInt = config_container[donorZone]->GetnMarker_MixingPlaneInterface() / 2;
 
-      /*--- Transfer the average value from the donorZone to the targetZone ---*/
-      /*--- Loops over the mixing planes defined in the config file to find the correct mixing plane for the donor-target combination ---*/
+      /*--- Transfer the average value from the donorZone to the targetZone
+       * Loops over the mixing planes defined in the config file to find the
+       * correct mixing plane for the donor-target combination ---*/
       for (auto iMarkerInt = 1; iMarkerInt <= nMarkerInt; iMarkerInt++) {
-            interface_container[donorZone][targetZone]->AllgatherAverage(solver_container[donorZone][INST_0][MESH_0][FLOW_SOL],solver_container[targetZone][INST_0][MESH_0][FLOW_SOL],
-                geometry_container[donorZone][INST_0][MESH_0],geometry_container[targetZone][INST_0][MESH_0],
-                config_container[donorZone], config_container[targetZone], iMarkerInt );
+        interface->AllgatherAverage(
+          solver_container[donorZone][INST_0][MESH_0][FLOW_SOL],
+          solver_container[targetZone][INST_0][MESH_0][FLOW_SOL],
+          geometry_container[donorZone][INST_0][MESH_0],
+          geometry_container[targetZone][INST_0][MESH_0],
+          config_container[donorZone], config_container[targetZone], iMarkerInt);
       }
 
       /*--- Set average value donorZone->targetZone ---*/
-      interface_container[donorZone][targetZone]->SetAverageValues(solver_container[donorZone][INST_0][MESH_0][FLOW_SOL],solver_container[targetZone][INST_0][MESH_0][FLOW_SOL], donorZone);
+      interface->SetAverageValues(solver_container[donorZone][INST_0][MESH_0][FLOW_SOL],
+                                  solver_container[targetZone][INST_0][MESH_0][FLOW_SOL], donorZone);
 
       /*--- Set average geometrical properties FROM donorZone IN targetZone ---*/
-      geometry_container[targetZone][INST_0][MESH_0]->SetAvgTurboGeoValues(config_container[iZone],geometry_container[iZone][INST_0][MESH_0], iZone);
-
-      break;
-    }
+      geometry_container[targetZone][INST_0][MESH_0]->SetAvgTurboGeoValues(
+          config_container[iZone], geometry_container[iZone][INST_0][MESH_0], iZone);
+     } break;
     case NO_TRANSFER:
     case ZONES_ARE_EQUAL:
     case NO_COMMON_INTERFACE:
       break;
     default:
-      if(rank == MASTER_NODE)
+      if (rank == MASTER_NODE) {
         cout << "WARNING: One of the intended interface transfer routines is not "
              << "known to the chosen driver and has not been executed." << endl;
+      }
       break;
+    }
+  };
+
+  auto type = interface_types[donorZone][targetZone];
+  auto* interface = interface_container[donorZone][targetZone];
+
+  while (interface != nullptr) {
+    HandleInterfaceType(type, interface);
+    type = interface->NextInterfaceType;
+    interface = interface->NextInterface;
   }
 
   return UpdateMesh;

--- a/SU2_CFD/src/interfaces/CInterface.cpp
+++ b/SU2_CFD/src/interfaces/CInterface.cpp
@@ -57,6 +57,8 @@ CInterface::~CInterface() {
 
   delete[] SpanValueCoeffTarget;
   delete[] SpanLevelDonor;
+
+  delete NextInterface;
 }
 
 void CInterface::BroadcastData(const CInterpolator& interpolator,

--- a/SU2_CFD/src/interfaces/fsi/CFlowTractionInterface.cpp
+++ b/SU2_CFD/src/interfaces/fsi/CFlowTractionInterface.cpp
@@ -158,9 +158,9 @@ void CFlowTractionInterface::GetPhysical_Constants(CSolver *flow_solution, CSolv
   Physical_Constants[1] = ModAmpl;
 
   /*--- For static FSI, we cannot apply the ramp like this ---*/
-  if ((!flow_config->GetTime_Domain())){
+  if (!flow_config->GetTime_Domain()) {
     Physical_Constants[1] = 1.0;
-    if (Ramp_Load){
+    if (Ramp_Load) {
       CurrentTime = static_cast<su2double>(struct_config->GetOuterIter());
       Ramp_Time = static_cast<su2double>(struct_config->GetnIterFSI_Ramp() - 1);
 

--- a/SU2_CFD/src/solvers/CHeatSolver.cpp
+++ b/SU2_CFD/src/solvers/CHeatSolver.cpp
@@ -257,6 +257,7 @@ void CHeatSolver::LoadRestart(CGeometry **geometry, CSolver ***solver, CConfig *
   solver[MESH_0][HEAT_SOL]->InitiateComms(geometry[MESH_0], config, MPI_QUANTITIES::SOLUTION);
   solver[MESH_0][HEAT_SOL]->CompleteComms(geometry[MESH_0], config, MPI_QUANTITIES::SOLUTION);
 
+  SU2_OMP_SAFE_GLOBAL_ACCESS(config->SetGlobalParam(MAIN_SOLVER::HEAT_EQUATION, RUNTIME_HEAT_SYS);)
   solver[MESH_0][HEAT_SOL]->Preprocessing(geometry[MESH_0], solver[MESH_0], config, MESH_0, NO_RK_ITER, RUNTIME_HEAT_SYS, false);
 
   /*--- Interpolate the solution down to the coarse multigrid levels ---*/

--- a/TestCases/fea_fsi/stat_fsi/config.cfg
+++ b/TestCases/fea_fsi/stat_fsi/config.cfg
@@ -1,24 +1,32 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%                                                                              %
 % SU2 configuration file                                                       %
-% Case description: Fluid structure interaction - Beam in channel - 2D - FEM   %
-% Author: R.Sanchez                                                            %
-% Institution: Imperial College London                                         %
-%                                                                              %
+% Case description: Aero-thermo-elasticity                                     %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+% FSI settings
 SOLVER= MULTIPHYSICS
+MULTIZONE_SOLVER= BLOCK_GAUSS_SEIDEL
+RAMP_LOADING= YES
+RAMP_FSI_ITER= 5
+BGS_RELAXATION= FIXED_PARAMETER
+STAT_RELAX_PARAMETER= 0.9
 
-CONFIG_LIST = (configFlow.cfg, configFEA.cfg)
+CONFIG_LIST= ( configFlow.cfg, configFEA.cfg )
 
-MULTIZONE_SOLVER = BLOCK_GAUSS_SEIDEL
+MARKER_ZONE_INTERFACE= ( wallF, wallS )
 
-MARKER_ZONE_INTERFACE = (wallF, wallS)
+SCREEN_OUTPUT= \
+  OUTER_ITER, INNER_ITER[0], AVG_BGS_RES[0], AVG_BGS_RES[1],\
+  RMS_DENSITY[0], RMS_UTOL[1], RMS_TEMPERATURE[1], VMS[1],\
+  TOTAL_HEATFLUX[1], DEFORM_MIN_VOLUME[0], DEFORM_ITER[0]
 
-MULTIZONE_MESH = NO
-SCREEN_OUTPUT=(OUTER_ITER, BGS_DENSITY[0], AVG_BGS_RES[1], DEFORM_MIN_VOLUME[0], DEFORM_ITER[0])
 RESTART_SOL= NO
-RESTART_ITER = 0
+RESTART_ITER= 0
 
-TIME_DOMAIN = NO
-OUTER_ITER = 8
+OUTER_ITER= 30
+CONV_RESIDUAL_MINVAL= -5
+
+MULTIZONE_MESH= NO
+WRT_ZONE_CONV= NO
+OUTPUT_WRT_FREQ= 100
+

--- a/TestCases/fea_fsi/stat_fsi/configFEA.cfg
+++ b/TestCases/fea_fsi/stat_fsi/configFEA.cfg
@@ -1,82 +1,63 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%                                                                              %
 % SU2 configuration file                                                       %
-% Case description: Fluid structure interaction - Beam in channel - 2D - FEM   %
-% Author: R.Sanchez                                                            %
-% Institution: TU Kaiserslautern                                               %
-%                                                                              %
+% Case description: Aero-thermo-elasticity                                     %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-% ------------- DIRECT, ADJOINT, AND LINEARIZED PROBLEM DEFINITION ------------%
-%
+% Nonlinear thermoelasticity
 SOLVER= ELASTICITY
-MATH_PROBLEM= DIRECT
-
-% ------------------------ PARAMETERS FEM SOLVER ------------------------------%
-
 GEOMETRIC_CONDITIONS= LARGE_DEFORMATIONS
 MATERIAL_MODEL= NEO_HOOKEAN
 MATERIAL_COMPRESSIBILITY= COMPRESSIBLE
-NONLINEAR_FEM_SOLUTION_METHOD = NEWTON_RAPHSON
-INNER_ITER = 10
+FORMULATION_ELASTICITY_2D= PLANE_STRAIN
+WEAKLY_COUPLED_HEAT_EQUATION= YES
+INC_NONDIM= DIMENSIONAL
 
-INCREMENTAL_LOAD = NO
+% Material properties
+ELASTICITY_MODULUS= 21000
+MATERIAL_DENSITY= 0.8
+POISSON_RATIO= 0.4
 
-% --------------------------- TIME STEP ISSUES --------------------------------%
+SPECIFIC_HEAT_CP= 1
+THERMAL_CONDUCTIVITY_CONSTANT= 4
+MATERIAL_REFERENCE_TEMPERATURE= 0.1
+MATERIAL_THERMAL_EXPANSION_COEFF= 1
 
-TIME_ITER= 1
-OUTPUT_WRT_FREQ= 1
+% Boundary conditions
+MARKER_CLAMPED= ( clamped )
+MARKER_FLUID_LOAD= ( wallS )
+MARKER_CHT_INTERFACE= ( wallS )
+MARKER_CREATE_COPY= ( clamped, isothermal )
+MARKER_ISOTHERMAL= ( isothermal, 0.1 )
 
-% --------------------------- MESH REFINEMENT ---------------------------------%
+MARKER_PLOTTING= ( wallS )
+MARKER_MONITORING= ( wallS )
 
+% Initial conditions
+FREESTREAM_TEMPERATURE= 0.1
+
+% Solver settings
+NUM_METHOD_GRAD= GREEN_GAUSS
+
+TIME_DISCRE_HEAT= EULER_IMPLICIT
+CFL_NUMBER= 1e8
+LINEAR_SOLVER= CONJUGATE_GRADIENT
+LINEAR_SOLVER_PREC= ILU
+LINEAR_SOLVER_ERROR= 1e-4
+LINEAR_SOLVER_ITER= 500
+
+% Convergence settings
+INNER_ITER= 5
+CONV_FIELD= RMS_UTOL
+CONV_RESIDUAL_MINVAL= -10
+
+% In/Out
+SCREEN_OUTPUT= INNER_ITER, RMS_RES, VMS, TOTAL_HEATFLUX, LINSOL
+
+MESH_FORMAT= SU2
 MESH_FILENAME= meshFEA.su2
-
-% --------------------------- FSI CONDITIONS ----------------------------------%
-
-RAMP_LOADING=NO
-
-STAT_RELAX_PARAMETER= 1.0
-BGS_RELAXATION = FIXED_PARAMETER
-PREDICTOR_ORDER = 0
-
-CONV_FIELD=RMS_UTOL
-CONV_RESIDUAL_MINVAL=-10
-
-% ----------------------------- INPUT/OUTPUT ----------------------------------%
+TABULAR_FORMAT= CSV
 
 VOLUME_FILENAME= result_beam
-
-BREAKDOWN_FILENAME= forces_breakdown.dat
-
 SOLUTION_FILENAME= solution_beam
 RESTART_FILENAME= restart_beam
 
-% ------------------------ STRUCTURAL PARAMETERS ------------------------------%
-
-ELASTICITY_MODULUS=21000
-MATERIAL_DENSITY=0.8
-FORMULATION_ELASTICITY_2D = PLANE_STRAIN
-POISSON_RATIO=0.4
-
-% -------------------------- DYNAMIC SIMULATION -------------------------------%
-TIME_DOMAIN= NO
-TIME_DISCRE_FEA= NEWMARK_IMPLICIT
-
-% -------------------------- STRUCTURAL SOLVER --------------------------------%
-
-LINEAR_SOLVER = CONJUGATE_GRADIENT
-LINEAR_SOLVER_PREC = JACOBI
-LINEAR_SOLVER_ERROR = 1E-3
-LINEAR_SOLVER_ITER = 2000
-
-% -------------------- BOUNDARY CONDITION DEFINITION --------------------------%
-
-MARKER_CLAMPED = ( clamped )
-MARKER_PRESSURE= ( wallS, 0.0)
-
-MARKER_FLUID_LOAD = (wallS)
-
-% ------------------------- INPUT/OUTPUT INFORMATION --------------------------%
-
-MESH_FORMAT= SU2
-TABULAR_FORMAT= CSV

--- a/TestCases/fea_fsi/stat_fsi/configFlow.cfg
+++ b/TestCases/fea_fsi/stat_fsi/configFlow.cfg
@@ -1,121 +1,81 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%                                                                              %
 % SU2 configuration file                                                       %
-% Case description: Fluid structure interaction - Beam in channel - 2D - FEM   %
-% Author: R.Sanchez                                                            %
-% Institution: TU Kaiserslautern                                               %
-%                                                                              %
+% Case description: Aero-thermo-elasticity                                     %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-% ------------- DIRECT, ADJOINT, AND LINEARIZED PROBLEM DEFINITION ------------%
-%
+% Laminar flow
 SOLVER= NAVIER_STOKES
-
 KIND_TURB_MODEL= NONE
-MATH_PROBLEM= DIRECT
 
-% --------------------------- MESH DEFORMATION ---------------------------------%
+% Material properties
+FLUID_MODEL= STANDARD_AIR
+VISCOSITY_MODEL= CONSTANT_VISCOSITY
+MU_CONSTANT= 1.82E-4
+CONDUCTIVITY_MODEL= CONSTANT_PRANDTL
+PRANDTL_LAM= 0.72
 
-MESH_FILENAME= meshFlow.su2
-
-DEFORM_MESH = YES
-MARKER_DEFORM_MESH = (wallF)
-
-DEFORM_STIFFNESS_TYPE = INVERSE_VOLUME
-
-DEFORM_LINEAR_SOLVER = CONJUGATE_GRADIENT
-DEFORM_LINEAR_SOLVER_PREC = LU_SGS
-DEFORM_LINEAR_SOLVER_ERROR = 1E-5
-DEFORM_NONLINEAR_ITER= 1
-DEFORM_LINEAR_SOLVER_ITER = 5000
-DEFORM_CONSOLE_OUTPUT = NO
-
-% -----------------------------------------------------------------------------%
-
-OUTPUT_WRT_FREQ= 10
-
-INNER_ITER= 200
-
-% ----------------------------- INPUT/OUTPUT ----------------------------------%
-
-VOLUME_FILENAME= result_flow
-CONV_FILENAME= history
-
-BREAKDOWN_FILENAME= forces_breakdown.dat
-
-SOLUTION_FILENAME= solution_flow
-RESTART_FILENAME= restart_flow
-
-% -------------------- BOUNDARY CONDITION DEFINITION --------------------------%
-
-MARKER_HEATFLUX= ( wallF, 0.0)
+% Boundary conditions
 MARKER_INLET= ( inlet, 0.0578070909, 20.1346756866, 1.0, 0.0, 0.0 )
-MARKER_OUTLET= ( outlet, 19.5809057203)
+MARKER_OUTLET= ( outlet, 19.5809057203 )
 MARKER_EULER= ( upper, lower )
+MARKER_CHT_INTERFACE= ( wallF )
 
 MARKER_PLOTTING= ( wallF )
 MARKER_MONITORING= ( wallF )
 
-% -------------------------- FLUID SIMULATION ---------------------------------%
+% Initial conditions
+MACH_NUMBER= 0.03
+INIT_OPTION= TD_CONDITIONS
+FREESTREAM_OPTION= TEMPERATURE_FS
+FREESTREAM_PRESSURE= 19.5809057203
+FREESTREAM_TEMPERATURE= 0.0578070909
 
-TIME_DOMAIN=NO
-MAX_TIME= 4.01
+% Mesh deformation
+DEFORM_MESH= YES
+MARKER_DEFORM_MESH= ( wallF )
+MARKER_DEFORM_MESH_SYM_PLANE= ( upper )
+DEFORM_NONLINEAR_ITER= 1
+DEFORM_STIFFNESS_TYPE= INVERSE_VOLUME
+DEFORM_LINEAR_SOLVER= CONJUGATE_GRADIENT
+DEFORM_LINEAR_SOLVER_PREC= ILU
+DEFORM_LINEAR_SOLVER_ITER= 500
+DEFORM_LINEAR_SOLVER_ERROR= 1E-8
+DEFORM_CONSOLE_OUTPUT= NO
 
-% ----------- COMPRESSIBLE AND INCOMPRESSIBLE FREE-STREAM DEFINITION ----------%
-
-MACH_NUMBER= 0.2
-MACH_MOTION= 0.2
-AoA= 0.0
-SIDESLIP_ANGLE= 0.0
-
-INIT_OPTION = TD_CONDITIONS
-FREESTREAM_OPTION = DENSITY_FS
-FREESTREAM_DENSITY = 1.18
-FREESTREAM_PRESSURE = 19.5809057203
-FREESTREAM_TEMPERATURE = 0.0578070909
-VISCOSITY_MODEL = CONSTANT_VISCOSITY
-MU_CONSTANT = 1.82E-3
-REYNOLDS_NUMBER= 10
-CFL_NUMBER = 100
-
-% ---------------------- REFERENCE VALUE DEFINITION ---------------------------%
-
-REF_ORIGIN_MOMENT_X = 0.00
-REF_ORIGIN_MOMENT_Y = 0.00
-REF_ORIGIN_MOMENT_Z = 0.00
-
-REF_AREA = 0.016
-REYNOLDS_LENGTH = 0.016
-
-% ------------- COMMON PARAMETERS DEFINING THE NUMERICAL METHOD ---------------%
-
-NUM_METHOD_GRAD= WEIGHTED_LEAST_SQUARES
-RK_ALPHA_COEFF= ( 0.66667, 0.66667, 1.000000 )
-
-% ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
-
-LINEAR_SOLVER= FGMRES
-LINEAR_SOLVER_PREC= ILU
-LINEAR_SOLVER_ERROR= 1E-6
-LINEAR_SOLVER_ITER= 2
-
-% -------------------- FLOW NUMERICAL METHOD DEFINITION -----------------------%
-
+% Solver settings
 CONV_NUM_METHOD_FLOW= ROE
 MUSCL_FLOW= YES
+NUM_METHOD_GRAD= WEIGHTED_LEAST_SQUARES
 SLOPE_LIMITER_FLOW= VENKATAKRISHNAN
 VENKAT_LIMITER_COEFF= 1.0
-JST_SENSOR_COEFF=( 0.5, 0.02 )
+
 TIME_DISCRE_FLOW= EULER_IMPLICIT
+CFL_NUMBER= 500
+LINEAR_SOLVER= FGMRES
+LINEAR_SOLVER_PREC= ILU
+LINEAR_SOLVER_ERROR= 0.1
+LINEAR_SOLVER_ITER= 10
 
-% --------------------------- CONVERGENCE PARAMETERS --------------------------%
+% Convergence settings
+INNER_ITER= 100
+CONV_FIELD= RMS_DENSITY
+CONV_RESIDUAL_MINVAL= -9
 
-CONV_RESIDUAL_MINVAL= -10
-CONV_STARTITER= 10
-CONV_CAUCHY_ELEMS= 100
-CONV_CAUCHY_EPS= 1E-5
+% Reference values
+REF_ORIGIN_MOMENT_X= 0.0
+REF_ORIGIN_MOMENT_Y= 0.0
+REF_ORIGIN_MOMENT_Z= 0.0
+REF_AREA= 0.016
+REYNOLDS_LENGTH= 0.016
 
-% ------------------------- INPUT/OUTPUT INFORMATION --------------------------%
+% In/Out
+SCREEN_OUTPUT= INNER_ITER, RMS_RES, TOTAL_HEATFLUX, LINSOL
 
 MESH_FORMAT= SU2
+MESH_FILENAME= meshFlow.su2
 TABULAR_FORMAT= CSV
+
+VOLUME_FILENAME= result_flow
+SOLUTION_FILENAME= solution_flow
+RESTART_FILENAME= restart_flow
+

--- a/TestCases/fea_fsi/stat_fsi/config_restart.cfg
+++ b/TestCases/fea_fsi/stat_fsi/config_restart.cfg
@@ -1,23 +1,32 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%                                                                              %
 % SU2 configuration file                                                       %
-% Case description: Fluid structure interaction - Beam in channel - 2D - FEM   %
-% Author: R.Sanchez                                                            %
-% Institution: Imperial College London                                         %
-%                                                                              %
+% Case description: Aero-thermo-elasticity                                     %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+% FSI settings
 SOLVER= MULTIPHYSICS
+MULTIZONE_SOLVER= BLOCK_GAUSS_SEIDEL
+RAMP_LOADING= NO
+RAMP_FSI_ITER= 5
+BGS_RELAXATION= FIXED_PARAMETER
+STAT_RELAX_PARAMETER= 0.9
 
-CONFIG_LIST = (configFlow.cfg, configFEA.cfg)
+CONFIG_LIST= ( configFlow.cfg, configFEA.cfg )
 
-MULTIZONE_SOLVER = BLOCK_GAUSS_SEIDEL
+MARKER_ZONE_INTERFACE= ( wallF, wallS )
 
-MARKER_ZONE_INTERFACE = (wallF, wallS)
+SCREEN_OUTPUT= \
+  OUTER_ITER, INNER_ITER[0], AVG_BGS_RES[0], AVG_BGS_RES[1],\
+  RMS_DENSITY[0], RMS_UTOL[1], RMS_TEMPERATURE[1], VMS[1],\
+  TOTAL_HEATFLUX[1], DEFORM_MIN_VOLUME[0], DEFORM_ITER[0]
 
-MULTIZONE_MESH = NO
-SCREEN_OUTPUT=(OUTER_ITER, BGS_DENSITY[0], AVG_BGS_RES[1], DEFORM_MIN_VOLUME[0], DEFORM_ITER[0])
 RESTART_SOL= YES
-RESTART_ITER = 0
-TIME_DOMAIN = NO
-OUTER_ITER = 2
+RESTART_ITER= 0
+
+OUTER_ITER= 1
+CONV_RESIDUAL_MINVAL= -5
+
+MULTIZONE_MESH= NO
+WRT_ZONE_CONV= NO
+OUTPUT_WRT_FREQ= 100
+

--- a/TestCases/hybrid_regression.py
+++ b/TestCases/hybrid_regression.py
@@ -711,15 +711,14 @@ def main():
     dyn_fsi.unsteady  = True
     test_list.append(dyn_fsi)
 
-    # FSI, Static, 2D, new mesh solver, restart
-    stat_fsi_restart           = TestCase('stat_fsi_restart')
-    stat_fsi_restart.cfg_dir   = "fea_fsi/stat_fsi"
-    stat_fsi_restart.cfg_file  = "config_restart.cfg"
-    stat_fsi_restart.test_iter = 1
-    stat_fsi_restart.test_vals         = [-3.549586, -4.460650, 0.000000, 35.000000]
-    stat_fsi_restart.test_vals_aarch64 = [-3.549586, -4.460713, 0.000000, 35.000000]
-    stat_fsi_restart.multizone = True
-    test_list.append(stat_fsi_restart)
+    # FSI+CHT, Static, 2D, new mesh solver, restart
+    fsi_cht_restart           = TestCase('fsi_cht_restart')
+    fsi_cht_restart.cfg_dir   = "fea_fsi/stat_fsi"
+    fsi_cht_restart.cfg_file  = "config_restart.cfg"
+    fsi_cht_restart.test_iter = 1
+    fsi_cht_restart.test_vals = [5, 0.006352, -1.960363, -9.335664, -9.346701, -9.312712, 6.0838e+02, -1.2974e-02, 5.7607e-08, 0]
+    fsi_cht_restart.multizone = True
+    test_list.append(fsi_cht_restart)
 
     ##############################################
     ### Method of Manufactured Solutions (MMS) ###

--- a/TestCases/hybrid_regression.py
+++ b/TestCases/hybrid_regression.py
@@ -715,8 +715,8 @@ def main():
     fsi_cht_restart           = TestCase('fsi_cht_restart')
     fsi_cht_restart.cfg_dir   = "fea_fsi/stat_fsi"
     fsi_cht_restart.cfg_file  = "config_restart.cfg"
-    fsi_cht_restart.test_iter = 1
-    fsi_cht_restart.test_vals = [5, 0.006352, -1.960363, -9.335664, -9.346701, -9.312712, 6.0838e+02, -1.2974e-02, 5.7607e-08, 0]
+    fsi_cht_restart.test_iter = 0
+    fsi_cht_restart.test_vals = [5, 0.006352, -1.960362, -9.327033, -9.580521, -9.317956, 6.0838e+02, -1.2974e-02, 5.7607e-08, 20]
     fsi_cht_restart.multizone = True
     test_list.append(fsi_cht_restart)
 

--- a/TestCases/parallel_regression.py
+++ b/TestCases/parallel_regression.py
@@ -1357,15 +1357,6 @@ def main():
     fsi2d.unsteady = True
     test_list.append(fsi2d)
 
-    # FSI, Static, 2D, new mesh solver
-    stat_fsi           = TestCase('stat_fsi')
-    stat_fsi.cfg_dir   = "fea_fsi/stat_fsi"
-    stat_fsi.cfg_file  = "config.cfg"
-    stat_fsi.test_iter = 7
-    stat_fsi.test_vals = [-3.301938, -4.971986, 0.000000, 11.000000]
-    stat_fsi.multizone = True
-    test_list.append(stat_fsi)
-
     # FSI, Dynamic, 2D, new mesh solver
     dyn_fsi           = TestCase('dyn_fsi')
     dyn_fsi.cfg_dir   = "fea_fsi/dyn_fsi"
@@ -1375,15 +1366,6 @@ def main():
     dyn_fsi.multizone = True
     dyn_fsi.unsteady  = True
     test_list.append(dyn_fsi)
-
-    # FSI, Static, 2D, new mesh solver, restart
-    stat_fsi_restart           = TestCase('stat_fsi_restart')
-    stat_fsi_restart.cfg_dir   = "fea_fsi/stat_fsi"
-    stat_fsi_restart.cfg_file  = "config_restart.cfg"
-    stat_fsi_restart.test_iter = 1
-    stat_fsi_restart.test_vals = [-3.486655, -4.425104, 0.000000, 27.000000]
-    stat_fsi_restart.multizone = True
-    test_list.append(stat_fsi_restart)
 
     # ###############################
     # ### Radiative Heat Transfer ###

--- a/TestCases/serial_regression.py
+++ b/TestCases/serial_regression.py
@@ -1074,7 +1074,7 @@ def main():
     dynbeam2d.test_vals = [-3.240012, 2.895060, -0.353140, 76220]
     test_list.append(dynbeam2d)
 
-    # # FSI, 2d
+    # FSI, 2d
     fsi2d           = TestCase('fsi2d')
     fsi2d.cfg_dir   = "fea_fsi/WallChannel_2d"
     fsi2d.cfg_file  = "configFSI.cfg"
@@ -1084,23 +1084,14 @@ def main():
     fsi2d.unsteady  = True
     test_list.append(fsi2d)
 
-    # FSI, Static, 2D, new mesh solver
-    stat_fsi           = TestCase('stat_fsi')
-    stat_fsi.cfg_dir   = "fea_fsi/stat_fsi"
-    stat_fsi.cfg_file  = "config.cfg"
-    stat_fsi.test_iter = 7
-    stat_fsi.test_vals = [-3.336320, -4.991964, 0.000000, 7.000000]
-    stat_fsi.multizone = True
-    test_list.append(stat_fsi)
-
-    # FSI, Static, 2D, new mesh solver, restart
-    stat_fsi_restart           = TestCase('stat_fsi_restart')
-    stat_fsi_restart.cfg_dir   = "fea_fsi/stat_fsi"
-    stat_fsi_restart.cfg_file  = "config_restart.cfg"
-    stat_fsi_restart.test_iter = 1
-    stat_fsi_restart.test_vals = [-3.401553, -4.672932, 0.000000, 26.000000]
-    stat_fsi_restart.multizone = True
-    test_list.append(stat_fsi_restart)
+    # FSI+CHT, Static, 2D, new mesh solver
+    fsi_cht           = TestCase('fsi_cht')
+    fsi_cht.cfg_dir   = "fea_fsi/stat_fsi"
+    fsi_cht.cfg_file  = "config.cfg"
+    fsi_cht.test_iter = 20
+    fsi_cht.test_vals = [5, -5.043408, -5.399417, -9.249020, -9.317983, -9.192967, 6.0835e+02, -1.2973e-02, 5.7607e-08, 40]
+    fsi_cht.multizone = True
+    test_list.append(fsi_cht)
 
     # FSI, Dynamic, 2D, new mesh solver
     dyn_fsi           = TestCase('dyn_fsi')

--- a/TestCases/serial_regression.py
+++ b/TestCases/serial_regression.py
@@ -1089,7 +1089,7 @@ def main():
     fsi_cht.cfg_dir   = "fea_fsi/stat_fsi"
     fsi_cht.cfg_file  = "config.cfg"
     fsi_cht.test_iter = 20
-    fsi_cht.test_vals = [5, -5.043408, -5.399417, -9.249020, -9.317983, -9.192967, 6.0835e+02, -1.2973e-02, 5.7607e-08, 40]
+    fsi_cht.test_vals = [5, -5.077012, -5.379779, -9.247804, -9.277819, -9.183796, 6.0835e+02, -1.2973e-02, 5.7607e-08, 29]
     fsi_cht.multizone = True
     test_list.append(fsi_cht)
 


### PR DESCRIPTION
## Proposed Changes
Before this was possible without coupling between the heat and structural solver, in a roundabout way with a 3-zone setup.
These changes allow a 2-zone setup with coupling between heat and structural solvers, shown in the modified regression test.
I have not tested adjoints yet.

<img width="838" height="513" alt="image" src="https://github.com/user-attachments/assets/e9d4c731-47ff-4276-8abb-cc57f1bf3b9d" />


## PR Checklist
- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [X] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [X] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [X] I have added a test case that demonstrates my contribution, if necessary.
- [X] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
