### PR TITLE
Add support for Riemann boundary condition to all scalar solvers

### DIFF
--- a/SU2_CFD/include/solvers/CScalarSolver.hpp
+++ b/SU2_CFD/include/solvers/CScalarSolver.hpp
@@ -494,6 +494,22 @@ class CScalarSolver : public CSolver {
   }
 
   /*!
+   * \brief Impose the boundary condition using characteristic recostruction.
+   * \param[in] geometry - Geometrical definition of the problem.
+   * \param[in] solver_container - Container vector with all the solutions.
+   * \param[in] numerics - Description of the numerical method.
+   * \param[in] config - Definition of the particular problem.
+   * \param[in] val_marker - Surface marker where the boundary condition is applied.
+   */
+  void BC_Riemann(CGeometry *geometry,
+                  CSolver **solver_container,
+                  CNumerics *conv_numerics,
+                  CNumerics *visc_numerics,
+                  CConfig *config,
+                  unsigned short val_marker) final;
+
+
+  /*!
    * \brief Impose the supersonic inlet boundary condition (same as inlet, see BC_Inlet).
    */
   void BC_Supersonic_Inlet(CGeometry *geometry, CSolver **solver_container, CNumerics *conv_numerics,

--- a/SU2_CFD/include/solvers/CScalarSolver.inl
+++ b/SU2_CFD/include/solvers/CScalarSolver.inl
@@ -371,6 +371,23 @@ void CScalarSolver<VariableType>::SumEdgeFluxes(CGeometry* geometry) {
   END_SU2_OMP_FOR
 }
 
+template<class VariableType>
+void CScalarSolver<VariableType>::BC_Riemann(CGeometry *geometry, CSolver **solver_container, CNumerics *conv_numerics, CNumerics *visc_numerics, CConfig *config, unsigned short val_marker) {
+  SU2_ZONE_SCOPED
+
+  string Marker_Tag         = config->GetMarker_All_TagBound(val_marker);
+
+  switch(config->GetKind_Data_Riemann(Marker_Tag))
+  {
+  case TOTAL_CONDITIONS_PT: case STATIC_SUPERSONIC_INFLOW_PT: case STATIC_SUPERSONIC_INFLOW_PD: case DENSITY_VELOCITY:
+    BC_Inlet(geometry, solver_container, conv_numerics, visc_numerics, config, val_marker);
+    break;
+  case STATIC_PRESSURE:
+    BC_Outlet(geometry, solver_container, conv_numerics, visc_numerics, config, val_marker);
+    break;
+  }
+}
+
 template <class VariableType>
 void CScalarSolver<VariableType>::BC_Periodic(CGeometry* geometry, CSolver** solver_container, CNumerics* numerics,
                                               CConfig* config) {

--- a/SU2_CFD/include/solvers/CTurbSolver.hpp
+++ b/SU2_CFD/include/solvers/CTurbSolver.hpp
@@ -55,20 +55,6 @@ public:
    */
   CTurbSolver(CGeometry* geometry, CConfig *config, bool conservative);
 
-  /*!
-   * \brief Impose via the residual the Euler wall boundary condition.
-   * \param[in] geometry - Geometrical definition of the problem.
-   * \param[in] solver_container - Container vector with all the solutions.
-   * \param[in] numerics - Description of the numerical method.
-   * \param[in] config - Definition of the particular problem.
-   * \param[in] val_marker - Surface marker where the boundary condition is applied.
-   */
-  void BC_Riemann(CGeometry *geometry,
-                  CSolver **solver_container,
-                  CNumerics *conv_numerics,
-                  CNumerics *visc_numerics,
-                  CConfig *config,
-                  unsigned short val_marker) final;
 
   /*!
    * \brief Impose via the residual the Euler wall boundary condition.

--- a/SU2_CFD/src/solvers/CSpeciesSolver.cpp
+++ b/SU2_CFD/src/solvers/CSpeciesSolver.cpp
@@ -517,9 +517,18 @@ su2double CSpeciesSolver::GetInletAtVertex(unsigned short iMarker, unsigned long
 
 void CSpeciesSolver::SetUniformInlet(const CConfig* config, unsigned short iMarker) {
   SU2_ZONE_SCOPED
+  bool riemann_inlet = false;
+
+  const string Marker_Tag = config->GetMarker_All_TagBound(iMarker);
+  if (config->GetMarker_All_KindBC(iMarker) == RIEMANN_BOUNDARY) {
+    switch (config->GetKind_Data_Riemann(Marker_Tag)) {
+      case TOTAL_CONDITIONS_PT: case STATIC_SUPERSONIC_INFLOW_PT: case STATIC_SUPERSONIC_INFLOW_PD: case DENSITY_VELOCITY:
+      riemann_inlet = true;
+      break;
+    }
+  }
   /*--- Find BC string to the numeric-identifier. ---*/
-  if (config->GetMarker_All_KindBC(iMarker) == INLET_FLOW || config->GetMarker_All_KindBC(iMarker) == SUPERSONIC_INLET) {
-    const string Marker_Tag = config->GetMarker_All_TagBound(iMarker);
+  if (config->GetMarker_All_KindBC(iMarker) == INLET_FLOW || config->GetMarker_All_KindBC(iMarker) == SUPERSONIC_INLET || riemann_inlet) {
     for (unsigned long iVertex = 0; iVertex < nVertex[iMarker]; iVertex++) {
       for (unsigned short iVar = 0; iVar < nVar; iVar++) {
         Inlet_SpeciesVars[iMarker][iVertex][iVar] = config->GetInlet_SpeciesVal(Marker_Tag)[iVar];

--- a/SU2_CFD/src/solvers/CTurbSolver.cpp
+++ b/SU2_CFD/src/solvers/CTurbSolver.cpp
@@ -47,21 +47,6 @@ CTurbSolver::~CTurbSolver() {
   }
 }
 
-void CTurbSolver::BC_Riemann(CGeometry *geometry, CSolver **solver_container, CNumerics *conv_numerics, CNumerics *visc_numerics, CConfig *config, unsigned short val_marker) {
-  SU2_ZONE_SCOPED
-
-  string Marker_Tag         = config->GetMarker_All_TagBound(val_marker);
-
-  switch(config->GetKind_Data_Riemann(Marker_Tag))
-  {
-  case TOTAL_CONDITIONS_PT: case STATIC_SUPERSONIC_INFLOW_PT: case STATIC_SUPERSONIC_INFLOW_PD: case DENSITY_VELOCITY:
-    BC_Inlet(geometry, solver_container, conv_numerics, visc_numerics, config, val_marker);
-    break;
-  case STATIC_PRESSURE:
-    BC_Outlet(geometry, solver_container, conv_numerics, visc_numerics, config, val_marker);
-    break;
-  }
-}
 
 void CTurbSolver::BC_TurboRiemann(CGeometry *geometry, CSolver **solver_container, CNumerics *conv_numerics, CNumerics *visc_numerics, CConfig *config, unsigned short val_marker) {
   SU2_ZONE_SCOPED

--- a/TestCases/axisymmetric_rans/air_nozzle/air_nozzle_species.cfg
+++ b/TestCases/axisymmetric_rans/air_nozzle/air_nozzle_species.cfg
@@ -1,0 +1,107 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                                                                              %
+% SU2 configuration file                                                       %
+% Case description: Axisymmetric supersonic converging-diverging air nozzle    %
+% Author: Florian Dittmann                                                     %
+% Date: 2021.12.02                                                             %
+% File Version 8.5.0 "Harrier"                                                 %
+%                                                                              %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+% ------------- DIRECT, ADJOINT, AND LINEARIZED PROBLEM DEFINITION ------------%
+%
+SOLVER= RANS
+KIND_TURB_MODEL= SST
+RESTART_SOL= NO
+AXISYMMETRIC= YES
+
+% -------------------- COMPRESSIBLE FREE-STREAM DEFINITION --------------------%
+%
+MACH_NUMBER= 1E-9
+INIT_OPTION= TD_CONDITIONS
+FREESTREAM_OPTION= TEMPERATURE_FS
+FREESTREAM_PRESSURE= 1400000
+FREESTREAM_TEMPERATURE= 373.15
+REF_DIMENSIONALIZATION= DIMENSIONAL
+
+% ---- IDEAL GAS, POLYTROPIC, VAN DER WAALS AND PENG ROBINSON CONSTANTS -------%
+%
+FLUID_MODEL= STANDARD_AIR
+
+% --------------------------- VISCOSITY MODEL ---------------------------------%
+%
+VISCOSITY_MODEL= CONSTANT_VISCOSITY
+MU_CONSTANT= 1.716E-5
+
+% --------------------------- THERMAL CONDUCTIVITY MODEL ----------------------%
+%
+CONDUCTIVITY_MODEL= CONSTANT_PRANDTL
+PRANDTL_LAM= 0.72
+PRANDTL_TURB= 0.90
+
+% -------------------- BOUNDARY CONDITION DEFINITION --------------------------%
+%
+MARKER_HEATFLUX= ( WALL, 0.0 )
+MARKER_SYM= ( SYMMETRY )
+MARKER_RIEMANN= ( INFLOW, TOTAL_CONDITIONS_PT, 1400000.0, 373.15, 1.0, 0.0, 0.0, \
+                  OUTFLOW, STATIC_PRESSURE, 100000.0, 0.0, 0.0, 0.0, 0.0 )
+MARKER_MONITORING = (WALL)
+
+
+% --------------------- SPECIES TRANSPORT SIMULATION --------------------------%
+%
+KIND_SCALAR_MODEL= SPECIES_TRANSPORT
+DIFFUSIVITY_MODEL= CONSTANT_DIFFUSIVITY
+DIFFUSIVITY_CONSTANT= 0.001
+MARKER_INLET_SPECIES= ( INFLOW, 0.5 )
+SPECIES_INIT= 0.25
+SPECIES_CLIPPING= YES
+SPECIES_CLIPPING_MAX= 1.0
+SPECIES_CLIPPING_MIN= 0.0
+
+% ------------- COMMON PARAMETERS DEFINING THE NUMERICAL METHOD ---------------%
+%
+NUM_METHOD_GRAD= GREEN_GAUSS
+CFL_NUMBER= 1000.0
+CFL_ADAPT= NO
+MAX_DELTA_TIME= 1E6
+OBJECTIVE_FUNCTION= DRAG
+
+% ----------- SLOPE LIMITER AND DISSIPATION SENSOR DEFINITION -----------------%
+%
+MUSCL_FLOW= YES
+SLOPE_LIMITER_FLOW= NONE
+
+% ------------------------ LINEAR SOLVER DEFINITION ---------------------------%
+%
+LINEAR_SOLVER= FGMRES
+LINEAR_SOLVER_PREC= ILU
+LINEAR_SOLVER_ILU_FILL_IN= 0
+LINEAR_SOLVER_ERROR= 0.01
+LINEAR_SOLVER_ITER= 10
+
+% -------------------- FLOW NUMERICAL METHOD DEFINITION -----------------------%
+%
+CONV_NUM_METHOD_FLOW= ROE
+ENTROPY_FIX_COEFF= 0.1
+TIME_DISCRE_FLOW= EULER_IMPLICIT
+
+% -------------------- TURBULENT NUMERICAL METHOD DEFINITION ------------------%
+%
+CONV_NUM_METHOD_TURB= SCALAR_UPWIND
+TIME_DISCRE_TURB= EULER_IMPLICIT
+CFL_REDUCTION_TURB= 1.0
+
+% --------------------------- CONVERGENCE PARAMETERS --------------------------%
+%
+ITER= 15
+CONV_RESIDUAL_MINVAL= -12
+CONV_STARTITER= 10
+
+% ------------------------- INPUT/OUTPUT INFORMATION --------------------------%
+%
+MESH_FILENAME= nozzle.su2
+RESTART_FILENAME= restart_flow
+OUTPUT_WRT_FREQ= 1000
+SCREEN_OUTPUT= (INNER_ITER, RMS_DENSITY, RMS_ENERGY, RMS_TKE, RMS_DISSIPATION, RMS_SPECIES_0, TOTAL_HEATFLUX, \
+                RMS_ADJ_DENSITY, RMS_ADJ_ENERGY, RMS_ADJ_TKE, RMS_ADJ_DISSIPATION)

--- a/TestCases/serial_regression.py
+++ b/TestCases/serial_regression.py
@@ -349,6 +349,15 @@ def main():
     axi_rans_air_nozzle_restart.tol       = 0.0001
     test_list.append(axi_rans_air_nozzle_restart)
 
+    # Axisymmetric air nozzle species
+    axi_rans_air_nozzle_species           = TestCase('axi_rans_air_nozzle_species')
+    axi_rans_air_nozzle_species.cfg_dir   = "axisymmetric_rans/air_nozzle"
+    axi_rans_air_nozzle_species.cfg_file  = "air_nozzle_species.cfg"
+    axi_rans_air_nozzle_species.test_iter = 10
+    axi_rans_air_nozzle_species.test_vals =  [-1.840714, 3.726195, -2.009323, 5.649002, -2.494388, 0.0000]
+    axi_rans_air_nozzle_species.tol       = 0.0001
+    test_list.append(axi_rans_air_nozzle_species)
+
     #################################
     ## Compressible RANS Restart  ###
     #################################


### PR DESCRIPTION
## Proposed Changes
Add support for Riemann boundary conditions to all scalar solvers by moving BC_Riemann definition from CTurbSolver to CScalarSolver.

I've only tested this for for CSpeciesSolver; I put the definition in CScalarSolver mainly just to avoid code duplication between CTurbSolver and CSpeciesSolver. Please let me know if there is a reason not to do this.

## PR Checklist

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [x] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [x] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
