### PR TITLE
Replace custom CUDA CSysMatrix matvec with cuSPARSE BSR SpMV

### DIFF
--- a/Common/src/linear_algebra/CSysMatrixGPU.cu
+++ b/Common/src/linear_algebra/CSysMatrixGPU.cu
@@ -28,32 +28,43 @@
 #include "../../include/linear_algebra/CSysMatrix.hpp"
 #include "../../include/linear_algebra/GPUComms.cuh"
 
-template<typename matrixType, typename vectorType>
-__global__ void GPUMatrixVectorProductAdd(matrixType* matrix, vectorType* vec, vectorType* prod, const unsigned long* d_row_ptr, const unsigned long* d_col_ind, unsigned long nPointDomain, unsigned long nVar, unsigned long nEqn)
-{
-   int row = (blockIdx.x * blockDim.x + threadIdx.x)/32;
-   int threadNo = threadIdx.x%32;
-   int activeThreads = nVar * (32/nVar);
+#include <cusparse.h>
+#include <cstdint>
+#include <type_traits>
 
-   int blockRow = (threadNo/nVar)%nVar;
+inline void cusparseAssert(cusparseStatus_t code, const char* file, int line, bool abort = true) {
+  if (code != CUSPARSE_STATUS_SUCCESS) {
+    fprintf(stderr, "cuSPARSEassert: %s %s %d\n", cusparseGetErrorString(code), file, line);
+    if (abort) exit(static_cast<int>(code));
+  }
+}
 
-   if(row<nPointDomain && threadNo<activeThreads) prod[row * nVar + blockRow] = 0.0;
+#define cusparseErrChk(ans)                    \
+  {                                            \
+    cusparseAssert((ans), __FILE__, __LINE__); \
+  }
 
-   __syncthreads();
+inline cusparseIndexType_t GetCusparseIndexType() {
+  if constexpr (sizeof(unsigned long) == 4) {
+    return CUSPARSE_INDEX_32I;
+  } else if constexpr (sizeof(unsigned long) == 8) {
+    return CUSPARSE_INDEX_64I;
+  } else {
+    static_assert(sizeof(unsigned long) == 4 || sizeof(unsigned long) == 8,
+                  "cuSPARSE BSR SpMV only supports 32-bit or 64-bit index arrays in this path.");
+  }
+}
 
-   if(row<nPointDomain && threadNo<activeThreads)
-   {
-      vectorType res = 0.0;
-
-      for(int index = d_row_ptr[row] * nVar * nEqn + threadNo; index < d_row_ptr[row+1] * nVar * nEqn; index+=activeThreads)
-      {
-         int blockCol = index%nEqn;
-         int blockNo = index/(nVar * nEqn);
-         res += matrix[index] * vec[(d_col_ind[blockNo])*nVar + blockCol];
-      }
-
-      atomicAdd(&prod[row * nVar + blockRow], res);
-   }
+template <class ScalarType>
+constexpr cudaDataType GetCudaDataType() {
+  if constexpr (std::is_same<ScalarType, float>::value) {
+    return CUDA_R_32F;
+  } else if constexpr (std::is_same<ScalarType, double>::value) {
+    return CUDA_R_64F;
+  } else {
+    static_assert(std::is_same<ScalarType, float>::value || std::is_same<ScalarType, double>::value,
+                  "cuSPARSE BSR SpMV only supports float and double in this path.");
+  }
 }
 
 template<class ScalarType>
@@ -62,26 +73,69 @@ void CSysMatrix<ScalarType>::HtDTransfer(bool trigger) const
    if(trigger) gpuErrChk(cudaMemcpy((void*)(d_matrix), (void*)&matrix[0], (sizeof(ScalarType)*nnz*nVar*nEqn), cudaMemcpyHostToDevice));
 }
 
-template<class ScalarType>
+template <class ScalarType>
 void CSysMatrix<ScalarType>::GPUMatrixVectorProduct(const CSysVector<ScalarType>& vec, CSysVector<ScalarType>& prod,
-                                                 CGeometry* geometry, const CConfig* config) const
-                                                 {
+                                                    CGeometry* geometry, const CConfig* config) const {
+  if (nVar != nEqn) {
+    SU2_MPI::Error("CUDA CSysMatrix matvec with cuSPARSE BSR requires square blocks.", CURRENT_FUNCTION);
+  }
 
-   ScalarType* d_vec = vec.GetDevicePointer();
-   ScalarType* d_prod = prod.GetDevicePointer();
+  ScalarType* d_vec = vec.GetDevicePointer();
+  ScalarType* d_prod = prod.GetDevicePointer();
 
-   vec.HtDTransfer();
-   prod.GPUSetVal(0.0);
+  vec.HtDTransfer();
 
-  dim3 blockDim(KernelParameters::MVP_BLOCK_SIZE,1,1);
-  int gridx = KernelParameters::round_up_division(KernelParameters::MVP_WARP_SIZE, nPointDomain);
-  dim3 gridDim(gridx, 1, 1);
+  const auto indexType = GetCusparseIndexType();
+  const auto valueType = GetCudaDataType<ScalarType>();
 
-  GPUMatrixVectorProductAdd<<<gridDim, blockDim>>>(d_matrix, d_vec, d_prod, d_row_ptr, d_col_ind, nPointDomain, nVar, nEqn);
-  gpuErrChk( cudaPeekAtLastError() );
+  const std::int64_t blockSize = static_cast<std::int64_t>(nVar);
+
+  const std::int64_t brows = static_cast<std::int64_t>(nPointDomain);
+  const std::int64_t bcols = static_cast<std::int64_t>(nPoint);
+  const std::int64_t bnnz = static_cast<std::int64_t>(nnz);
+
+  const std::int64_t xSize = static_cast<std::int64_t>(nPoint) * blockSize;
+  const std::int64_t ySize = static_cast<std::int64_t>(nPointDomain) * blockSize;
+
+  const ScalarType alpha = 1.0;
+  const ScalarType beta = 0.0;
+
+  cusparseHandle_t handle = nullptr;
+  cusparseConstSpMatDescr_t matA = nullptr;
+  cusparseDnVecDescr_t vecX = nullptr;
+  cusparseDnVecDescr_t vecY = nullptr;
+
+  cusparseErrChk(cusparseCreate(&handle));
+
+  cusparseErrChk(cusparseCreateConstBsr(&matA, brows, bcols, bnnz, blockSize, blockSize, d_row_ptr, d_col_ind, d_matrix,
+                                        indexType, indexType, CUSPARSE_INDEX_BASE_ZERO, valueType, CUSPARSE_ORDER_ROW));
+
+  cusparseErrChk(cusparseCreateDnVec(&vecX, xSize, d_vec, valueType));
+  cusparseErrChk(cusparseCreateDnVec(&vecY, ySize, d_prod, valueType));
+
+  size_t bufferSize = 0;
+  void* dBuffer = nullptr;
+
+  cusparseErrChk(cusparseSpMV_bufferSize(handle, CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha, matA, vecX, &beta, vecY,
+                                         valueType, CUSPARSE_SPMV_BSR_ALG1, &bufferSize));
+
+  if (bufferSize > 0) {
+    gpuErrChk(cudaMalloc(&dBuffer, bufferSize));
+  }
+
+  cusparseErrChk(cusparseSpMV(handle, CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha, matA, vecX, &beta, vecY, valueType,
+                              CUSPARSE_SPMV_BSR_ALG1, dBuffer));
+
+  if (dBuffer != nullptr) {
+    gpuErrChk(cudaFree(dBuffer));
+  }
+
+  cusparseErrChk(cusparseDestroyDnVec(vecY));
+  cusparseErrChk(cusparseDestroyDnVec(vecX));
+  cusparseErrChk(cusparseDestroySpMat(matA));
+  cusparseErrChk(cusparseDestroy(handle));
 
   prod.DtHTransfer();
-
 }
 
 template class CSysMatrix<su2mixedfloat>; //This is a temporary fix for invalid instantiations due to separating the member function from the header file the class is defined in. Will try to rectify it in coming commits.

--- a/meson.build
+++ b/meson.build
@@ -20,10 +20,13 @@ python = pymod.find_installation()
 if get_option('enable-cuda')
   add_languages('cuda')
   add_global_arguments('-arch=sm_86', language : 'cuda')
+  cuda_deps = [meson.get_compiler('cuda').find_library('cusparse', required : true)]
+else
+  cuda_deps = []
 endif
 
 su2_cpp_args = []
-su2_deps     = [declare_dependency(include_directories: 'externals/CLI11')]
+su2_deps     = [declare_dependency(include_directories: 'externals/CLI11')] + cuda_deps
 
 default_warning_flags = []
 if build_machine.system() != 'windows'


### PR DESCRIPTION
## Summary

This PR replaces the custom CUDA `CSysMatrix` block-sparse matrix-vector product kernel with cuSPARSE BSR SpMV for the CUDA square-block path.

This is not only a performance or maintenance refactor. It is primarily a correctness fix.

The previous custom CUDA kernel has two independent numerical correctness problems:

1. It silently produces incorrect results for some valid square-block inputs.
2. It also silently executes on rectangular block layouts (`nVar != nEqn`), but that path was never semantically correct and can produce wrong results.

Because of these issues, the previous CUDA kernel was not semantically safe for all inputs accepted by the interface. For the square-block CUDA path, the matrix storage is already BSR-like, so this PR replaces the custom kernel with cuSPARSE BSR SpMV instead of extending a path with known correctness mismatches.

## What changed

- Removed the custom CUDA `GPUMatrixVectorProductAdd` kernel.
- Replaced `CSysMatrix<ScalarType>::GPUMatrixVectorProduct` with cuSPARSE BSR SpMV for the CUDA path.
- Added an explicit CUDA-side guard for `nVar != nEqn`.
- Added cuSPARSE as a CUDA build dependency in Meson.
- Kept the CPU matvec path unchanged.

## Why the previous CUDA kernel is being replaced

The motivation here is not only simplification. The previous CUDA kernel had correctness risks that were reproducible at the matrix-vector-product level.

### Problem 1: square-block routing bug

The old kernel derives the output component from a fixed `threadNo`-based `blockRow`, while the actual matrix entry being processed changes with the loop index:

```text
threadNo = threadIdx.x % 32
blockRow = (threadNo / nVar) % nVar
index += activeThreads
```

But the true dense-block row of the current matrix entry is determined by the current `index`, not by the fixed thread id.

That means a single thread can process entries belonging to different local block rows, while still accumulating everything into one fixed output component. This creates an algorithmic routing mismatch.

A minimal synthetic square-block case demonstrates it directly:

```text
nPointDomain = 1
nPoint       = 2
nVar = nEqn  = 5

row_ptr = [0, 2]
col_ind = [0, 1]

matrix[0]  = 1
matrix[30] = 10
all other matrix entries = 0

vec[:] = 1
```

Expected CPU reference output:

```text
[1, 10, 0, 0, 0]
```

Observed outputs:

```text
CPU reference   = [1, 10, 0, 0, 0]
old CUDA kernel = [11, 0, 0, 0, 0]
cuSPARSE BSR    = [1, 10, 0, 0, 0]
```

In this example, one CUDA lane processes both `index = 0` and `index = 30`. Those two entries belong to different local block rows, but the old kernel routes both contributions to the same output component.

### Problem 2: rectangular block layouts were accepted, but not semantically consistent with the CPU path

`CSysMatrix` has a general block interface with shape `nVar x nEqn`.

The CPU path uses the correct input-vector stride:

```text
vec[col_j * nEqn]
```

However, the old CUDA kernel uses:

```text
vec[d_col_ind[blockNo] * nVar + blockCol]
```

That is not semantically consistent with the CPU rectangular-block matvec definition when `nVar != nEqn`.

So although the old CUDA kernel would execute for rectangular blocks, that execution was not actually equivalent to the CPU rectangular-block matvec semantics. In other words, the rectangular CUDA path appeared to be accepted by the implementation, but its indexing was not consistent with the CPU rectangular-block definition.

A minimal synthetic rectangular case shows this clearly:

```text
nPointDomain = 1
nPoint       = 2
nVar         = 3
nEqn         = 6

row_ptr = [0, 2]
col_ind = [0, 1]

matrix[0]  = 5
matrix[30] = 7

vec[0] = 1
vec[3] = 100
vec[6] = 1
all other vec entries = 0
```

Observed outputs:

```text
CPU rectangular reference = [5, 0, 7]
old CUDA kernel           = [705, 0, 0]
```

This is not just a corner-case API detail. It shows that the previous CUDA kernel could silently accept a rectangular block layout and produce a wrong result without any explicit failure.

## Why explicit rejection is better than silent execution

This PR intentionally supports only the CUDA square-block case:

```text
nVar == nEqn
```

For `nVar != nEqn`, the new CUDA path now fails explicitly instead of silently running an incorrect algorithm.

So this PR does not reduce the set of rectangular CUDA cases that were correctly supported before, because the old kernel did not provide a semantically correct rectangular CUDA implementation in the first place.

The behavior change is:

```text
before: rectangular CUDA input may run and silently compute the wrong answer
after:  rectangular CUDA input is rejected explicitly
```

That is a correctness improvement, not a compatibility regression.

## Why cuSPARSE BSR is the right replacement here

For the CUDA square-block path, the existing storage is BSR-like in the sense relevant here:

- `row_ptr`
- `col_ind`
- `matrix` as dense block payloads

The cuSPARSE path uses the matching BSR block direction for the existing block payload layout and provides a well-tested implementation of the required operation.

Given the observed correctness problems in both square and rectangular cases, using cuSPARSE for the valid square-block CUDA path is more robust than preserving a separate custom implementation for that path.

## Validation

### Build

- Serial CUDA build completed locally.
- MPI-enabled CUDA build could not be evaluated on my local Arch/GCC 16.1.1 environment because `nvcc` failed Meson's CUDA compiler sanity check before SU2 compilation. This happened before building the modified source files and was not a cuSPARSE link failure.

### 1. Synthetic square-block validation

Compared:

- CPU reference BSR matvec
- old custom CUDA kernel
- new cuSPARSE BSR path

Result:

```text
CPU reference   = [1, 10, 0, 0, 0]
old CUDA kernel = [11, 0, 0, 0, 0]
cuSPARSE BSR    = [1, 10, 0, 0, 0]
```

### 2. Synthetic rectangular-block validation

Compared:

- CPU rectangular-block reference
- old custom CUDA kernel
- new CUDA-path behavior

Result:

```text
CPU rectangular reference = [5, 0, 7]
old CUDA kernel           = [705, 0, 0]
new CUDA path             = explicit rejection via square-block guard
```

### 3. Real SU2 integration cases

Ran 6 existing runnable implicit Krylov cases with four-way comparison:

```text
develop CPU
develop CUDA
new branch CPU
new branch CUDA
```

Tested cases:

```text
periodic2d_sector
udf_lam_flatplate_s
udf_lam_flatplate_m
udf_lam_flatplate_l
udf_test_11_probes_s
udf_test_11_probes_m
```

Summary:

- `new CPU` matched `develop CPU` in 6/6 cases.
- `new CUDA` matched `new CPU` in 6/6 cases.
- `develop CUDA` differed from CPU / new CUDA in 5/6 cases.
- No `GPUassert`, `cuSPARSEassert`, illegal memory access, or segmentation fault was observed.
- One case showed `NaN` flags in all four runs, so that behavior was not new-CUDA-specific.

For cases without standard residual columns, the final `history.csv` row was compared across all common numeric fields.

## Scope

This PR changes only the CUDA matrix-vector product implementation for the square-block `CSysMatrix` path.

It does not change:

- CPU matvec semantics
- Krylov solver logic
- preconditioner logic
- CFD solver physics
- matrix assembly semantics

## Follow-up work

This PR focuses on correctness first.

The current implementation creates/destroys cuSPARSE descriptors and allocates/frees the SpMV workspace inside each matvec call. That can be optimized later by caching:

- the cuSPARSE handle
- BSR matrix descriptor
- dense vector descriptors
- SpMV workspace
- optional `cusparseSpMV_preprocess()` state

### Follow-up draft

I have also prepared a follow-up draft PR in my fork to show the next intended step after this correctness PR:

- LwhJesse/SU2#1

That draft is based on this PR branch, not directly on `develop`, so it shows only the incremental resource-lifecycle change: caching the cuSPARSE handle, BSR matrix descriptor, and SpMV workspace after the cuSPARSE BSR path introduced here.

## Related Work

This replaces the earlier narrower draft PR #2813, which attempted to fix only the contribution-routing issue inside the existing custom CUDA kernel. After additional testing, the scope changed to replacing the square-block CUDA path with cuSPARSE BSR SpMV and explicitly rejecting unsupported rectangular CUDA blocks.

## PR Checklist

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with `--warnlevel=3` when using meson).
- [x] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [x] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.

