### PR TITLE
Fix misleading "All convergence criteria satisfied." message on interrupted runs

### DIFF
--- a/SU2_CFD/include/output/COutput.hpp
+++ b/SU2_CFD/include/output/COutput.hpp
@@ -321,6 +321,7 @@ protected:
   vector<su2double> oldFunc,     /*!< \brief Old value of the coefficient. */
   newFunc;                       /*!< \brief Current value of the coefficient. */
   bool convergence;              /*!< \brief To indicate if the solver has converged or not. */
+  bool convergenceInterrupted;   /*!< \brief To indicate that the exit was forced by an interrupt signal instead of the convergence criteria. */
   su2double initResidual;        /*!< \brief Initial value of the residual to evaluate the convergence level. */
   vector<string> convFields;     /*!< \brief Name of the field to be monitored for convergence. */
   unsigned long convergenceStartIter = 0; /*!< \brief Iteration the convergence history is counted from. */
@@ -587,6 +588,12 @@ public:
    * \return Boolean indicating whether the problem is converged.
    */
   bool GetConvergence() const {return convergence;}
+
+  /*!
+   * \brief Get whether the exit was forced by an interrupt signal (e.g. SIGTERM) instead of the convergence criteria.
+   * \return Boolean indicating whether an interrupt signal forced the exit.
+   */
+  bool GetConvergenceInterrupted() const {return convergenceInterrupted;}
 
   /*!
    * \brief Set the value of the convergence flag.

--- a/SU2_CFD/src/drivers/CMultizoneDriver.cpp
+++ b/SU2_CFD/src/drivers/CMultizoneDriver.cpp
@@ -650,7 +650,9 @@ bool CMultizoneDriver::Monitor(unsigned long TimeIter) {
 
     if ((MaxIterationsReached || InnerConvergence) && (rank == MASTER_NODE)) {
       cout << "\n----------------------------- Solver Exit -------------------------------" << endl;
-      if (InnerConvergence) cout << "All convergence criteria satisfied." << endl;
+      if (driver_output->GetConvergenceInterrupted())
+        cout << "Interrupt signal received, exiting before the convergence criteria were satisfied." << endl;
+      else if (InnerConvergence) cout << "All convergence criteria satisfied." << endl;
       else cout << "\nMaximum number of iterations reached (OUTER_ITER = " << OuterIter+1 << ") before convergence." << endl;
       driver_output->PrintConvergenceSummary();
       cout << "-------------------------------------------------------------------------" << endl;

--- a/SU2_CFD/src/drivers/CSinglezoneDriver.cpp
+++ b/SU2_CFD/src/drivers/CSinglezoneDriver.cpp
@@ -278,7 +278,9 @@ bool CSinglezoneDriver::Monitor(unsigned long TimeIter){
 
     if ((MaxIterationsReached || InnerConvergence) && (rank == MASTER_NODE)) {
       cout << "\n----------------------------- Solver Exit -------------------------------" << endl;
-      if (InnerConvergence) cout << "All convergence criteria satisfied." << endl;
+      if (output_container[ZONE_0]->GetConvergenceInterrupted())
+        cout << "Interrupt signal received, exiting before the convergence criteria were satisfied." << endl;
+      else if (InnerConvergence) cout << "All convergence criteria satisfied." << endl;
       else cout << "\nMaximum number of iterations reached (ITER = " << nInnerIter << ") before convergence." << endl;
       output_container[ZONE_0]->PrintConvergenceSummary();
       cout << "-------------------------------------------------------------------------" << endl;

--- a/SU2_CFD/src/output/COutput.cpp
+++ b/SU2_CFD/src/output/COutput.cpp
@@ -130,6 +130,7 @@ COutput::COutput(const CConfig *config, unsigned short ndim, bool fem_output):
   cauchySerie = vector<vector<su2double>>(convFields.size(), vector<su2double>(nCauchy_Elems, 0.0));
   cauchyValue = 0.0;
   convergence = false;
+  convergenceInterrupted = false;
 
   /*--- Initialize time convergence monitoring structure ---*/
 
@@ -1014,15 +1015,24 @@ bool COutput::ConvergenceMonitoring(CConfig *config, unsigned long Iteration) {
 
   if (convFields.empty() || Iteration < config->GetStartConv_Iter()) convergence = false;
 
-  /*--- If a SIGTERM signal is sent to one of the processes, we set convergence to true. ---*/
-  if (STOP) convergence = true;
+  /*--- If a SIGTERM signal is sent to one of the processes, we set convergence to true so the
+   *    solver stops and saves the solution, but remember that the exit was forced by the signal
+   *    rather than by the convergence criteria so the exit message stays truthful. ---*/
+  if (STOP) {
+    if (!convergence) convergenceInterrupted = true;
+    convergence = true;
+  }
 
-  /*--- Apply the same convergence criteria to all processors. ---*/
+  /*--- Apply the same convergence criteria to all processors, and propagate an
+   *    interrupt received on any rank. ---*/
 
-  unsigned short local = convergence, global = 0;
+  unsigned short local[2] = {static_cast<unsigned short>(convergence),
+                             static_cast<unsigned short>(convergenceInterrupted)};
+  unsigned short global[2] = {0, 0};
 
-  SU2_MPI::Allreduce(&local, &global, 1, MPI_UNSIGNED_SHORT, MPI_MAX, SU2_MPI::GetComm());
-  convergence = global > 0;
+  SU2_MPI::Allreduce(local, global, 2, MPI_UNSIGNED_SHORT, MPI_MAX, SU2_MPI::GetComm());
+  convergence = global[0] > 0;
+  convergenceInterrupted = global[1] > 0;
 
   return convergence;
 }


### PR DESCRIPTION
## Proposed Changes

Interrupt-driven termination is not limited to a user's Ctrl-C. SIGTERM is the normal way batch schedulers terminate a job at its wall-clock limit: SLURM sends SIGTERM when a job reaches its `TimeLimit` and on `scancel` (waiting `KillWait` before SIGKILL), and PBS/Torque and LSF behave equivalently. Today every SU2 job that exhausts its allocation on a cluster ends with a log stating "All convergence criteria satisfied." directly above a Solver Exit table whose every criterion reads "No". Any parameter sweep or optimization loop that classifies runs by scraping that banner silently admits timed-out, unconverged runs as converged, and a human skimming the log is misled the same way. That population is far larger than the manual-interrupt case.

Mechanism: on SIGTERM the signal handler sets `STOP`, and `COutput::ConvergenceMonitoring` forces `convergence = true` so the run stops and saves. Both `CSinglezoneDriver::Monitor` and `CMultizoneDriver::Monitor` then read that flag as `InnerConvergence` and print the satisfied banner.

Fix: a new `convergenceInterrupted` member of `COutput` records that the stop came from the interrupt path rather than from the criteria. It is propagated across ranks in the existing convergence Allreduce as a count-2 element-wise `MPI_MAX` (SU2's serial MPI stub does not define `MPI_BOR`, and the AD layer maps only SUM/MIN/MAX/PROD), exposed through `GetConvergenceInterrupted()`, and both drivers print

```
Interrupt signal received, exiting before the convergence criteria were satisfied.
```

on that path. Stop-and-save behavior, exit code 0, and the genuine-convergence and maximum-iteration messages are unchanged.

Files: `SU2_CFD/include/output/COutput.hpp`, `SU2_CFD/src/output/COutput.cpp`, `SU2_CFD/src/drivers/CSinglezoneDriver.cpp`, `SU2_CFD/src/drivers/CMultizoneDriver.cpp` (+29/-8).

Verification (QuickStart `inv_NACA0012.cfg`, serial release build of develop `07aa46b1`):
- SIGTERM sent to the exact `SU2_CFD` process about 8 s into the run: the new interrupt message is printed, the satisfied banner does not appear, restart and solution files are written, exit code 0.
- Run to genuine convergence and run to maximum iterations: output byte-identical to the unpatched build (checked when the change was first made on develop `81ce6a68f9`).
- Touched files re-checked with `-Wall -Wextra`: no new warnings.

## Related Work

The defect is present at v8.5.0 and at the current develop tip. I found no existing upstream issue or PR that addresses it. The change is independent of the other NEMO-related PRs from the same qualification campaign; it touches only the output and driver exit path.

## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [x] I am submitting my contribution to the develop branch.
- [x] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [x] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [x] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
