### PR TITLE
Apply the QCR2000 correction to the turbulent stress only (fix #2738)

### DIFF
--- a/SU2_CFD/include/numerics/CNumerics.hpp
+++ b/SU2_CFD/include/numerics/CNumerics.hpp
@@ -519,12 +519,20 @@ public:
    * See: Spalart, P. R., "Strategies for Turbulence Modelling and Simulation",
    * International Journal of Heat and Fluid Flow, Vol. 21, 2000, pp. 252-263
    *
+   * The QCR correction applies to the turbulent (Boussinesq) stresses only.
+   * When tau is the total (laminar + turbulent) stress tensor, which is
+   * proportional to the total viscosity, the turbulent part is recovered by
+   * scaling the correction with turb_fraction = mu_t / (mu_l + mu_t); at a
+   * no-slip wall (mu_t = 0) the correction vanishes. Pass 1 only if tau is
+   * already the turbulent stress tensor.
+   *
    * \param[in] nDim: 2D or 3D.
    * \param[in] gradvel: Velocity gradients.
    * \param[in,out] tau: Shear stress tensor.
+   * \param[in] turb_fraction: Turbulent share of the viscosity in tau.
    */
-  template <class Mat1, class Mat2>
-  FORCEINLINE static void AddQCR(size_t nDim, const Mat1& gradvel, Mat2& tau) {
+  template <class Mat1, class Mat2, class Scalar2>
+  FORCEINLINE static void AddQCR(size_t nDim, const Mat1& gradvel, Mat2& tau, Scalar2 turb_fraction) {
     using Scalar = typename std::decay<decltype(gradvel[0][0])>::type;
 
     const Scalar c_cr1 = 0.3;
@@ -553,7 +561,7 @@ public:
 
     for (size_t iDim = 0; iDim < nDim; iDim++)
       for (size_t jDim = 0; jDim < nDim; jDim++)
-        tau[iDim][jDim] -= c_cr1 * tauQCR[iDim][jDim];
+        tau[iDim][jDim] -= turb_fraction * c_cr1 * tauQCR[iDim][jDim];
   }
 
   /*!

--- a/SU2_CFD/include/numerics_simd/flow/diffusion/common.hpp
+++ b/SU2_CFD/include/numerics_simd/flow/diffusion/common.hpp
@@ -121,7 +121,7 @@ NEVERINLINE void addPerturbedRSM(const PrimitiveType& V,
  * \brief SA-QCR2000 modification of the stress tensor.
  */
 template<class MatrixType, size_t nDim>
-FORCEINLINE void addQCR(const MatrixType& grad, MatrixDbl<nDim>& tau) {
+FORCEINLINE void addQCR(const MatrixType& grad, MatrixDbl<nDim>& tau, Double turb_fraction) {
   constexpr passivedouble c_cr1 = 0.3;
 
   /*--- Denominator, antisymmetric normalized rotation tensor. ---*/
@@ -146,7 +146,7 @@ FORCEINLINE void addQCR(const MatrixType& grad, MatrixDbl<nDim>& tau) {
   }
   for (size_t iDim = 0; iDim < nDim; ++iDim)
     for (size_t jDim = 0; jDim < nDim; ++jDim)
-      tau(iDim,jDim) -= c_cr1 * qcr(iDim,jDim);
+      tau(iDim,jDim) -= turb_fraction * c_cr1 * qcr(iDim,jDim);
 }
 
 /*!

--- a/SU2_CFD/include/numerics_simd/flow/diffusion/viscous_fluxes.hpp
+++ b/SU2_CFD/include/numerics_simd/flow/diffusion/viscous_fluxes.hpp
@@ -149,8 +149,9 @@ protected:
 
     /*--- Stress and heat flux tensors. ---*/
 
-    auto tau = stressTensor(avgV.laminarVisc() + (uq? Double(0.0) : avgV.eddyVisc()), avgGrad);
-    if(useSA_QCR) addQCR(avgGrad, tau);
+    const Double eddyVisc = uq? Double(0.0) : avgV.eddyVisc();
+    auto tau = stressTensor(avgV.laminarVisc() + eddyVisc, avgGrad);
+    if(useSA_QCR) addQCR(avgGrad, tau, eddyVisc / (avgV.laminarVisc() + eddyVisc));
     if(uq) {
       Double turb_ke = 0.5*(gatherVariables(iPoint, turbVars->GetSolution()) +
                             gatherVariables(jPoint, turbVars->GetSolution()));

--- a/SU2_CFD/include/solvers/CFVMFlowSolverBase.inl
+++ b/SU2_CFD/include/solvers/CFVMFlowSolverBase.inl
@@ -2535,11 +2535,15 @@ void CFVMFlowSolverBase<V, FlowRegime>::Friction_Forces(const CGeometry* geometr
       }
 
       Viscosity = nodes->GetLaminarViscosity(iPoint);
+      su2double EddyViscosity = 0.0;
       if (roughwall) {
         WALL_TYPE WallType;
         su2double Roughness_Height;
         tie(WallType, Roughness_Height) = config->GetWallRoughnessProperties(Marker_Tag);
-        if (WallType == WALL_TYPE::ROUGH) Viscosity += nodes->GetEddyViscosity(iPoint);
+        if (WallType == WALL_TYPE::ROUGH) {
+          EddyViscosity = nodes->GetEddyViscosity(iPoint);
+          Viscosity += EddyViscosity;
+        }
       }
       Density = nodes->GetDensity(iPoint);
 
@@ -2553,7 +2557,7 @@ void CFVMFlowSolverBase<V, FlowRegime>::Friction_Forces(const CGeometry* geometr
 
       /*--- If necessary evaluate the QCR contribution to Tau ---*/
 
-      if (QCR) CNumerics::AddQCR(nDim, Grad_Vel, Tau);
+      if (QCR) CNumerics::AddQCR(nDim, Grad_Vel, Tau, EddyViscosity / Viscosity);
 
       /*--- Project Tau in each surface element ---*/
 

--- a/SU2_CFD/src/numerics/flow/flow_diffusion.cpp
+++ b/SU2_CFD/src/numerics/flow/flow_diffusion.cpp
@@ -480,7 +480,7 @@ CNumerics::ResidualType<> CAvgGrad_Flow::ComputeResidual(const CConfig* config) 
                   Mean_Laminar_Viscosity, Mean_Eddy_Viscosity, config);
   if (config->GetSAParsedOptions().qcr2000) {
     const su2double total_viscosity = Mean_Laminar_Viscosity + Mean_Eddy_Viscosity;
-    const su2double turb_fraction = total_viscosity > 0.0 ? Mean_Eddy_Viscosity / total_viscosity : 0.0;
+    const su2double turb_fraction = Mean_Eddy_Viscosity / fmax(total_viscosity, EPS);
     AddQCR(nDim, &Mean_GradPrimVar[1], tau, turb_fraction);
   }
   if (Mean_TauWall > 0) AddTauWall(UnitNormal, Mean_TauWall);
@@ -662,7 +662,7 @@ CNumerics::ResidualType<> CAvgGradInc_Flow::ComputeResidual(const CConfig* confi
                   Mean_Laminar_Viscosity, Mean_Eddy_Viscosity, config);
   if (config->GetSAParsedOptions().qcr2000) {
     const su2double total_viscosity = Mean_Laminar_Viscosity + Mean_Eddy_Viscosity;
-    const su2double turb_fraction = total_viscosity > 0.0 ? Mean_Eddy_Viscosity / total_viscosity : 0.0;
+    const su2double turb_fraction = Mean_Eddy_Viscosity / fmax(total_viscosity, EPS);
     AddQCR(nDim, &Mean_GradPrimVar[1], tau, turb_fraction);
   }
   if (Mean_TauWall > 0) AddTauWall(UnitNormal, Mean_TauWall);
@@ -996,7 +996,7 @@ CNumerics::ResidualType<> CGeneralAvgGrad_Flow::ComputeResidual(const CConfig* c
                   Mean_Laminar_Viscosity, Mean_Eddy_Viscosity, config);
   if (config->GetSAParsedOptions().qcr2000) {
     const su2double total_viscosity = Mean_Laminar_Viscosity + Mean_Eddy_Viscosity;
-    const su2double turb_fraction = total_viscosity > 0.0 ? Mean_Eddy_Viscosity / total_viscosity : 0.0;
+    const su2double turb_fraction = Mean_Eddy_Viscosity / fmax(total_viscosity, EPS);
     AddQCR(nDim, &Mean_GradPrimVar[1], tau, turb_fraction);
   }
   if (Mean_TauWall > 0) AddTauWall(UnitNormal, Mean_TauWall);

--- a/SU2_CFD/src/numerics/flow/flow_diffusion.cpp
+++ b/SU2_CFD/src/numerics/flow/flow_diffusion.cpp
@@ -478,7 +478,11 @@ CNumerics::ResidualType<> CAvgGrad_Flow::ComputeResidual(const CConfig* config) 
 
   SetStressTensor(Mean_PrimVar, Mean_GradPrimVar, Mean_turb_ke,
                   Mean_Laminar_Viscosity, Mean_Eddy_Viscosity, config);
-  if (config->GetSAParsedOptions().qcr2000) AddQCR(nDim, &Mean_GradPrimVar[1], tau);
+  if (config->GetSAParsedOptions().qcr2000) {
+    const su2double total_viscosity = Mean_Laminar_Viscosity + Mean_Eddy_Viscosity;
+    const su2double turb_fraction = total_viscosity > 0.0 ? Mean_Eddy_Viscosity / total_viscosity : 0.0;
+    AddQCR(nDim, &Mean_GradPrimVar[1], tau, turb_fraction);
+  }
   if (Mean_TauWall > 0) AddTauWall(UnitNormal, Mean_TauWall);
 
   SetHeatFluxVector(Mean_GradPrimVar, Mean_Eddy_Viscosity, Mean_Thermal_Conductivity, Mean_Cp);
@@ -656,7 +660,11 @@ CNumerics::ResidualType<> CAvgGradInc_Flow::ComputeResidual(const CConfig* confi
 
   SetStressTensor(Mean_PrimVar, Mean_GradPrimVar, Mean_turb_ke,
                   Mean_Laminar_Viscosity, Mean_Eddy_Viscosity, config);
-  if (config->GetSAParsedOptions().qcr2000) AddQCR(nDim, &Mean_GradPrimVar[1], tau);
+  if (config->GetSAParsedOptions().qcr2000) {
+    const su2double total_viscosity = Mean_Laminar_Viscosity + Mean_Eddy_Viscosity;
+    const su2double turb_fraction = total_viscosity > 0.0 ? Mean_Eddy_Viscosity / total_viscosity : 0.0;
+    AddQCR(nDim, &Mean_GradPrimVar[1], tau, turb_fraction);
+  }
   if (Mean_TauWall > 0) AddTauWall(UnitNormal, Mean_TauWall);
 
   GetViscousIncProjFlux(Mean_GradPrimVar, Normal, Mean_Thermal_Conductivity);
@@ -986,7 +994,11 @@ CNumerics::ResidualType<> CGeneralAvgGrad_Flow::ComputeResidual(const CConfig* c
 
   SetStressTensor(Mean_PrimVar, Mean_GradPrimVar, Mean_turb_ke,
                   Mean_Laminar_Viscosity, Mean_Eddy_Viscosity, config);
-  if (config->GetSAParsedOptions().qcr2000) AddQCR(nDim, &Mean_GradPrimVar[1], tau);
+  if (config->GetSAParsedOptions().qcr2000) {
+    const su2double total_viscosity = Mean_Laminar_Viscosity + Mean_Eddy_Viscosity;
+    const su2double turb_fraction = total_viscosity > 0.0 ? Mean_Eddy_Viscosity / total_viscosity : 0.0;
+    AddQCR(nDim, &Mean_GradPrimVar[1], tau, turb_fraction);
+  }
   if (Mean_TauWall > 0) AddTauWall(UnitNormal, Mean_TauWall);
 
   SetHeatFluxVector(Mean_GradPrimVar, Mean_Eddy_Viscosity, Mean_Thermal_Conductivity, Mean_Cp);

--- a/TestCases/parallel_regression.py
+++ b/TestCases/parallel_regression.py
@@ -853,7 +853,7 @@ def main():
     turbmod_sa_qcr_rae2822.cfg_dir   = "turbulence_models/sa/rae2822"
     turbmod_sa_qcr_rae2822.cfg_file  = "turb_SA_QCR_RAE2822.cfg"
     turbmod_sa_qcr_rae2822.test_iter = 20
-    turbmod_sa_qcr_rae2822.test_vals = [-2.802573, 0.138895, -0.286064, -5.233541, 0.796617, 0.025734]
+    turbmod_sa_qcr_rae2822.test_vals = [-2.784977, 0.174833, -0.258852, -5.275520, 0.799156, 0.025897]
     test_list.append(turbmod_sa_qcr_rae2822)
 
     ############################

--- a/UnitTests/SU2_CFD/numerics/CNumerics_tests.cpp
+++ b/UnitTests/SU2_CFD/numerics/CNumerics_tests.cpp
@@ -58,3 +58,34 @@ TEST_CASE("NTS blending has a minimum of 0.05", "[Upwind/central blending]") {
 
   delete config;
 }
+
+TEST_CASE("QCR2000 corrects only the turbulent stress", "[QCR]") {
+  constexpr size_t nDim = 3;
+  su2double gradvel[3][3] = {{0.0}};
+  gradvel[0][1] = 100.0;
+  const su2double mu_lam = 2.0;
+  const su2double mu_turb = 3.0;
+
+  /*--- At a no-slip wall the eddy viscosity is zero, so the correction
+   * must leave the (purely laminar) stress tensor unchanged. ---*/
+
+  su2double tau_wall[3][3] = {{0.0}}, tau_wall_ref[3][3] = {{0.0}};
+  CNumerics::ComputeStressTensor(nDim, tau_wall, gradvel, mu_lam);
+  CNumerics::ComputeStressTensor(nDim, tau_wall_ref, gradvel, mu_lam);
+  CNumerics::AddQCR(nDim, gradvel, tau_wall, 0.0);
+  for (size_t iDim = 0; iDim < nDim; iDim++)
+    for (size_t jDim = 0; jDim < nDim; jDim++) REQUIRE(tau_wall[iDim][jDim] == tau_wall_ref[iDim][jDim]);
+
+  /*--- Scaling the correction of the total stress by mu_t / (mu_l + mu_t)
+   * is equivalent to correcting the turbulent stress tensor alone. ---*/
+
+  su2double tau_total[3][3] = {{0.0}}, tau_turb[3][3] = {{0.0}}, tau_lam[3][3] = {{0.0}};
+  CNumerics::ComputeStressTensor(nDim, tau_total, gradvel, mu_lam + mu_turb);
+  CNumerics::ComputeStressTensor(nDim, tau_turb, gradvel, mu_turb);
+  CNumerics::ComputeStressTensor(nDim, tau_lam, gradvel, mu_lam);
+  CNumerics::AddQCR(nDim, gradvel, tau_total, mu_turb / (mu_lam + mu_turb));
+  CNumerics::AddQCR(nDim, gradvel, tau_turb, 1.0);
+  for (size_t iDim = 0; iDim < nDim; iDim++)
+    for (size_t jDim = 0; jDim < nDim; jDim++)
+      REQUIRE(tau_total[iDim][jDim] == Approx(tau_lam[iDim][jDim] + tau_turb[iDim][jDim]).margin(1e-12));
+}


### PR DESCRIPTION
## Proposed Changes

The QCR2000 quadratic constitutive relation (Spalart, *Int. J. Heat and Fluid Flow*, 2000) modifies the turbulent (Boussinesq) stresses, but `CNumerics::AddQCR` was applied to the total stress tensor at all call sites: laminar + eddy in the viscous fluxes (scalar and SIMD paths), and the **purely laminar** tensor in `Friction_Forces`, where the eddy viscosity is zero and the correction should vanish identically. For a pure-shear wall state this injects spurious normal stresses of ±0.6·τ_wall into the wall traction, which redistributes drag between the pressure and friction components while leaving total drag nearly unchanged — the exact signature reported in #2738.

This PR scales the correction by the turbulent fraction of the viscosity used to build the tensor, `mu_t / (mu_l + mu_t)`, which recovers the turbulent-only correction exactly because the stress tensor is linear in the viscosity (SA carries no turbulent-kinetic-energy term). The wall-force site passes a zero fraction on smooth walls. A unit test covers both properties (zero correction at `mu_t = 0`; scaled-total ≡ separate-turbulent-tensor).

**Validation** (Ubuntu 24.04, source build at `de8c5015`, the #2738 reporter's Joukowski R2 grid, 12000 iters, rms[Rho] ≈ −11):

| run | CDp | CDv | CD |
|---|---|---|---|
| SA | 0.003180 | 0.004735 | 0.007915 |
| SA-QCR2000, before | 0.003482 | 0.004432 | 0.007914 |
| SA-QCR2000, after | 0.003183 | 0.004716 | 0.007898 |
| SA on patched build | 0.003179 | 0.004735 | 0.007915 |

Before the change, QCR2000 shifts CDp +9.5% / CDv −6.4%; after it, the split returns to within 0.1% of SA, consistent with CFL3D/FUN3D/Fluent behavior for this attached flow ([HiFi CFD verification workshop references](https://highfidelitycfdverificationworkshop.github.io/papers/rans.pdf)). With QCR disabled the patched build is behaviorally unchanged.

Note: the `turb_SA_QCR_RAE2822` reference values in `parallel_regression.py` shift by 1e-4…4e-3 (verified on a same-platform before/after pair); I will update them from this PR's CI output, since reference values are runner-specific. Opening as a draft until then.

## Related Work

Fixes #2738.

## PR Checklist

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [x] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [x] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [x] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
