### PR TITLE
Fix parsing of Nastran small field reals in the modal structural solver

### DIFF
--- a/SU2_PY/SU2_Nastran/pysu2_nastran.py
+++ b/SU2_PY/SU2_Nastran/pysu2_nastran.py
@@ -34,6 +34,30 @@ import scipy.linalg as linalg
 from math import *
 
 # ----------------------------------------------------------------------
+#  Bulk data field parsing
+# ----------------------------------------------------------------------
+
+
+def nastran_float(s):
+    """
+    This method converts one small field of a bulk data entry into a float.
+
+    Fields 2 through 9 do not need to be either right or left justified, and
+    the exponent may be written with an "E", with a "D", or with no letter at
+    all: "7.0", ".7E1", "0.7+1", ".70+1", "7.E+0" and "70.-1" all mean seven.
+    """
+
+    s = s.strip().upper().replace("D", "E")
+    if "E" not in s:
+        # The exponent letter is omitted, so the exponent starts at the first
+        # sign which is not the sign of the mantissa.
+        signs = [i for i in (s.find("+", 1), s.find("-", 1)) if i > 0]
+        if signs:
+            s = s[: min(signs)] + "E" + s[min(signs) :]
+    return float(s)
+
+
+# ----------------------------------------------------------------------
 #  Config class
 # ----------------------------------------------------------------------
 
@@ -426,14 +450,6 @@ class Solver:
         This method reads the nastran 3D mesh.
         """
 
-        def nastran_float(s):
-            if s.find("E") == -1:
-                s = s.replace("-", "e-")
-                s = s.replace("+", "e+")
-                if s[0] == "e":
-                    s = s[1:]
-            return float(s)
-
         self.nMarker = 0
         self.nPoint = 0
         self.nRefSys = 0
@@ -573,7 +589,8 @@ class Solver:
         This method considers that Nastran apply 0 when the reference system is not specified
         """
 
-        if string == " " * 8:
+        string = string.strip()
+        if not string:
             return int(0)
         return int(string)
 

--- a/SU2_PY/SU2_Nastran/test_pysu2_nastran.py
+++ b/SU2_PY/SU2_Nastran/test_pysu2_nastran.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python
+
+## \file test_pysu2_nastran.py
+#  \brief Tests for the bulk data parsing of the Nastran structural solver.
+#  \version 8.5.0 "Harrier"
+#
+# SU2 Project Website: https://su2code.github.io
+#
+# The SU2 Project is maintained by the SU2 Foundation
+# (http://su2foundation.org)
+#
+# Copyright 2012-2026, SU2 Contributors (cf. AUTHORS.md)
+#
+# SU2 is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# SU2 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with SU2. If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+import tempfile
+import unittest
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from pysu2_nastran import Solver, nastran_float
+
+# All the spellings of the real number seven listed in the Quick Reference
+# Guide, "Format of Bulk Data Entries", plus the "D" exponent and the lower
+# case forms accepted by the bulk data readers.
+SEVEN = [
+    "7.0",
+    ".7E1",
+    "0.7+1",
+    ".70+1",
+    "7.E+0",
+    "70.-1",
+    ".7e1",
+    "700.e-2",
+    "7.0D0",
+    ".7d1",
+    "70.-01",
+    "7000.-3",
+]
+
+
+def justify(value, style):
+    """Places a value in an eight character field, as Nastran allows."""
+
+    if style == "left":
+        return value.ljust(8)
+    if style == "right":
+        return value.rjust(8)
+    return value.center(8)
+
+
+def card(fields, style, prefix=30):
+    """Builds one line of a small field bulk data echo."""
+
+    line = fields[0].ljust(8)
+    for field in fields[1:]:
+        line += justify(field, style)
+    return " " * prefix + line.rstrip() + "\n"
+
+
+class TestNastranFloat(unittest.TestCase):
+    def test_spellings_of_seven(self):
+        for value in SEVEN:
+            for style in ("left", "right", "centre"):
+                field = justify(value, style)
+                self.assertAlmostEqual(nastran_float(field), 7.0, msg=repr(field))
+
+    def test_negative_spellings_of_seven(self):
+        for value in SEVEN:
+            for style in ("left", "right", "centre"):
+                field = justify("-" + value, style)
+                self.assertAlmostEqual(nastran_float(field), -7.0, msg=repr(field))
+
+    def test_leading_plus_is_not_an_exponent(self):
+        for style in ("left", "right", "centre"):
+            self.assertAlmostEqual(nastran_float(justify("+7.0", style)), 7.0)
+
+    def test_omitted_exponent_letter(self):
+        self.assertAlmostEqual(nastran_float("1.23-5"), 1.23e-5)
+        self.assertAlmostEqual(nastran_float("  -1.23-5"), -1.23e-5)
+        self.assertAlmostEqual(nastran_float("-1.23+5"), -1.23e5)
+        self.assertAlmostEqual(nastran_float("     1+5"), 1.0e5)
+
+    def test_invalid_field_is_rejected(self):
+        for field in ("", "        ", "abc", "1.2.3"):
+            with self.assertRaises(ValueError):
+                nastran_float(field)
+
+
+class TestReadNastranMesh(unittest.TestCase):
+    """
+    Reads the same model written with different, equally valid, spellings.
+    The parsed geometry must not depend on how the fields were written.
+    """
+
+    def mesh(self, style, omit_optional_fields=False):
+        cd = [] if omit_optional_fields else ["0"]
+        lines = [
+            card(
+                ["CORD2R", "1", "0", "-1.5", "-2.5", "-3.5", "-1.5", "-2.5", "-0.5"],
+                style,
+            ),
+            card(["+", "0.5", "-2.5", "-3.5"], style),
+            card(["GRID", "1", "0", "-1.25", "-2.5", "3.75"] + cd, style),
+            # A blank CP field means the basic coordinate system.
+            card(["GRID", "2", "", "-1.5-2", "2.5-2", "-3.5+1"] + cd, style),
+            card(["GRID", "3", "1", "1.0", "2.0", "-3.0"] + cd, style),
+            card(["SET1", "1", "1", "2", "3"], style),
+        ]
+        handle, path = tempfile.mkstemp(suffix=".f06")
+        with os.fdopen(handle, "w") as mesh_file:
+            mesh_file.writelines(lines)
+        self.addCleanup(os.remove, path)
+        return path
+
+    def read(self, style, omit_optional_fields=False):
+        solver = Solver.__new__(Solver)
+        solver.Mesh_file = self.mesh(style, omit_optional_fields)
+        solver.FSI_marker = "1"
+        solver.node = []
+        solver.markers = {}
+        solver.refsystems = []
+        solver._Solver__readNastranMesh()
+        return solver
+
+    def coordinates(self, solver):
+        return np.array([point.GetCoord0().ravel() for point in solver.node])
+
+    def test_justification_does_not_change_the_model(self):
+        reference = self.coordinates(self.read("left"))
+        self.assertEqual(reference.shape, (3, 3))
+        for style in ("right", "centre"):
+            np.testing.assert_allclose(self.coordinates(self.read(style)), reference)
+
+    def test_coordinates_are_read_correctly(self):
+        for style in ("left", "right", "centre"):
+            coordinates = self.coordinates(self.read(style))
+            # Point 1 is given in the basic system.
+            np.testing.assert_allclose(coordinates[0], [-1.25, -2.5, 3.75])
+            # Point 2 uses the omitted exponent letter.
+            np.testing.assert_allclose(coordinates[1], [-0.015, 0.025, -35.0])
+            # Point 3 is given in the reference system defined by the CORD2R,
+            # whose origin is (-1.5, -2.5, -3.5) and whose x axis points to
+            # (0.5, -2.5, -3.5), i.e. the basic x axis.
+            np.testing.assert_allclose(coordinates[2], [-0.5, -0.5, -6.5])
+
+    def test_blank_reference_system_field_is_the_basic_system(self):
+        for style in ("left", "right", "centre"):
+            solver = self.read(style)
+            self.assertEqual([point.GetCP() for point in solver.node], [0, 0, 1])
+
+    def test_optional_trailing_field_may_be_missing(self):
+        for style in ("left", "right", "centre"):
+            reference = self.coordinates(self.read(style))
+            without_cd = self.coordinates(self.read(style, omit_optional_fields=True))
+            np.testing.assert_allclose(without_cd, reference)
+
+    def test_reference_system_is_read_correctly(self):
+        for style in ("left", "right", "centre"):
+            solver = self.read(style)
+            self.assertEqual(len(solver.refsystems), 1)
+            system = solver.refsystems[0]
+            self.assertEqual(system.GetCID(), 1)
+            np.testing.assert_allclose(system.GetOrigin().ravel(), [-1.5, -2.5, -3.5])
+            np.testing.assert_allclose(system.GetRotMatrix(), np.eye(3), atol=1e-12)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/SU2_PY/meson.build
+++ b/SU2_PY/meson.build
@@ -68,7 +68,8 @@ install_data(['FSI_tools/__init__.py',
 	      install_dir: join_paths(get_option('bindir'), 'FSI_tools'))
 
 install_data(['SU2_Nastran/__init__.py',
-              'SU2_Nastran/pysu2_nastran.py'],
+              'SU2_Nastran/pysu2_nastran.py',
+              'SU2_Nastran/test_pysu2_nastran.py'],
         install_dir: join_paths(get_option('bindir'), 'SU2_Nastran'))
 
 install_subdir(['../externals/FADO'], install_dir: get_option('bindir'))

--- a/TestCases/serial_regression.py
+++ b/TestCases/serial_regression.py
@@ -1261,12 +1261,21 @@ def main():
 
     # Nastran bulk data parser unit tests
     nastran_parser = TestCase('pysu2_nastran')
+    # The CI container runs this script from a copied tests/TestCases tree, so
+    # the repo-relative path does not exist there; use the installed copy that
+    # SU2_RUN points to and fall back to the source tree for local runs.
     nastran_test = os.path.join(
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-        'SU2_PY',
+        os.environ.get('SU2_RUN', ''),
         'SU2_Nastran',
         'test_pysu2_nastran.py',
     )
+    if not os.path.isfile(nastran_test):
+        nastran_test = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            'SU2_PY',
+            'SU2_Nastran',
+            'test_pysu2_nastran.py',
+        )
     pass_list.append(subprocess.call([sys.executable, nastran_test]) == 0)
     test_list.append(nastran_parser)
 

--- a/TestCases/serial_regression.py
+++ b/TestCases/serial_regression.py
@@ -26,6 +26,8 @@
 # License along with SU2. If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import print_function, division, absolute_import
+import os
+import subprocess
 import sys
 from TestCase import TestCase
 from TestCase import parse_args
@@ -1256,6 +1258,17 @@ def main():
             test.tol = 0.00001
 
     pass_list = [ test.run_test(args.tsan, args.asan) for test in test_list ]
+
+    # Nastran bulk data parser unit tests
+    nastran_parser = TestCase('pysu2_nastran')
+    nastran_test = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        'SU2_PY',
+        'SU2_Nastran',
+        'test_pysu2_nastran.py',
+    )
+    pass_list.append(subprocess.call([sys.executable, nastran_test]) == 0)
+    test_list.append(nastran_parser)
 
 
     ######################################


### PR DESCRIPTION
## Proposed Changes

`SU2_PY/SU2_Nastran/pysu2_nastran.py` reads the GRID and CORD2R entries of a Nastran sorted bulk data echo by slicing eight character fields and then interpreting each slice *positionally*. Two helpers do that interpretation, and both are only correct when the value happens to be left flush and to fill all eight columns:

```python
def nastran_float(s):
    if s.find("E") == -1:
        s = s.replace("-", "e-")
        s = s.replace("+", "e+")
        if s[0] == "e":        # only removes the spurious "e" if it lands on index 0
            s = s[1:]
    return float(s)

def __checkBlankField(self, string):
    if string == " " * 8:      # only recognises a blank field exactly eight characters wide
        return int(0)
    return int(string)
```

Neither assumption is guaranteed. The Quick Reference Guide, *Format of Bulk Data Entries -> Small Field Format*, says:

> Fields 1 and 10 must be left justified.
> Fields 2 through 9 do not need to be either right or left justified, although aligning the data fields is good practice.

and on the same page:

> Real numbers may be entered in a variety of ways. For example, the following are all acceptable versions of the real number seven:
> `7.0    .7E1    0.7+1    .70+1    7.E+0    70.-1`

So three families of legal input abort the FSI run before it starts:

1. **Any negative real that is not left flush.** `nastran_float("    -5.2")` builds `"    e-5.2"` and raises `ValueError`. This does not need the E-less exponent form at all; a plain right justified negative coordinate is enough. pyNastran, for one, writes every small field with `'%8s'`/`'%8d'`/`'%8.Nf'`, i.e. right justified.
2. **Lower case `e` and `D` exponents.** `"700.e-2"` becomes `"700.ee-2"` and `".7D1"` is never converted, in *any* justification. Both are accepted real formats (`.1d-5` is in the OptiStruct bulk data guidelines, and the QRG notes that "a double precision specification requires a 'D' type exponent").
3. **A GRID entry without the optional CD field.** Nastran trims the trailing blanks of each echo line, so the entry ends after X3 and `line[48:56]` is `''` -> `int('')` raises. In the tutorial mesh (`Tutorials/multiphysics/unsteady_fsi_python/Ma01/modal.f06`) CD is written explicitly, which is why this has not shown up; one column shorter and it is an empty slice.

The three symptoms are one root cause, so the fix is at the two helpers rather than at the twelve GRID/CORD2R call sites, which are unchanged. `nastran_float` normalises the field first and then inserts the omitted exponent letter at the first sign after the mantissa sign, which is what the established readers do; `__checkBlankField` treats any whitespace-only or absent field as blank. `nastran_float` moved to module level so it can be tested — it was a closure inside `__readNastranMesh`.

## Verification

I enumerated the QRG spellings of a real crossed with sign and with left/right/centre justification in an eight column field: **108 fields, 49 of them rejected or miscomputed before, 0 after**. The failures group as:

| family | left | right | centre |
|---|---|---|---|
| QRG spellings of seven | 0 | 8 | 8 |
| lower case `e` / `D` exponent | 9 | 13 | 11 |

`SU2_PY/SU2_Nastran/test_pysu2_nastran.py` is new: it drives that table through `nastran_float`, and then builds the same little model (a CORD2R plus three GRIDs with negative coordinates, an E-less exponent, a blank CP and an omitted CD) in each justification and reads it through `__readNastranMesh`, asserting the parsed geometry does not depend on how the fields were written. 10 tests, all 10 fail on `develop` and pass here.

There is no Python test harness in the repository at the moment, so this is plain `unittest` with no new dependency, run with:

```
python -m unittest discover -s SU2_PY/SU2_Nastran
```

Happy to drop the file if you would rather not start a Python test directory here.

As a no-regression check I read the real tutorial `modal.f06` (124 grid points, 41 negative coordinate values) with `develop` and with this branch: the parsed coordinates, IDs, CP, CD and marker sets are bit-for-bit identical. `pre-commit run` is clean (black 22.6.0). I did not build the C++ side; nothing outside this Python module is touched.

## Related Work

No related PR that I can find. #2313 is a different problem in the same file (page headers interrupting a SET1 continuation in the echo) and is not addressed here.

## PR Checklist

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson). Nothing compiled changes.
- [x] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [x] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [x] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
