### PR TITLE
[WIP] cache Least Squares matrix for gradient computation

### DIFF
--- a/Common/include/CConfig.hpp
+++ b/Common/include/CConfig.hpp
@@ -135,7 +135,8 @@ private:
   Hold_GridFixed,           /*!< \brief Flag hold fixed some part of the mesh during the deformation. */
   Axisymmetric,             /*!< \brief Flag for axisymmetric calculations */
   Enable_Cuda,              /*!< \brief Flag for switching GPU computing*/
-  Integrated_HeatFlux;      /*!< \brief Flag for heat flux BC whether it deals with integrated values.*/
+  Integrated_HeatFlux,      /*!< \brief Flag for heat flux BC whether it deals with integrated values.*/
+  Cache_LSQ_Metrics;        /*!< \brief Cache the factorized least-squares metric terms (rebuilt after mesh motion). */
   su2double Buffet_k;       /*!< \brief Sharpness coefficient for buffet sensor.*/
   su2double Buffet_lambda;  /*!< \brief Offset parameter for buffet sensor.*/
   su2double Damp_Engine_Inflow;   /*!< \brief Damping factor for the engine inlet. */
@@ -9732,6 +9733,11 @@ public:
    * \return YES if the passed values is the integrated heat flux over the marker's surface.
    */
   bool GetIntegrated_HeatFlux() const { return Integrated_HeatFlux; }
+
+  /*!
+   * \brief Reuse the factorized least-squares metric terms across gradient evaluations.
+   */
+  bool GetCache_LSQ_Metrics() const { return Cache_LSQ_Metrics; }
 
   /*!
    * \brief Get Compute Average.

--- a/Common/include/CConfig.hpp
+++ b/Common/include/CConfig.hpp
@@ -135,8 +135,7 @@ private:
   Hold_GridFixed,           /*!< \brief Flag hold fixed some part of the mesh during the deformation. */
   Axisymmetric,             /*!< \brief Flag for axisymmetric calculations */
   Enable_Cuda,              /*!< \brief Flag for switching GPU computing*/
-  Integrated_HeatFlux,      /*!< \brief Flag for heat flux BC whether it deals with integrated values.*/
-  Cache_LSQ_Metrics;        /*!< \brief Cache the factorized least-squares metric terms (rebuilt after mesh motion). */
+  Integrated_HeatFlux;      /*!< \brief Flag for heat flux BC whether it deals with integrated values.*/
   su2double Buffet_k;       /*!< \brief Sharpness coefficient for buffet sensor.*/
   su2double Buffet_lambda;  /*!< \brief Offset parameter for buffet sensor.*/
   su2double Damp_Engine_Inflow;   /*!< \brief Damping factor for the engine inlet. */
@@ -9735,9 +9734,12 @@ public:
   bool GetIntegrated_HeatFlux() const { return Integrated_HeatFlux; }
 
   /*!
-   * \brief Reuse the factorized least-squares metric terms across gradient evaluations.
+   * \brief Whether the factorized least-squares gradient metric terms are cached and reused
+   *        across evaluations. This is the default behavior, except for periodic boundaries
+   *        (their metric and RHS accumulations are fused in one exchange) and the discrete
+   *        adjoint (the coordinate dependence of the metrics must remain on the tape).
    */
-  bool GetCache_LSQ_Metrics() const { return Cache_LSQ_Metrics; }
+  bool GetLSQMetricCaching() const { return (nMarker_PerBound == 0) && !DiscreteAdjoint; }
 
   /*!
    * \brief Get Compute Average.

--- a/Common/include/geometry/CGeometry.hpp
+++ b/Common/include/geometry/CGeometry.hpp
@@ -217,6 +217,12 @@ class CGeometry {
   unsigned long edgeColorGroupSize{1};     /*!< \brief Size of the edge groups within each color. */
   unsigned long elemColorGroupSize{1};     /*!< \brief Size of the element groups within each color. */
 
+  /*--- Cached least-squares gradient metric terms (see CACHE_LSQ_METRICS). ---*/
+
+  su2activematrix LSQMetricCache[2];             /*!< \brief Cached LSQ metrics S = inv(A), upper triangle stored
+                                                             row-wise, [0] unweighted, [1] inverse-distance weighted. */
+  bool LSQMetricCacheValid[2] = {false, false};  /*!< \brief Validity of the cached LSQ metrics per weighting. */
+
   ColMajorMatrix<uint8_t> CoarseGridColor_; /*!< \brief Coarse grid levels, colorized. */
 
  public:
@@ -1918,6 +1924,28 @@ class CGeometry {
    * \brief Force the natural (sequential) edge coloring.
    */
   void SetNaturalEdgeColoring();
+
+  /*!
+   * \brief Get the cached least-squares metric terms (S = inv(A), upper triangle row-wise).
+   * \param[in] weighted - False for unweighted, true for inverse-distance weighting.
+   */
+  inline su2activematrix& GetLSQMetricCache(bool weighted) { return LSQMetricCache[weighted]; }
+  inline const su2activematrix& GetLSQMetricCache(bool weighted) const { return LSQMetricCache[weighted]; }
+
+  /*!
+   * \brief Check whether the cached least-squares metric terms are valid for a weighting.
+   */
+  inline bool LSQMetricCacheIsValid(bool weighted) const { return LSQMetricCacheValid[weighted]; }
+
+  /*!
+   * \brief Declare the cached least-squares metric terms valid for a weighting.
+   */
+  inline void SetLSQMetricCacheValid(bool weighted) { LSQMetricCacheValid[weighted] = true; }
+
+  /*!
+   * \brief Invalidate the cached least-squares metric terms (e.g. if node coordinates change).
+   */
+  inline void InvalidateLSQMetricCache() { LSQMetricCacheValid[0] = LSQMetricCacheValid[1] = false; }
 
   /*!
    * \brief Get the group size used in edge coloring.

--- a/Common/include/geometry/CGeometry.hpp
+++ b/Common/include/geometry/CGeometry.hpp
@@ -217,7 +217,7 @@ class CGeometry {
   unsigned long edgeColorGroupSize{1};     /*!< \brief Size of the edge groups within each color. */
   unsigned long elemColorGroupSize{1};     /*!< \brief Size of the element groups within each color. */
 
-  /*--- Cached least-squares gradient metric terms (see CACHE_LSQ_METRICS). ---*/
+  /*--- Cached least-squares gradient metric terms (see computeGradientsLeastSquares.hpp). ---*/
 
   su2activematrix LSQMetricCache[2];            /*!< \brief Cached LSQ metrics S = inv(A), upper triangle stored
                                                             row-wise, [0] unweighted, [1] inverse-distance weighted. */

--- a/Common/include/geometry/CGeometry.hpp
+++ b/Common/include/geometry/CGeometry.hpp
@@ -219,9 +219,9 @@ class CGeometry {
 
   /*--- Cached least-squares gradient metric terms (see CACHE_LSQ_METRICS). ---*/
 
-  su2activematrix LSQMetricCache[2];             /*!< \brief Cached LSQ metrics S = inv(A), upper triangle stored
-                                                             row-wise, [0] unweighted, [1] inverse-distance weighted. */
-  bool LSQMetricCacheValid[2] = {false, false};  /*!< \brief Validity of the cached LSQ metrics per weighting. */
+  su2activematrix LSQMetricCache[2];            /*!< \brief Cached LSQ metrics S = inv(A), upper triangle stored
+                                                            row-wise, [0] unweighted, [1] inverse-distance weighted. */
+  bool LSQMetricCacheValid[2] = {false, false}; /*!< \brief Validity of the cached LSQ metrics per weighting. */
 
   ColMajorMatrix<uint8_t> CoarseGridColor_; /*!< \brief Coarse grid levels, colorized. */
 

--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -1778,9 +1778,6 @@ void CConfig::SetConfig_Options() {
   addStringDoubleListOption("MARKER_HEATFLUX", nMarker_HeatFlux, Marker_HeatFlux, Heat_Flux);
   /*!\brief INTEGRATED_HEATFLUX \n DESCRIPTION: Prescribe Heatflux in [W] instead of [W/m^2] \ingroup Config \default false */
   addBoolOption("INTEGRATED_HEATFLUX", Integrated_HeatFlux, false);
-  /*!\brief CACHE_LSQ_METRICS \n DESCRIPTION: Cache the factorized least-squares gradient metrics (S = A^-1) and
-   reuse them across gradient evaluations. Not active for periodic boundaries or the discrete adjoint. \default false */
-  addBoolOption("CACHE_LSQ_METRICS", Cache_LSQ_Metrics, false);
   /*!\brief MARKER_HEATTRANSFER DESCRIPTION: Heat flux with specified heat transfer coefficient boundary marker(s)\n
    * Format: ( Heat transfer marker, heat transfer coefficient, wall temperature (static), ... ) \ingroup Config  */
   addExhaustOption("MARKER_HEATTRANSFER", nMarker_HeatTransfer, Marker_HeatTransfer, HeatTransfer_Coeff, HeatTransfer_WallTemp);
@@ -3887,17 +3884,6 @@ void CConfig::SetPostprocessing(SU2_COMPONENT val_software, unsigned short val_i
       SU2_MPI::Error("Centered schemes do not use MUSCL reconstruction (use MUSCL_FLOW= NO).", CURRENT_FUNCTION);
     } else {
       MUSCL_Flow = false;
-    }
-  }
-
-  /*--- The cached LSQ metrics require an RHS-only periodic exchange that is not implemented, and
-   *    their coordinate dependence must remain on the tape for the discrete adjoint. On moving or
-   *    deforming grids the cache is invalidated and rebuilt whenever the dual grid is updated. ---*/
-  if (Cache_LSQ_Metrics && (nMarker_PerBound > 0 || DiscreteAdjoint)) {
-    Cache_LSQ_Metrics = false;
-    if (rank == MASTER_NODE) {
-      cout << "WARNING: CACHE_LSQ_METRICS is not compatible with periodic boundaries or the\n"
-              "         discrete adjoint. The option was disabled." << endl;
     }
   }
 

--- a/Common/src/CConfig.cpp
+++ b/Common/src/CConfig.cpp
@@ -1778,6 +1778,9 @@ void CConfig::SetConfig_Options() {
   addStringDoubleListOption("MARKER_HEATFLUX", nMarker_HeatFlux, Marker_HeatFlux, Heat_Flux);
   /*!\brief INTEGRATED_HEATFLUX \n DESCRIPTION: Prescribe Heatflux in [W] instead of [W/m^2] \ingroup Config \default false */
   addBoolOption("INTEGRATED_HEATFLUX", Integrated_HeatFlux, false);
+  /*!\brief CACHE_LSQ_METRICS \n DESCRIPTION: Cache the factorized least-squares gradient metrics (S = A^-1) and
+   reuse them across gradient evaluations. Not active for periodic boundaries or the discrete adjoint. \default false */
+  addBoolOption("CACHE_LSQ_METRICS", Cache_LSQ_Metrics, false);
   /*!\brief MARKER_HEATTRANSFER DESCRIPTION: Heat flux with specified heat transfer coefficient boundary marker(s)\n
    * Format: ( Heat transfer marker, heat transfer coefficient, wall temperature (static), ... ) \ingroup Config  */
   addExhaustOption("MARKER_HEATTRANSFER", nMarker_HeatTransfer, Marker_HeatTransfer, HeatTransfer_Coeff, HeatTransfer_WallTemp);
@@ -3886,6 +3889,18 @@ void CConfig::SetPostprocessing(SU2_COMPONENT val_software, unsigned short val_i
       MUSCL_Flow = false;
     }
   }
+
+  /*--- The cached LSQ metrics require an RHS-only periodic exchange that is not implemented, and
+   *    their coordinate dependence must remain on the tape for the discrete adjoint. On moving or
+   *    deforming grids the cache is invalidated and rebuilt whenever the dual grid is updated. ---*/
+  if (Cache_LSQ_Metrics && (nMarker_PerBound > 0 || DiscreteAdjoint)) {
+    Cache_LSQ_Metrics = false;
+    if (rank == MASTER_NODE) {
+      cout << "WARNING: CACHE_LSQ_METRICS is not compatible with periodic boundaries or the\n"
+              "         discrete adjoint. The option was disabled." << endl;
+    }
+  }
+
   if (MUSCL_AdjFlow && (Kind_ConvNumScheme_AdjFlow == SPACE_CENTERED)) {
     if (OptionIsSet("MUSCL_ADJFLOW")) {
       SU2_MPI::Error("Centered schemes do not use MUSCL reconstruction (use MUSCL_ADJFLOW= NO).", CURRENT_FUNCTION);

--- a/Common/src/geometry/CMultiGridGeometry.cpp
+++ b/Common/src/geometry/CMultiGridGeometry.cpp
@@ -1000,6 +1000,9 @@ void CMultiGridGeometry::MatchActuator_Disk(const CConfig* config) {
 
 void CMultiGridGeometry::SetControlVolume(const CGeometry* fine_grid, unsigned short action) {
   BEGIN_SU2_OMP_SAFE_GLOBAL_ACCESS {
+    /*--- Coarse coordinates change with the fine grid, any cached LSQ metrics are stale. ---*/
+    if (action != ALLOCATE) InvalidateLSQMetricCache();
+
     /*--- Compute the area of the coarse volume ---*/
     for (auto iCoarsePoint = 0u; iCoarsePoint < nPoint; iCoarsePoint++) {
       nodes->SetVolume(iCoarsePoint, 0.0);

--- a/Common/src/geometry/CPhysicalGeometry.cpp
+++ b/Common/src/geometry/CPhysicalGeometry.cpp
@@ -6759,6 +6759,9 @@ void CPhysicalGeometry::SetControlVolume(CConfig* config, unsigned short action)
 
   BEGIN_SU2_OMP_SAFE_GLOBAL_ACCESS { /*--- The following is difficult to parallelize with threads. ---*/
 
+    /*--- Node coordinates changed, any cached LSQ gradient metrics are stale. ---*/
+    if (action != ALLOCATE) InvalidateLSQMetricCache();
+
     su2double my_DomainVolume = 0.0;
     for (auto iElem = 0ul; iElem < nElem; iElem++) {
       const auto nNodes = elem[iElem]->GetnNodes();

--- a/SU2_CFD/include/gradients/computeGradientsLeastSquares.hpp
+++ b/SU2_CFD/include/gradients/computeGradientsLeastSquares.hpp
@@ -30,7 +30,30 @@
 #include "../../../Common/include/toolboxes/geometry_toolbox.hpp"
 #include "correctGradientsSymmetry.hpp"
 
+/*!
+ * \brief Caching strategy for the least-squares metric terms (S := inv(A)).
+ * \note The metric terms depend only on the grid coordinates and the type of weighting,
+ *       they can be computed once (BUILD) and reused (APPLY) while the coordinates do
+ *       not change, which reduces the work per evaluation to the right-hand-side sums
+ *       and one small matrix-vector product per point. On moving/deforming grids the
+ *       cache is invalidated when the dual grid is updated (CGeometry::SetControlVolume)
+ *       and rebuilt on the next evaluation.
+ */
+enum class LSQ_METRIC_CACHE {
+  NONE,   /*!< \brief Assemble and factorize the metric terms on the fly (no reuse). */
+  BUILD,  /*!< \brief Assemble and factorize, then store S in the geometry cache for reuse. */
+  APPLY,  /*!< \brief Reuse the S matrix stored in the geometry cache. */
+};
+
 namespace detail {
+
+/*!
+ * \brief Flattened index of entry (iDim,jDim), iDim <= jDim, of an upper triangular
+ *        matrix stored row-wise (the layout of the cached LSQ metric terms).
+ */
+FORCEINLINE constexpr size_t lsqCacheIdx(size_t nDim, size_t iDim, size_t jDim) {
+  return iDim * nDim - (iDim * (iDim - 1)) / 2 + (jDim - iDim);
+}
 
 /*!
  * \brief Prepare Smatrix for 2D.
@@ -77,7 +100,8 @@ FORCEINLINE void solveLeastSquares(size_t iPoint,
                                    size_t varBegin,
                                    size_t varEnd,
                                    const RMatrixType& Rmatrix,
-                                   GradientType& gradient)
+                                   GradientType& gradient,
+                                   su2activematrix* metricCache = nullptr)
 {
   const auto eps = pow(std::numeric_limits<passivedouble>::epsilon(),2);
 
@@ -131,6 +155,16 @@ FORCEINLINE void solveLeastSquares(size_t iPoint,
     computeSmatrix(r11, r12, r13, r22, r23, r33, detR2, Smatrix);
   }
 
+  /*--- Store the metric terms in the geometry cache for reuse (a singular point stores
+   *    S = 0, i.e. its gradient will be zero, as in the on-the-fly path). Only used in
+   *    primal mode, hence no AD handling. ---*/
+
+  if (metricCache != nullptr) {
+    for (size_t iDim = 0; iDim < nDim; ++iDim)
+      for (size_t jDim = iDim; jDim < nDim; ++jDim)
+        (*metricCache)(iPoint, lsqCacheIdx(nDim, iDim, jDim)) = Smatrix[iDim][jDim];
+  }
+
   if (periodic) {
     /*--- Stop preacc here as gradient is in/out. ---*/
     for (size_t iDim = 0; iDim < nDim; ++iDim)
@@ -159,6 +193,152 @@ FORCEINLINE void solveLeastSquares(size_t iPoint,
       for (size_t iDim = 0; iDim < nDim; ++iDim)
         AD::SetPreaccOut(gradient(iPoint, iVar, iDim));
     AD::EndPreacc();
+  }
+}
+
+/*!
+ * \brief Fast least-squares gradient evaluation reusing cached metric terms.
+ * \ingroup FvmAlgos
+ * \note Requires a previous call in BUILD mode with the same weighting, which stores
+ *       S = inv(A) in the geometry cache (shared by all solvers, one slot per weighting).
+ *       Only the right-hand side b = sum_k w*dist*(u_k - u_i) is accumulated (in an edge
+ *       loop, i.e. each edge is visited once since its contribution is identical for both
+ *       end points), followed by the product S*b per point. Not compatible with periodic
+ *       boundaries.
+ */
+template<size_t nDim, class FieldType, class GradientType>
+void computeGradientsLeastSquaresCached(CSolver* solver,
+                                        MPI_QUANTITIES kindMpiComm,
+                                        CGeometry& geometry,
+                                        const CConfig& config,
+                                        bool weighted,
+                                        const FieldType& field,
+                                        const size_t varBegin,
+                                        const size_t varEnd,
+                                        const int idxVel,
+                                        GradientType& gradient)
+{
+  const auto& metricCache = geometry.GetLSQMetricCache(weighted);
+  const size_t nPoint = geometry.GetnPoint();
+  const size_t nPointDomain = geometry.GetnPointDomain();
+
+#ifdef HAVE_OMP
+  constexpr size_t OMP_MAX_CHUNK = 512;
+
+  const size_t chunkSize = computeStaticChunkSize(nPointDomain,
+                           omp_get_max_threads(), OMP_MAX_CHUNK);
+#endif
+
+  /*--- Clear the right-hand-side accumulators, including halo points, which
+   *    receive edge contributions (discarded when halos are communicated). ---*/
+
+  SU2_OMP_FOR_STAT(2048)
+  for (size_t iPoint = 0; iPoint < nPoint; ++iPoint)
+    for (size_t iVar = varBegin; iVar < varEnd; ++iVar)
+      for (size_t iDim = 0; iDim < nDim; ++iDim)
+        gradient(iPoint, iVar, iDim) = 0.0;
+  END_SU2_OMP_FOR
+
+  /*--- Accumulate the RHS in a loop over the edges: the contribution of edge {i,j} is
+   *    w*dist_ij*(u_j - u_i) for BOTH end points. A race-free edge coloring is required
+   *    with multiple threads, the "natural" coloring (single color, used with the
+   *    reducer strategy) forces the fallback to a thread-safe loop over nodes. ---*/
+
+  const auto& coloring = geometry.GetEdgeColoring();
+
+  const bool safeColoring = (omp_get_max_threads() == 1) || (coloring.getOuterSize() > 1);
+
+  if (safeColoring) {
+    const size_t groupSize = geometry.GetEdgeColorGroupSize();
+
+    for (auto iColor = 0ul; iColor < coloring.getOuterSize(); ++iColor) {
+      const auto* edgeIndices = coloring.innerIdx(iColor);
+      const auto nEdgesColor = coloring.getNumNonZeros(iColor);
+
+      SU2_OMP_FOR_DYN(nextMultiple(size_t(32), groupSize))
+      for (auto k = 0ul; k < nEdgesColor; ++k) {
+        const auto iEdge = edgeIndices[k];
+        const auto iPoint = geometry.edges->GetNode(iEdge, 0);
+        const auto jPoint = geometry.edges->GetNode(iEdge, 1);
+
+        su2double dist_ij[nDim] = {0.0};
+        GeometryToolbox::Distance(nDim, geometry.nodes->GetCoord(jPoint),
+                                  geometry.nodes->GetCoord(iPoint), dist_ij);
+
+        su2double weight = 1.0;
+        if (weighted) {
+          const su2double dist2 = GeometryToolbox::SquaredNorm(nDim, dist_ij);
+          if (dist2 <= 0.0) continue;
+          weight = 1.0 / dist2;
+        }
+
+        for (size_t iVar = varBegin; iVar < varEnd; ++iVar) {
+          const su2double delta_ij = weight * (field(jPoint,iVar) - field(iPoint,iVar));
+
+          for (size_t iDim = 0; iDim < nDim; ++iDim) {
+            const su2double contrib = dist_ij[iDim] * delta_ij;
+            gradient(iPoint, iVar, iDim) += contrib;
+            gradient(jPoint, iVar, iDim) += contrib;
+          }
+        }
+      }
+      END_SU2_OMP_FOR
+    }
+  }
+  else {
+    SU2_OMP_FOR_DYN(chunkSize)
+    for (size_t iPoint = 0; iPoint < nPointDomain; ++iPoint) {
+      const auto coord_i = geometry.nodes->GetCoord(iPoint);
+
+      for (auto jPoint : geometry.nodes->GetPoints(iPoint)) {
+        su2double dist_ij[nDim] = {0.0};
+        GeometryToolbox::Distance(nDim, geometry.nodes->GetCoord(jPoint), coord_i, dist_ij);
+
+        su2double weight = 1.0;
+        if (weighted) {
+          const su2double dist2 = GeometryToolbox::SquaredNorm(nDim, dist_ij);
+          if (dist2 <= 0.0) continue;
+          weight = 1.0 / dist2;
+        }
+
+        for (size_t iVar = varBegin; iVar < varEnd; ++iVar) {
+          const su2double delta_ij = weight * (field(jPoint,iVar) - field(iPoint,iVar));
+
+          for (size_t iDim = 0; iDim < nDim; ++iDim)
+            gradient(iPoint, iVar, iDim) += dist_ij[iDim] * delta_ij;
+        }
+      }
+    }
+    END_SU2_OMP_FOR
+  }
+
+  /*--- Multiply the RHS by the cached S matrix. ---*/
+
+  SU2_OMP_FOR_DYN(chunkSize)
+  for (size_t iPoint = 0; iPoint < nPointDomain; ++iPoint) {
+    for (size_t iVar = varBegin; iVar < varEnd; ++iVar) {
+      su2double Cvector[nDim] = {0.0};
+
+      for (size_t iDim = 0; iDim < nDim; ++iDim)
+        for (size_t jDim = 0; jDim < nDim; ++jDim)
+          Cvector[iDim] += metricCache(iPoint, lsqCacheIdx(nDim, min(iDim,jDim), max(iDim,jDim))) *
+                           gradient(iPoint, iVar, jDim);
+
+      for (size_t iDim = 0; iDim < nDim; ++iDim)
+        gradient(iPoint, iVar, iDim) = Cvector[iDim];
+    }
+  }
+  END_SU2_OMP_FOR
+
+  /*--- Compute the corrections for symmetry planes and Euler walls. ---*/
+
+  correctGradientsSymmetry<nDim>(geometry, config, varBegin, varEnd, idxVel, gradient);
+
+  /*--- Obtain the gradients at halo points from the MPI ranks that own them. ---*/
+
+  if (solver != nullptr) {
+    solver->InitiateComms(&geometry, &config, kindMpiComm);
+    solver->CompleteComms(&geometry, &config, kindMpiComm);
   }
 }
 
@@ -192,11 +372,34 @@ void computeGradientsLeastSquares(CSolver* solver,
                                   const size_t varEnd,
                                   const int idxVel,
                                   GradientType& gradient,
-                                  RMatrixType& Rmatrix)
+                                  RMatrixType& Rmatrix,
+                                  LSQ_METRIC_CACHE cacheMode)
 {
   const bool periodic = (solver != nullptr) && (config.GetnMarker_Periodic() > 0);
 
+  /*--- The metric caching does not support the mid-computation periodic accumulations. ---*/
+
+  if (periodic) cacheMode = LSQ_METRIC_CACHE::NONE;
+
+  if (cacheMode == LSQ_METRIC_CACHE::APPLY) {
+    computeGradientsLeastSquaresCached<nDim>(solver, kindMpiComm, geometry, config, weighted,
+                                             field, varBegin, varEnd, idxVel, gradient);
+    return;
+  }
+
   const size_t nPointDomain = geometry.GetnPointDomain();
+
+  /*--- In BUILD mode, allocate the geometry cache for this weighting (all threads
+   *    synchronize on the master doing the allocation). ---*/
+
+  su2activematrix* metricCache = nullptr;
+
+  if (cacheMode == LSQ_METRIC_CACHE::BUILD) {
+    metricCache = &geometry.GetLSQMetricCache(weighted);
+    BEGIN_SU2_OMP_SAFE_GLOBAL_ACCESS {
+      if (metricCache->size() == 0) metricCache->resize(nPointDomain, nDim*(nDim+1)/2);
+    } END_SU2_OMP_SAFE_GLOBAL_ACCESS
+  }
 
 #ifdef HAVE_OMP
   constexpr size_t OMP_MAX_CHUNK = 512;
@@ -292,10 +495,20 @@ void computeGradientsLeastSquares(CSolver* solver,
     else {
       /*--- Periodic comms are not needed, solve the LS problem for iPoint. ---*/
 
-      solveLeastSquares<nDim, false>(iPoint, varBegin, varEnd, Rmatrix, gradient);
+      solveLeastSquares<nDim, false>(iPoint, varBegin, varEnd, Rmatrix, gradient, metricCache);
     }
   }
   END_SU2_OMP_FOR
+
+  /*--- Declare the cache valid and make sure the edge coloring is available before the
+   *    first cached evaluation, building it here avoids a race on its lazy construction. ---*/
+
+  if (metricCache != nullptr) {
+    BEGIN_SU2_OMP_SAFE_GLOBAL_ACCESS {
+      geometry.GetEdgeColoring();
+      geometry.SetLSQMetricCacheValid(weighted);
+    } END_SU2_OMP_SAFE_GLOBAL_ACCESS
+  }
 
   /*--- Correct the gradient values across any periodic boundaries. ---*/
 
@@ -348,15 +561,16 @@ void computeGradientsLeastSquares(CSolver* solver,
                                   const size_t varEnd,
                                   const int idxVel,
                                   GradientType& gradient,
-                                  RMatrixType& Rmatrix) {
+                                  RMatrixType& Rmatrix,
+                                  LSQ_METRIC_CACHE cacheMode = LSQ_METRIC_CACHE::NONE) {
   switch (geometry.GetnDim()) {
   case 2:
     detail::computeGradientsLeastSquares<2>(solver, kindMpiComm, kindPeriodicComm, geometry, config,
-                                            weighted, field, varBegin, varEnd, idxVel, gradient, Rmatrix);
+                                            weighted, field, varBegin, varEnd, idxVel, gradient, Rmatrix, cacheMode);
     break;
   case 3:
     detail::computeGradientsLeastSquares<3>(solver, kindMpiComm, kindPeriodicComm, geometry, config,
-                                            weighted, field, varBegin, varEnd, idxVel, gradient, Rmatrix);
+                                            weighted, field, varBegin, varEnd, idxVel, gradient, Rmatrix, cacheMode);
     break;
   default:
     SU2_MPI::Error("Too many dimensions to compute gradients.", CURRENT_FUNCTION);

--- a/SU2_CFD/include/gradients/computeGradientsLeastSquares.hpp
+++ b/SU2_CFD/include/gradients/computeGradientsLeastSquares.hpp
@@ -30,21 +30,6 @@
 #include "../../../Common/include/toolboxes/geometry_toolbox.hpp"
 #include "correctGradientsSymmetry.hpp"
 
-/*!
- * \brief Caching strategy for the least-squares metric terms (S := inv(A)).
- * \note The metric terms depend only on the grid coordinates and the type of weighting,
- *       they can be computed once (BUILD) and reused (APPLY) while the coordinates do
- *       not change, which reduces the work per evaluation to the right-hand-side sums
- *       and one small matrix-vector product per point. On moving/deforming grids the
- *       cache is invalidated when the dual grid is updated (CGeometry::SetControlVolume)
- *       and rebuilt on the next evaluation.
- */
-enum class LSQ_METRIC_CACHE {
-  NONE,   /*!< \brief Assemble and factorize the metric terms on the fly (no reuse). */
-  BUILD,  /*!< \brief Assemble and factorize, then store S in the geometry cache for reuse. */
-  APPLY,  /*!< \brief Reuse the S matrix stored in the geometry cache. */
-};
-
 namespace detail {
 
 /*!
@@ -90,6 +75,45 @@ FORCEINLINE void computeSmatrix(su2double r11, su2double r12, su2double r13,
 }
 
 /*!
+ * \brief Factorize the accumulated normal matrix A of the least-squares problem
+ *        (Cholesky) and form S = inv(A), the entries r* are the unique entries of A.
+ *        A (nearly) singular matrix results in S = 0, i.e. a zero gradient.
+ * \ingroup FvmAlgos
+ */
+template<size_t nDim>
+FORCEINLINE void invertNormalMatrix(su2double r11, su2double r12, su2double r13,
+                                    su2double r22, su2double r23_a, su2double r23_b,
+                                    su2double r33, su2double Smatrix[][nDim])
+{
+  const auto eps = pow(std::numeric_limits<passivedouble>::epsilon(),2);
+
+  r11 = sqrt(max(r11, eps));
+  r12 /= r11;
+  r22 = sqrt(max(r22 - r12*r12, eps));
+
+  su2double r23 = 0.0;
+  if (nDim == 3) {
+    r13 /= r11;
+    r23 = r23_a/r22 - r23_b*r12/(r11*r22);
+    r33 = sqrt(max(r33 - r23*r23 - r13*r13, eps));
+  }
+  else {
+    r13 = 0.0;
+    r33 = 1.0;
+  }
+
+  /*--- Compute determinant ---*/
+
+  const su2double detR2 = pow(r11*r22*r33, 2);
+
+  /*--- S matrix := inv(R)*traspose(inv(R)), detect singular matrix ---*/
+
+  if (detR2 > eps) {
+    computeSmatrix(r11, r12, r13, r22, r23, r33, detR2, Smatrix);
+  }
+}
+
+/*!
  * \brief Solve the least-squares problem for one point.
  * \ingroup FvmAlgos
  * \note See detail::computeGradientsLeastSquares for the
@@ -100,12 +124,9 @@ FORCEINLINE void solveLeastSquares(size_t iPoint,
                                    size_t varBegin,
                                    size_t varEnd,
                                    const RMatrixType& Rmatrix,
-                                   GradientType& gradient,
-                                   su2activematrix* metricCache = nullptr)
+                                   GradientType& gradient)
 {
-  const auto eps = pow(std::numeric_limits<passivedouble>::epsilon(),2);
-
-  /*--- Entries of upper triangular matrix R. ---*/
+  /*--- Entries of the normal matrix A. ---*/
 
   if (periodic) {
     AD::StartPreacc();
@@ -114,14 +135,10 @@ FORCEINLINE void solveLeastSquares(size_t iPoint,
     AD::SetPreaccIn(Rmatrix(iPoint,1,1));
   }
 
-  su2double r11 = Rmatrix(iPoint,0,0);
-  su2double r12 = Rmatrix(iPoint,0,1);
-  su2double r22 = Rmatrix(iPoint,1,1);
-  su2double r13 = 0.0, r23 = 0.0, r33 = 1.0;
-
-  r11 = sqrt(max(r11, eps));
-  r12 /= r11;
-  r22 = sqrt(max(r22 - r12*r12, eps));
+  const su2double r11 = Rmatrix(iPoint,0,0);
+  const su2double r12 = Rmatrix(iPoint,0,1);
+  const su2double r22 = Rmatrix(iPoint,1,1);
+  su2double r13 = 0.0, r23_a = 0.0, r23_b = 0.0, r33 = 0.0;
 
   if (nDim == 3) {
     if (periodic) {
@@ -133,37 +150,13 @@ FORCEINLINE void solveLeastSquares(size_t iPoint,
 
     r13 = Rmatrix(iPoint,0,2);
     r33 = Rmatrix(iPoint,2,2);
-    const auto r23_a = Rmatrix(iPoint,1,2);
-    const auto r23_b = Rmatrix(iPoint,2,1);
-
-    r13 /= r11;
-    r23 = r23_a/r22 - r23_b*r12/(r11*r22);
-    r33 = sqrt(max(r33 - r23*r23 - r13*r13, eps));
+    r23_a = Rmatrix(iPoint,1,2);
+    r23_b = Rmatrix(iPoint,2,1);
   }
-
-  /*--- Compute determinant ---*/
-
-  const su2double detR2 = pow(r11*r22*r33, 2);
-
-  /*--- S matrix := inv(R)*traspose(inv(R)) ---*/
 
   su2double Smatrix[nDim][nDim] = {{0.0}};
 
-  /*--- Detect singular matrix ---*/
-
-  if (detR2 > eps) {
-    computeSmatrix(r11, r12, r13, r22, r23, r33, detR2, Smatrix);
-  }
-
-  /*--- Store the metric terms in the geometry cache for reuse (a singular point stores
-   *    S = 0, i.e. its gradient will be zero, as in the on-the-fly path). Only used in
-   *    primal mode, hence no AD handling. ---*/
-
-  if (metricCache != nullptr) {
-    for (size_t iDim = 0; iDim < nDim; ++iDim)
-      for (size_t jDim = iDim; jDim < nDim; ++jDim)
-        (*metricCache)(iPoint, lsqCacheIdx(nDim, iDim, jDim)) = Smatrix[iDim][jDim];
-  }
+  invertNormalMatrix<nDim>(r11, r12, r13, r22, r23_a, r23_b, r33, Smatrix);
 
   if (periodic) {
     /*--- Stop preacc here as gradient is in/out. ---*/
@@ -197,12 +190,93 @@ FORCEINLINE void solveLeastSquares(size_t iPoint,
 }
 
 /*!
- * \brief Fast least-squares gradient evaluation reusing cached metric terms.
+ * \brief Assemble, factorize, and store the least-squares gradient metric terms
+ *        (S = inv(A), upper triangle row-wise) of a grid in the geometry cache.
  * \ingroup FvmAlgos
- * \note Requires a previous call in BUILD mode with the same weighting, which stores
- *       S = inv(A) in the geometry cache (shared by all solvers, one slot per weighting).
- *       Only the right-hand side b = sum_k w*dist*(u_k - u_i) is accumulated (in an edge
- *       loop, i.e. each edge is visited once since its contribution is identical for both
+ * \note The metric terms depend only on the node coordinates and the weighting. They are
+ *       computed during the geometry preprocessing (see CDriver::InitializeGeometry) and,
+ *       on moving/deforming grids, recomputed on the first gradient evaluation after the
+ *       dual grid update invalidates them (CGeometry::SetControlVolume). The function is
+ *       safe to call from inside or outside an OpenMP parallel region, and returns
+ *       immediately if the cache is already valid.
+ */
+template<size_t nDim>
+void computeLSQMetrics(CGeometry& geometry, bool weighted)
+{
+  if (geometry.LSQMetricCacheIsValid(weighted)) return;
+
+  const size_t nPointDomain = geometry.GetnPointDomain();
+
+#ifdef HAVE_OMP
+  constexpr size_t OMP_MAX_CHUNK = 512;
+
+  const size_t chunkSize = computeStaticChunkSize(nPointDomain,
+                           omp_get_max_threads(), OMP_MAX_CHUNK);
+#endif
+
+  auto& metricCache = geometry.GetLSQMetricCache(weighted);
+
+  BEGIN_SU2_OMP_SAFE_GLOBAL_ACCESS {
+    if (metricCache.size() == 0) metricCache.resize(nPointDomain, nDim*(nDim+1)/2);
+  } END_SU2_OMP_SAFE_GLOBAL_ACCESS
+
+  SU2_OMP_FOR_DYN(chunkSize)
+  for (size_t iPoint = 0; iPoint < nPointDomain; ++iPoint) {
+    const auto coord_i = geometry.nodes->GetCoord(iPoint);
+
+    /*--- Accumulate the unique entries of the normal matrix A. ---*/
+
+    su2double r11 = 0.0, r12 = 0.0, r13 = 0.0, r22 = 0.0, r23_a = 0.0, r23_b = 0.0, r33 = 0.0;
+
+    for (auto jPoint : geometry.nodes->GetPoints(iPoint)) {
+      su2double dist_ij[nDim] = {0.0};
+      GeometryToolbox::Distance(nDim, geometry.nodes->GetCoord(jPoint), coord_i, dist_ij);
+
+      su2double weight = 1.0;
+      if (weighted) {
+        const su2double dist2 = GeometryToolbox::SquaredNorm(nDim, dist_ij);
+        if (dist2 <= 0.0) continue;
+        weight = 1.0 / dist2;
+      }
+
+      r11 += dist_ij[0]*dist_ij[0]*weight;
+      r12 += dist_ij[0]*dist_ij[1]*weight;
+      r22 += dist_ij[1]*dist_ij[1]*weight;
+
+      if (nDim == 3) {
+        r13   += dist_ij[0]*dist_ij[2]*weight;
+        r23_a += dist_ij[1]*dist_ij[2]*weight;
+        r23_b += dist_ij[0]*dist_ij[2]*weight;
+        r33   += dist_ij[2]*dist_ij[2]*weight;
+      }
+    }
+
+    su2double Smatrix[nDim][nDim] = {{0.0}};
+
+    invertNormalMatrix<nDim>(r11, r12, r13, r22, r23_a, r23_b, r33, Smatrix);
+
+    for (size_t iDim = 0; iDim < nDim; ++iDim)
+      for (size_t jDim = iDim; jDim < nDim; ++jDim)
+        metricCache(iPoint, lsqCacheIdx(nDim, iDim, jDim)) = Smatrix[iDim][jDim];
+  }
+  END_SU2_OMP_FOR
+
+  /*--- Declare the cache valid and make sure the edge coloring is available before the
+   *    first cached evaluation, building it here avoids a race on its lazy construction. ---*/
+
+  BEGIN_SU2_OMP_SAFE_GLOBAL_ACCESS {
+    geometry.GetEdgeColoring();
+    geometry.SetLSQMetricCacheValid(weighted);
+  } END_SU2_OMP_SAFE_GLOBAL_ACCESS
+}
+
+/*!
+ * \brief Fast least-squares gradient evaluation reusing the cached metric terms.
+ * \ingroup FvmAlgos
+ * \note Requires valid metric terms for this weighting in the geometry cache (see
+ *       computeLSQMetrics, shared by all solvers, one slot per weighting). Only the
+ *       right-hand side b = sum_k w*dist*(u_k - u_i) is accumulated (in an edge loop,
+ *       i.e. each edge is visited once since its contribution is identical for both
  *       end points), followed by the product S*b per point. Not compatible with periodic
  *       boundaries.
  */
@@ -373,33 +447,22 @@ void computeGradientsLeastSquares(CSolver* solver,
                                   const int idxVel,
                                   GradientType& gradient,
                                   RMatrixType& Rmatrix,
-                                  LSQ_METRIC_CACHE cacheMode)
+                                  bool useCaching)
 {
   const bool periodic = (solver != nullptr) && (config.GetnMarker_Periodic() > 0);
 
-  /*--- The metric caching does not support the mid-computation periodic accumulations. ---*/
+  /*--- Use the cached metric terms, rebuilding them if the coordinates changed since the
+   *    geometry preprocessing (or if this combination was not covered by it). The caching
+   *    does not support the mid-computation periodic accumulations. ---*/
 
-  if (periodic) cacheMode = LSQ_METRIC_CACHE::NONE;
-
-  if (cacheMode == LSQ_METRIC_CACHE::APPLY) {
+  if (useCaching && !periodic) {
+    computeLSQMetrics<nDim>(geometry, weighted);
     computeGradientsLeastSquaresCached<nDim>(solver, kindMpiComm, geometry, config, weighted,
                                              field, varBegin, varEnd, idxVel, gradient);
     return;
   }
 
   const size_t nPointDomain = geometry.GetnPointDomain();
-
-  /*--- In BUILD mode, allocate the geometry cache for this weighting (all threads
-   *    synchronize on the master doing the allocation). ---*/
-
-  su2activematrix* metricCache = nullptr;
-
-  if (cacheMode == LSQ_METRIC_CACHE::BUILD) {
-    metricCache = &geometry.GetLSQMetricCache(weighted);
-    BEGIN_SU2_OMP_SAFE_GLOBAL_ACCESS {
-      if (metricCache->size() == 0) metricCache->resize(nPointDomain, nDim*(nDim+1)/2);
-    } END_SU2_OMP_SAFE_GLOBAL_ACCESS
-  }
 
 #ifdef HAVE_OMP
   constexpr size_t OMP_MAX_CHUNK = 512;
@@ -495,20 +558,10 @@ void computeGradientsLeastSquares(CSolver* solver,
     else {
       /*--- Periodic comms are not needed, solve the LS problem for iPoint. ---*/
 
-      solveLeastSquares<nDim, false>(iPoint, varBegin, varEnd, Rmatrix, gradient, metricCache);
+      solveLeastSquares<nDim, false>(iPoint, varBegin, varEnd, Rmatrix, gradient);
     }
   }
   END_SU2_OMP_FOR
-
-  /*--- Declare the cache valid and make sure the edge coloring is available before the
-   *    first cached evaluation, building it here avoids a race on its lazy construction. ---*/
-
-  if (metricCache != nullptr) {
-    BEGIN_SU2_OMP_SAFE_GLOBAL_ACCESS {
-      geometry.GetEdgeColoring();
-      geometry.SetLSQMetricCacheValid(weighted);
-    } END_SU2_OMP_SAFE_GLOBAL_ACCESS
-  }
 
   /*--- Correct the gradient values across any periodic boundaries. ---*/
 
@@ -562,15 +615,34 @@ void computeGradientsLeastSquares(CSolver* solver,
                                   const int idxVel,
                                   GradientType& gradient,
                                   RMatrixType& Rmatrix,
-                                  LSQ_METRIC_CACHE cacheMode = LSQ_METRIC_CACHE::NONE) {
+                                  bool useCaching = false) {
   switch (geometry.GetnDim()) {
   case 2:
     detail::computeGradientsLeastSquares<2>(solver, kindMpiComm, kindPeriodicComm, geometry, config,
-                                            weighted, field, varBegin, varEnd, idxVel, gradient, Rmatrix, cacheMode);
+                                            weighted, field, varBegin, varEnd, idxVel, gradient, Rmatrix, useCaching);
     break;
   case 3:
     detail::computeGradientsLeastSquares<3>(solver, kindMpiComm, kindPeriodicComm, geometry, config,
-                                            weighted, field, varBegin, varEnd, idxVel, gradient, Rmatrix, cacheMode);
+                                            weighted, field, varBegin, varEnd, idxVel, gradient, Rmatrix, useCaching);
+    break;
+  default:
+    SU2_MPI::Error("Too many dimensions to compute gradients.", CURRENT_FUNCTION);
+    break;
+  }
+}
+
+/*!
+ * \brief Compute (if not already valid) the cached least-squares gradient metric terms of
+ *        a grid for one type of weighting, see detail::computeLSQMetrics.
+ * \ingroup FvmAlgos
+ */
+inline void computeLSQGradientMetrics(CGeometry& geometry, bool weighted) {
+  switch (geometry.GetnDim()) {
+  case 2:
+    detail::computeLSQMetrics<2>(geometry, weighted);
+    break;
+  case 3:
+    detail::computeLSQMetrics<3>(geometry, weighted);
     break;
   default:
     SU2_MPI::Error("Too many dimensions to compute gradients.", CURRENT_FUNCTION);

--- a/SU2_CFD/include/solvers/CFVMFlowSolverBase.inl
+++ b/SU2_CFD/include/solvers/CFVMFlowSolverBase.inl
@@ -424,8 +424,16 @@ void CFVMFlowSolverBase<V, R>::SetPrimitive_Gradient_LS(CGeometry* geometry, con
   auto& gradient = reconstruction ? nodes->GetGradient_Reconstruction() : nodes->GetGradient_Primitive();
   const auto comm = reconstruction? MPI_QUANTITIES::PRIMITIVE_GRAD_REC : MPI_QUANTITIES::PRIMITIVE_GRADIENT;
 
+  /*--- With metric caching, reuse the factorized LSQ terms stored in the geometry (shared by
+   *    all solvers, one slot per weighting) or (re)build them on the first evaluation. ---*/
+
+  auto cacheMode = LSQ_METRIC_CACHE::NONE;
+  if (config->GetCache_LSQ_Metrics()) {
+    cacheMode = geometry->LSQMetricCacheIsValid(weighted) ? LSQ_METRIC_CACHE::APPLY : LSQ_METRIC_CACHE::BUILD;
+  }
+
   computeGradientsLeastSquares(this, comm, commPer, *geometry, *config, weighted,
-                               primitives, 0, nPrimVarGrad, prim_idx.Velocity(), gradient, rmatrix);
+                               primitives, 0, nPrimVarGrad, prim_idx.Velocity(), gradient, rmatrix, cacheMode);
 }
 
 template <class V, ENUM_REGIME R>

--- a/SU2_CFD/include/solvers/CFVMFlowSolverBase.inl
+++ b/SU2_CFD/include/solvers/CFVMFlowSolverBase.inl
@@ -424,16 +424,9 @@ void CFVMFlowSolverBase<V, R>::SetPrimitive_Gradient_LS(CGeometry* geometry, con
   auto& gradient = reconstruction ? nodes->GetGradient_Reconstruction() : nodes->GetGradient_Primitive();
   const auto comm = reconstruction? MPI_QUANTITIES::PRIMITIVE_GRAD_REC : MPI_QUANTITIES::PRIMITIVE_GRADIENT;
 
-  /*--- With metric caching, reuse the factorized LSQ terms stored in the geometry (shared by
-   *    all solvers, one slot per weighting) or (re)build them on the first evaluation. ---*/
-
-  auto cacheMode = LSQ_METRIC_CACHE::NONE;
-  if (config->GetCache_LSQ_Metrics()) {
-    cacheMode = geometry->LSQMetricCacheIsValid(weighted) ? LSQ_METRIC_CACHE::APPLY : LSQ_METRIC_CACHE::BUILD;
-  }
-
   computeGradientsLeastSquares(this, comm, commPer, *geometry, *config, weighted,
-                               primitives, 0, nPrimVarGrad, prim_idx.Velocity(), gradient, rmatrix, cacheMode);
+                               primitives, 0, nPrimVarGrad, prim_idx.Velocity(), gradient, rmatrix,
+                               config->GetLSQMetricCaching());
 }
 
 template <class V, ENUM_REGIME R>

--- a/SU2_CFD/src/drivers/CDriver.cpp
+++ b/SU2_CFD/src/drivers/CDriver.cpp
@@ -32,6 +32,8 @@
 #include "../../../Common/include/geometry/CPhysicalGeometry.hpp"
 #include "../../../Common/include/geometry/CMultiGridGeometry.hpp"
 
+#include "../../include/gradients/computeGradientsLeastSquares.hpp"
+
 #include "../../include/solvers/CSolverFactory.hpp"
 #include "../../include/solvers/CFEM_DG_EulerSolver.hpp"
 
@@ -667,6 +669,33 @@ void CDriver::InitializeGeometry(CConfig* config, CGeometry **&geometry, bool du
       /*--- Initialize the communication framework for the periodic BCs. ---*/
       geometry[iMesh]->PreprocessPeriodicComms(geometry[iMesh], config);
 
+    }
+  }
+
+  /*--- Precompute the least-squares gradient metric terms (S = inv(A)) required by the
+   *    numerical settings, they depend only on the grid coordinates and the weighting.
+   *    Combinations not covered here (e.g. auxiliary variable gradients) are computed on
+   *    first use, and on moving/deforming grids the terms are recomputed after each mesh
+   *    update. ---*/
+
+  if (!dummy && !fem_solver && config->GetLSQMetricCaching()) {
+
+    const auto kindGrad = config->GetKind_Gradient_Method();
+    const bool lsqGrad = (kindGrad == LEAST_SQUARES) || (kindGrad == WEIGHTED_LEAST_SQUARES);
+
+    const auto kindGradRecon = config->GetKind_Gradient_Method_Recon();
+    const bool lsqGradRecon = config->GetReconstructionGradientRequired() &&
+                              ((kindGradRecon == LEAST_SQUARES) || (kindGradRecon == WEIGHTED_LEAST_SQUARES));
+
+    if (lsqGrad) computeLSQGradientMetrics(*geometry[MESH_0], kindGrad == WEIGHTED_LEAST_SQUARES);
+    if (lsqGradRecon) computeLSQGradientMetrics(*geometry[MESH_0], kindGradRecon == WEIGHTED_LEAST_SQUARES);
+
+    /*--- The coarse multigrid levels only compute gradients for the viscous fluxes. ---*/
+
+    if (lsqGrad && config->GetViscous()) {
+      for (iMesh = 1; iMesh <= config->GetnMGLevels(); iMesh++) {
+        computeLSQGradientMetrics(*geometry[iMesh], kindGrad == WEIGHTED_LEAST_SQUARES);
+      }
     }
   }
 

--- a/SU2_CFD/src/solvers/CSolver.cpp
+++ b/SU2_CFD/src/solvers/CSolver.cpp
@@ -2174,13 +2174,9 @@ void CSolver::SetAuxVar_Gradient_LS(CGeometry *geometry, const CConfig *config) 
   auto& gradient = base_nodes->GetAuxVarGradient();
   auto& rmatrix  = base_nodes->GetRmatrix();
 
-  auto cacheMode = LSQ_METRIC_CACHE::NONE;
-  if (config->GetCache_LSQ_Metrics()) {
-    cacheMode = geometry->LSQMetricCacheIsValid(weighted) ? LSQ_METRIC_CACHE::APPLY : LSQ_METRIC_CACHE::BUILD;
-  }
-
   computeGradientsLeastSquares(this, MPI_QUANTITIES::AUXVAR_GRADIENT, PERIODIC_NONE, *geometry, *config,
-                               weighted, solution, 0, base_nodes->GetnAuxVar(), -1, gradient, rmatrix, cacheMode);
+                               weighted, solution, 0, base_nodes->GetnAuxVar(), -1, gradient, rmatrix,
+                               config->GetLSQMetricCaching());
 }
 
 void CSolver::SetSolution_Gradient_GG(CGeometry *geometry, const CConfig *config, short idxVel, bool reconstruction) {
@@ -2214,14 +2210,8 @@ void CSolver::SetSolution_Gradient_LS(CGeometry *geometry, const CConfig *config
   auto& gradient = reconstruction? base_nodes->GetGradient_Reconstruction() : base_nodes->GetGradient();
   const auto comm = reconstruction? MPI_QUANTITIES::SOLUTION_GRAD_REC : MPI_QUANTITIES::SOLUTION_GRADIENT;
 
-  /*--- The cached metrics (stored per-geometry) are shared with all other LSQ gradients. ---*/
-
-  auto cacheMode = LSQ_METRIC_CACHE::NONE;
-  if (config->GetCache_LSQ_Metrics()) {
-    cacheMode = geometry->LSQMetricCacheIsValid(weighted) ? LSQ_METRIC_CACHE::APPLY : LSQ_METRIC_CACHE::BUILD;
-  }
-
-  computeGradientsLeastSquares(this, comm, commPer, *geometry, *config, weighted, solution, 0, nVar, idxVel, gradient, rmatrix, cacheMode);
+  computeGradientsLeastSquares(this, comm, commPer, *geometry, *config, weighted, solution, 0, nVar, idxVel,
+                               gradient, rmatrix, config->GetLSQMetricCaching());
 }
 
 void CSolver::SetUndivided_Laplacian(CGeometry *geometry, const CConfig *config) {

--- a/SU2_CFD/src/solvers/CSolver.cpp
+++ b/SU2_CFD/src/solvers/CSolver.cpp
@@ -2174,8 +2174,13 @@ void CSolver::SetAuxVar_Gradient_LS(CGeometry *geometry, const CConfig *config) 
   auto& gradient = base_nodes->GetAuxVarGradient();
   auto& rmatrix  = base_nodes->GetRmatrix();
 
+  auto cacheMode = LSQ_METRIC_CACHE::NONE;
+  if (config->GetCache_LSQ_Metrics()) {
+    cacheMode = geometry->LSQMetricCacheIsValid(weighted) ? LSQ_METRIC_CACHE::APPLY : LSQ_METRIC_CACHE::BUILD;
+  }
+
   computeGradientsLeastSquares(this, MPI_QUANTITIES::AUXVAR_GRADIENT, PERIODIC_NONE, *geometry, *config,
-                               weighted, solution, 0, base_nodes->GetnAuxVar(), -1, gradient, rmatrix);
+                               weighted, solution, 0, base_nodes->GetnAuxVar(), -1, gradient, rmatrix, cacheMode);
 }
 
 void CSolver::SetSolution_Gradient_GG(CGeometry *geometry, const CConfig *config, short idxVel, bool reconstruction) {
@@ -2209,7 +2214,14 @@ void CSolver::SetSolution_Gradient_LS(CGeometry *geometry, const CConfig *config
   auto& gradient = reconstruction? base_nodes->GetGradient_Reconstruction() : base_nodes->GetGradient();
   const auto comm = reconstruction? MPI_QUANTITIES::SOLUTION_GRAD_REC : MPI_QUANTITIES::SOLUTION_GRADIENT;
 
-  computeGradientsLeastSquares(this, comm, commPer, *geometry, *config, weighted, solution, 0, nVar, idxVel, gradient, rmatrix);
+  /*--- The cached metrics (stored per-geometry) are shared with all other LSQ gradients. ---*/
+
+  auto cacheMode = LSQ_METRIC_CACHE::NONE;
+  if (config->GetCache_LSQ_Metrics()) {
+    cacheMode = geometry->LSQMetricCacheIsValid(weighted) ? LSQ_METRIC_CACHE::APPLY : LSQ_METRIC_CACHE::BUILD;
+  }
+
+  computeGradientsLeastSquares(this, comm, commPer, *geometry, *config, weighted, solution, 0, nVar, idxVel, gradient, rmatrix, cacheMode);
 }
 
 void CSolver::SetUndivided_Laplacian(CGeometry *geometry, const CConfig *config) {

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -1483,17 +1483,6 @@ NUM_METHOD_GRAD= GREEN_GAUSS
 % NONE and the method specified in NUM_METHOD_GRAD is used.
 NUM_METHOD_GRAD_RECON = LEAST_SQUARES
 %
-% Cache the factorized least-squares gradient metrics (grid-only terms) and reuse
-% them across evaluations, computing only the right-hand side in an edge-based loop.
-% The cache is stored per grid with one slot per weighting (unweighted and inverse-
-% distance), shared by all solvers (flow, turbulence, species, ...), so mixing e.g.
-% unweighted reconstruction gradients with weighted viscous gradients is supported.
-% On moving/deforming grids the cache is invalidated and rebuilt after each mesh
-% update (once per time step), so the savings scale with the number of inner
-% iterations. Automatically disabled for periodic boundaries and the discrete
-% adjoint. (NO, YES)
-CACHE_LSQ_METRICS= NO
-%
 % CFL number (initial value for the adaptive CFL number)
 CFL_NUMBER= 15.0
 %

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -1483,6 +1483,17 @@ NUM_METHOD_GRAD= GREEN_GAUSS
 % NONE and the method specified in NUM_METHOD_GRAD is used.
 NUM_METHOD_GRAD_RECON = LEAST_SQUARES
 %
+% Cache the factorized least-squares gradient metrics (grid-only terms) and reuse
+% them across evaluations, computing only the right-hand side in an edge-based loop.
+% The cache is stored per grid with one slot per weighting (unweighted and inverse-
+% distance), shared by all solvers (flow, turbulence, species, ...), so mixing e.g.
+% unweighted reconstruction gradients with weighted viscous gradients is supported.
+% On moving/deforming grids the cache is invalidated and rebuilt after each mesh
+% update (once per time step), so the savings scale with the number of inner
+% iterations. Automatically disabled for periodic boundaries and the discrete
+% adjoint. (NO, YES)
+CACHE_LSQ_METRICS= NO
+%
 % CFL number (initial value for the adaptive CFL number)
 CFL_NUMBER= 15.0
 %


### PR DESCRIPTION
## Proposed Changes

  This PR ~adds an opt-in option, `CACHE_LSQ_METRICS` (default `NO`),~  caches the factorized metric terms of the (weighted or unweighted) least-squares gradients. The LSQ normal matrix A depends only on the node coordinates and on the weighting, yet it is currently re-assembled and re-factorized on every gradient evaluation, every nonlinear iteration. With the option enabled:

  - On the first evaluation the normal matrix is assembled and factorized as usual, and its inverse S = A^-1 (6 unique entries per node in 3D, 3 in 2D) is stored in `CGeometry`.
  - Every subsequent evaluation only accumulates the right-hand side b = sum_k w*d*(u_k - u_i) in a loop over the edges (using the edge coloring; the contribution of an edge is identical for both of its end points, so each edge is visited once) followed by one small symmetric matrix-vector product S*b per node.
  - The cache is stored per grid level with one slot per weighting, shared by all solvers (flow primitive and reconstruction gradients, turbulence/species/scalar solution gradients, auxiliary variables). The common practice of unweighted LSQ for MUSCL reconstruction plus inverse-distance-weighted LSQ for viscous gradients is fully supported: both slots are built once and reused; e.g. the turbulence solver directly reuses the metrics built by the flow solver.
  - Moving/deforming grids are supported: the cache is invalidated in `SetControlVolume(..., UPDATE)` (the common point of all mesh motion/deformation paths, on fine and coarse MG levels) and rebuilt on the next evaluation, i.e. once per mesh update, so the savings scale with the number of inner iterations per time step.
  - The option is automatically disabled (with a warning) for periodic boundaries (the periodic LSQ communication fuses the matrix and RHS accumulations; an RHS-only exchange would be needed) and for the discrete adjoint (the coordinate dependence of the metrics must remain on the tape).

  #### Saved operations (per node per gradient evaluation, 3D, k edge-neighbors, N variables)

  Eliminated from every evaluation after the first:
  - normal-matrix assembly: ~21k flops (~300 flops per node on tetrahedra, k=14),
  - per-node Cholesky factorization + inversion: ~35 flops and 3 sqrt (no sqrt/div remain in the iteration path),
  - half of the geometric edge work (distance vectors and solution differences are computed once per edge instead of once per node-neighbor pair).

  What remains is the RHS accumulation (~4N flops per node per edge) and one S*b product (18N flops per node). For the N=6 compressible primitives this roughly halves the gradient-kernel flops; for scalar solvers (N=1-2, e.g. SA) where the assembly dominates it is a ~4-5x reduction. Measured end-to-end (serial, linear-solver work held fixed): ~3.3% of total wall time on an inviscid ONERA M6 (57.5k nodes, tets, one gradient set per iteration) and ~6% on a 2D RANS-SA case (three LSQ gradient sets per iteration). Cases dominated by the linear solver will see proportionally less.

  #### Memory footprint
  
  The cache adds nDim*(nDim+1)/2 su2doubles per node per weighting used (48 B/node per weighting in 3D, 24 B/node in 2D; at most two weightings), allocated lazily per grid level and shared by all solvers. For reference, every solver already allocates an nDim*nDim `Rmatrix` scratch (72 B/node in 3D), so for a typical RANS case the addition is small compared to the existing gradient machinery and negligible compared to overall solver memory.

  #### Validation

  With the option enabled, results are identical to `develop` (to output precision) for:
  - inviscid NACA0012, unweighted LSQ reconstruction, 200 iterations (serial and 2 MPI ranks),
  - RANS-SA NACA0012 with `NUM_METHOD_GRAD= WEIGHTED_LEAST_SQUARES` and `NUM_METHOD_GRAD_RECON= LEAST_SQUARES` (all residuals including the turbulence variable),
  - an unsteady pitching NACA0012 with `GRID_MOVEMENT= RIGID_MOTION` (dual time stepping), exercising the invalidation/rebuild path,
  - hybrid-parallel runs (OpenMP edge-colored loop, bit-reproducible run-to-run; falls back to a race-free node loop if the natural coloring is in use).

  ~`config_template.cfg` documents the new option. Default behavior (`CACHE_LSQ_METRICS= NO`) is bit-identical to current develop.~
  
- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [x] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [ ] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cfg), if necessary.
