### PR TITLE
Fix MUSCL_TURB with convective schemes that do not store density gradients

### DIFF
--- a/SU2_CFD/include/solvers/CScalarSolver.inl
+++ b/SU2_CFD/include/solvers/CScalarSolver.inl
@@ -226,6 +226,14 @@ void CScalarSolver<VariableType>::Upwind_Residual(CGeometry* geometry, CSolver**
             Limiter_j = flowNodes->GetLimiter_Primitive(jPoint);
           }
 
+          /*--- Some upwind schemes (see EulerNPrimVarGrad) size the flow's gradient/limiter
+           * columns smaller than the full primitive count, e.g. excluding density. Fall back
+           * to the cell-centered primitives for those. ---*/
+          for (auto iVar = 0u; iVar < solver_container[FLOW_SOL]->GetnPrimVar(); iVar++) {
+            flowPrimVar_i[iVar] = V_i[iVar];
+            flowPrimVar_j[iVar] = V_j[iVar];
+          }
+
           for (auto iVar = 0u; iVar < solver_container[FLOW_SOL]->GetnPrimVarGrad(); iVar++) {
             const su2double V_ij = V_j[iVar] - V_i[iVar];
 
@@ -237,8 +245,8 @@ void CScalarSolver<VariableType>::Upwind_Residual(CGeometry* geometry, CSolver**
               Project_Grad_j *= Limiter_j[iVar];
             }
 
-            flowPrimVar_i[iVar] = V_i[iVar] + 0.5 * Project_Grad_i;
-            flowPrimVar_j[iVar] = V_j[iVar] - 0.5 * Project_Grad_j;
+            flowPrimVar_i[iVar] += 0.5 * Project_Grad_i;
+            flowPrimVar_j[iVar] -= 0.5 * Project_Grad_j;
           }
 
           numerics->SetPrimitive(flowPrimVar_i, flowPrimVar_j);

--- a/TestCases/TestCase.py
+++ b/TestCases/TestCase.py
@@ -121,6 +121,8 @@ class TestCase:
         self.enabled_on_cpu_arch = ["x86_64","amd64","aarch64","arm64"]
         self.enabled_with_tsan = True
         self.enabled_with_asan = True
+        self.enabled_with_regular = True # Set to False for a case that should only run under a sanitizer,
+                                          # e.g. one added purely to exercise a sanitizer-only finding.
         self.command = self.Command()
         self.timeout = 0
         self.tol = 0.0
@@ -1035,6 +1037,10 @@ class TestCase:
         tsan_compatible = not with_tsan or self.enabled_with_tsan
         asan_compatible = not with_asan or self.enabled_with_asan
         tapetests_compatible = not with_tapetests or self.enabled_with_tapetests
+        # A case marked enabled_with_regular = False only runs under a sanitizer/tapetests mode,
+        # e.g. one added purely to exercise a finding that only a sanitizer catches.
+        regular_run = not (with_tsan or with_asan or with_tapetests)
+        regular_compatible = not regular_run or self.enabled_with_regular
 
         if not tsan_compatible:
             print('Ignoring test "%s" because it is not enabled to run with the thread sanitizer.' % self.tag)
@@ -1042,7 +1048,10 @@ class TestCase:
         if not tapetests_compatible:
             print('Ignoring test "%s" because it is not enabled to run a test of the tape.' % self.tag)
 
-        return is_enabled_on_arch and tsan_compatible and asan_compatible and tapetests_compatible and tapetests_compatible
+        if not regular_compatible:
+            print('Ignoring test "%s" because it is only enabled to run under a sanitizer.' % self.tag)
+
+        return is_enabled_on_arch and tsan_compatible and asan_compatible and tapetests_compatible and regular_compatible
 
     def adjust_test_data(self):
 

--- a/TestCases/serial_regression.py
+++ b/TestCases/serial_regression.py
@@ -315,7 +315,7 @@ def main():
     tutorial_trans_e387_sst_asan.cfg_dir          = "../Tutorials/compressible_flow/Transitional_Airfoil/Langtry_and_Menter/E387"
     tutorial_trans_e387_sst_asan.cfg_file         = "transitional_SST_LM_model_ConfigFile.cfg"
     tutorial_trans_e387_sst_asan.test_iter        = 2
-    tutorial_trans_e387_sst_asan.test_vals        = [-6.418119, -4.827573, -2.220229, 3.029787, 3.123846, 5.000000, -5.604338]
+    tutorial_trans_e387_sst_asan.test_vals        = [-6.418119, -4.827573, -2.220229, 3.029787, 3.123846, 5.000000, -5.610239]
     tutorial_trans_e387_sst_asan.timeout          = 1600
     tutorial_trans_e387_sst_asan.no_restart       = True
     tutorial_trans_e387_sst_asan.enabled_with_regular = False

--- a/TestCases/serial_regression.py
+++ b/TestCases/serial_regression.py
@@ -308,6 +308,19 @@ def main():
     turb_naca0012_sst.timeout   = 3200
     test_list.append(turb_naca0012_sst)
 
+    # E387 transitional SST+LM tutorial config, re-run here as a sanitizer-only probe.
+    # Covers the density gradient not being available for MUSCL_TURB=YES with a flow scheme
+    # that does not store that gradient.
+    tutorial_trans_e387_sst_asan                  = TestCase('tutorial_trans_e387_sst_asan')
+    tutorial_trans_e387_sst_asan.cfg_dir          = "../Tutorials/compressible_flow/Transitional_Airfoil/Langtry_and_Menter/E387"
+    tutorial_trans_e387_sst_asan.cfg_file         = "transitional_SST_LM_model_ConfigFile.cfg"
+    tutorial_trans_e387_sst_asan.test_iter        = 2
+    tutorial_trans_e387_sst_asan.test_vals        = [-6.418119, -4.827573, -2.220229, 3.029787, 3.123846, 5.000000, -5.604338]
+    tutorial_trans_e387_sst_asan.timeout          = 1600
+    tutorial_trans_e387_sst_asan.no_restart       = True
+    tutorial_trans_e387_sst_asan.enabled_with_regular = False
+    test_list.append(tutorial_trans_e387_sst_asan)
+
     # NACA0012 (SST V2003m, FUN3D results for finest grid: CL=1.0840, CD=0.01253)
     turb_naca0012_sst_2003m           = TestCase('turb_naca0012_sst_2003m')
     turb_naca0012_sst_2003m.cfg_dir   = "rans/naca0012"

--- a/TestCases/tutorials.py
+++ b/TestCases/tutorials.py
@@ -266,7 +266,7 @@ def main():
     tutorial_trans_e387_sst.cfg_dir    = "../Tutorials/compressible_flow/Transitional_Airfoil/Langtry_and_Menter/E387"
     tutorial_trans_e387_sst.cfg_file   = "transitional_SST_LM_model_ConfigFile.cfg"
     tutorial_trans_e387_sst.test_iter  = 20
-    tutorial_trans_e387_sst.test_vals  = [-6.532415, -2.932984, 0.401484, 1.078294, 0.188167, 2.000000, -10.005786]
+    tutorial_trans_e387_sst.test_vals  = [-6.532415, -5.082018, -0.789469, 1.078293, 0.188166, 2.000000, -9.567997]
     tutorial_trans_e387_sst.no_restart = True
     test_list.append(tutorial_trans_e387_sst)
 


### PR DESCRIPTION
## Proposed Changes
Fall back to no reconstruction for variables that are not stored.

## PR Checklist
- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [X] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [X] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [X] I have added a test case that demonstrates my contribution, if necessary.
- [X] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
