### PR TITLE
Make single and double precision restarts compatible with either version of the code

### DIFF
--- a/Common/include/option_structure.hpp
+++ b/Common/include/option_structure.hpp
@@ -210,6 +210,8 @@ const int CGNS_STRING_SIZE = 33; /*!< \brief Length of strings used in the CGNS 
 const int SU2_RESTART_MAGIC_NUMBER = 535532; /*!< \brief Hex representation of "SU2". */
 const int SU2_RESTART_HEADER_SIZE = 5;       /*!< \brief Number of ints in the header. */
 const int SU2_RESTART_PRECISION_IDX = 3;     /*!< \brief Position of the precision field. */
+const int SU2_RESTART_METADATA_IDX = 4;      /*!< \brief Position of the legacy metadata count. */
+const int SU2_RESTART_MAX_METADATA = 8;      /*!< \brief Most metadata doubles a trailer ever had. */
 
 /*!
  * \brief Size in bytes of the floating point data of a native SU2 binary solution file.
@@ -224,6 +226,20 @@ inline int GetSU2BinaryScalarSize(int precisionField) {
     SU2_MPI::Error("Invalid floating point precision in the header of a binary SU2 solution file.", CURRENT_FUNCTION);
   }
   return precisionField;
+}
+
+/*!
+ * \brief Number of metadata scalars in the trailer of a native SU2 binary solution file.
+ * \param[in] precisionField - The SU2_RESTART_PRECISION_IDX entry of the file header.
+ * \param[in] metadataField - The SU2_RESTART_METADATA_IDX entry of the file header.
+ * \return Number of scalars of the trailer, preceded by one int (the iteration number),
+ * or 0 for the files that do not have one.
+ * \note Only files that still use the two ints as trailer counts have a trailer, and in
+ * those the precision field is the number of trailer ints, which was always 1 (see above).
+ */
+inline int GetSU2BinaryMetadataSize(int precisionField, int metadataField) {
+  if (precisionField != 1) return 0;
+  return std::min(metadataField, SU2_RESTART_MAX_METADATA);
 }
 
 /*!

--- a/Common/include/option_structure.hpp
+++ b/Common/include/option_structure.hpp
@@ -195,6 +195,49 @@ inline unsigned short nPointsOfElementType(unsigned short elementType) {
 }
 
 const int CGNS_STRING_SIZE = 33; /*!< \brief Length of strings used in the CGNS format. */
+
+/*--- Layout of the header of the native SU2 binary solution/restart format, shared by
+      CSU2BinaryFileWriter and the routines that read those files so they cannot drift
+      apart. The header is SU2_RESTART_HEADER_SIZE ints: a magic number, the number of
+      variables, the number of points, the size in bytes of the floating point data that
+      follows, and one spare. ---*/
+const int SU2_RESTART_MAGIC_NUMBER = 535532; /*!< \brief Hex representation of "SU2". */
+const int SU2_RESTART_HEADER_SIZE = 5;       /*!< \brief Number of ints in the header. */
+const int SU2_RESTART_PRECISION_IDX = 3;     /*!< \brief Position of the precision field. */
+
+/*!
+ * \brief Size in bytes of the floating point data of a native SU2 binary solution file.
+ * \param[in] precisionField - The SU2_RESTART_PRECISION_IDX entry of the file header.
+ * \return 8 for double precision, 4 for single precision.
+ * \note The field was introduced after the format, files written before it have a 0 there
+ * and were always double precision.
+ */
+inline int GetSU2BinaryScalarSize(int precisionField) {
+  if (precisionField == 0) return static_cast<int>(sizeof(double));
+  if (precisionField != static_cast<int>(sizeof(double)) && precisionField != static_cast<int>(sizeof(float))) {
+    SU2_MPI::Error("Invalid floating point precision in the header of a binary SU2 solution file.", CURRENT_FUNCTION);
+  }
+  return precisionField;
+}
+
+/*!
+ * \brief Convert floating point data read from a native SU2 binary solution file, which
+ * may have been written by a build of different precision, to the precision of this build.
+ * \param[in] buffer - Raw data as read from the file, of size count*scalarSize bytes.
+ * \param[in] scalarSize - Size in bytes of the scalars in the file, see GetSU2BinaryScalarSize.
+ * \param[in] count - Number of scalars.
+ * \param[out] data - Converted data, must not overlap with buffer.
+ */
+inline void SU2BinaryDataToPassive(const void* buffer, int scalarSize, unsigned long count, passivedouble* data) {
+  if (scalarSize == static_cast<int>(sizeof(float))) {
+    const auto* src = static_cast<const float*>(buffer);
+    for (unsigned long i = 0; i < count; ++i) data[i] = src[i];
+  } else {
+    const auto* src = static_cast<const double*>(buffer);
+    for (unsigned long i = 0; i < count; ++i) data[i] = src[i];
+  }
+}
+
 const int SU2_BINARY_STRING_SIZE = 65; /*!< \brief Length of strings (e.g. marker names) used in the native
                                                     SU2 binary mesh format. Shared by CSU2BinaryMeshReaderBase
                                                     and CSU2MeshBinaryFileWriter so they cannot drift apart. */

--- a/Common/include/option_structure.hpp
+++ b/Common/include/option_structure.hpp
@@ -200,7 +200,13 @@ const int CGNS_STRING_SIZE = 33; /*!< \brief Length of strings used in the CGNS 
       CSU2BinaryFileWriter and the routines that read those files so they cannot drift
       apart. The header is SU2_RESTART_HEADER_SIZE ints: a magic number, the number of
       variables, the number of points, the size in bytes of the floating point data that
-      follows, and one spare. ---*/
+      follows, and one spare.
+
+      The 4th and 5th ints used to be the number of ints and of doubles of a metadata
+      trailer (1 and 5, later 1 and 8) that the writer appended after the data. That
+      trailer is no longer written (metadata goes to a separate ASCII file) and both
+      ints have been 0 since, but old files in circulation still have 1 and 5 or 8
+      there, which is why 1 is accepted below as meaning double precision. ---*/
 const int SU2_RESTART_MAGIC_NUMBER = 535532; /*!< \brief Hex representation of "SU2". */
 const int SU2_RESTART_HEADER_SIZE = 5;       /*!< \brief Number of ints in the header. */
 const int SU2_RESTART_PRECISION_IDX = 3;     /*!< \brief Position of the precision field. */
@@ -209,11 +215,11 @@ const int SU2_RESTART_PRECISION_IDX = 3;     /*!< \brief Position of the precisi
  * \brief Size in bytes of the floating point data of a native SU2 binary solution file.
  * \param[in] precisionField - The SU2_RESTART_PRECISION_IDX entry of the file header.
  * \return 8 for double precision, 4 for single precision.
- * \note The field was introduced after the format, files written before it have a 0 there
+ * \note Files written before the field had this meaning have a 0 or a 1 there (see above)
  * and were always double precision.
  */
 inline int GetSU2BinaryScalarSize(int precisionField) {
-  if (precisionField == 0) return static_cast<int>(sizeof(double));
+  if (precisionField == 0 || precisionField == 1) return static_cast<int>(sizeof(double));
   if (precisionField != static_cast<int>(sizeof(double)) && precisionField != static_cast<int>(sizeof(float))) {
     SU2_MPI::Error("Invalid floating point precision in the header of a binary SU2 solution file.", CURRENT_FUNCTION);
   }

--- a/Common/src/geometry/CPhysicalGeometry.cpp
+++ b/Common/src/geometry/CPhysicalGeometry.cpp
@@ -7938,8 +7938,8 @@ void CPhysicalGeometry::SetSensitivity(CConfig* config) {
     char str_buf[CGNS_STRING_SIZE], fname[100];
     unsigned short iVar;
     strcpy(fname, filename.c_str());
-    int nRestart_Vars = 5, nFields;
-    int* Restart_Vars = new int[5];
+    int nRestart_Vars = SU2_RESTART_HEADER_SIZE, nFields;
+    int* Restart_Vars = new int[SU2_RESTART_HEADER_SIZE];
     passivedouble* Restart_Data = nullptr;
     int Restart_Iter = 0;
     passivedouble Restart_Meta_Passive[8] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
@@ -7969,7 +7969,7 @@ void CPhysicalGeometry::SetSensitivity(CConfig* config) {
     /*--- Check that this is an SU2 binary file. SU2 binary files
      have the hex representation of "SU2" as the first int in the file. ---*/
 
-    if (Restart_Vars[0] != 535532) {
+    if (Restart_Vars[0] != SU2_RESTART_MAGIC_NUMBER) {
       SU2_MPI::Error(string("File ") + string(fname) + string(" is not a binary SU2 restart file.\n") +
                          string("SU2 reads/writes binary restart files by default.\n") +
                          string("Note that backward compatibility for ASCII restart files is\n") +
@@ -7977,9 +7977,11 @@ void CPhysicalGeometry::SetSensitivity(CConfig* config) {
                      CURRENT_FUNCTION);
     }
 
-    /*--- Store the number of fields for simplicity. ---*/
+    /*--- Store the number of fields for simplicity. The file may have been written by
+     a build of different precision, in which case the data needs to be converted. ---*/
 
     nFields = Restart_Vars[1];
+    const int scalarSize = GetSU2BinaryScalarSize(Restart_Vars[SU2_RESTART_PRECISION_IDX]);
 
     /*--- Read the variable names from the file. Note that we are adopting a
      fixed length of 33 for the string length to match with CGNS. This is
@@ -8001,14 +8003,22 @@ void CPhysicalGeometry::SetSensitivity(CConfig* config) {
 
     /*--- Read in the data for the restart at all local points. ---*/
 
-    ret = fread(Restart_Data, sizeof(passivedouble), nFields * GetnPointDomain(), fhw);
-    if (ret != static_cast<unsigned long>(nFields) * GetnPointDomain()) {
+    const unsigned long nScalars = static_cast<unsigned long>(nFields) * GetnPointDomain();
+
+    if (scalarSize == static_cast<int>(sizeof(passivedouble))) {
+      ret = fread(Restart_Data, scalarSize, nScalars, fhw);
+    } else {
+      vector<char> buffer(nScalars * scalarSize);
+      ret = fread(buffer.data(), scalarSize, nScalars, fhw);
+      SU2BinaryDataToPassive(buffer.data(), scalarSize, nScalars, Restart_Data);
+    }
+    if (ret != nScalars) {
       SU2_MPI::Error("Error reading restart file.", CURRENT_FUNCTION);
     }
 
     /*--- Compute (negative) displacements and grab the metadata. ---*/
 
-    ret = sizeof(int) + 8 * sizeof(passivedouble);
+    ret = sizeof(int) + 8 * scalarSize;
     fseek(fhw, -ret, SEEK_END);
 
     /*--- Read the external iteration. ---*/
@@ -8020,10 +8030,12 @@ void CPhysicalGeometry::SetSensitivity(CConfig* config) {
 
     /*--- Read the metadata. ---*/
 
-    ret = fread(Restart_Meta_Passive, sizeof(passivedouble), 8, fhw);
+    double meta_buf[8]; /*--- Large enough and correctly aligned for either precision. ---*/
+    ret = fread(meta_buf, scalarSize, 8, fhw);
     if (ret != 8) {
       SU2_MPI::Error("Error reading restart file.", CURRENT_FUNCTION);
     }
+    SU2BinaryDataToPassive(meta_buf, scalarSize, 8, Restart_Meta_Passive);
 
     /*--- Close the file. ---*/
 
@@ -8065,7 +8077,7 @@ void CPhysicalGeometry::SetSensitivity(CConfig* config) {
     /*--- Check that this is an SU2 binary file. SU2 binary files
      have the hex representation of "SU2" as the first int in the file. ---*/
 
-    if (Restart_Vars[0] != 535532) {
+    if (Restart_Vars[0] != SU2_RESTART_MAGIC_NUMBER) {
       SU2_MPI::Error(string("File ") + string(fname) + string(" is not a binary SU2 restart file.\n") +
                          string("SU2 reads/writes binary restart files by default.\n") +
                          string("Note that backward compatibility for ASCII restart files is\n") +
@@ -8073,9 +8085,11 @@ void CPhysicalGeometry::SetSensitivity(CConfig* config) {
                      CURRENT_FUNCTION);
     }
 
-    /*--- Store the number of fields for simplicity. ---*/
+    /*--- Store the number of fields for simplicity. The file may have been written by
+     a build of different precision, in which case the data needs to be converted. ---*/
 
     nFields = Restart_Vars[1];
+    const int scalarSize = GetSU2BinaryScalarSize(Restart_Vars[SU2_RESTART_PRECISION_IDX]);
 
     /*--- Read the variable names from the file. Note that we are adopting a
      fixed length of 33 for the string length to match with CGNS. This is
@@ -8109,9 +8123,12 @@ void CPhysicalGeometry::SetSensitivity(CConfig* config) {
 
     delete[] mpi_str_buf;
 
-    /*--- We're writing only su2doubles in the data portion of the file. ---*/
+    /*--- The data portion of the file holds scalars of the precision recorded in the
+     header, which is not necessarily that of this build. Describe them as opaque
+     blocks of bytes so that the file views do not depend on the build precision. ---*/
 
-    etype = MPI_DOUBLE;
+    MPI_Type_contiguous(scalarSize, MPI_BYTE, &etype);
+    MPI_Type_commit(&etype);
 
     /*--- We need to ignore the 4 ints describing the nVar_Restart and nPoints,
      along with the string names of the variables. ---*/
@@ -8129,11 +8146,11 @@ void CPhysicalGeometry::SetSensitivity(CConfig* config) {
     for (iPoint_Global = 0; iPoint_Global < GetGlobal_nPointDomain(); iPoint_Global++) {
       if (GetGlobal_to_Local_Point(iPoint_Global) > -1) {
         blocklen[counter] = nFields;
-        displace[counter] = iPoint_Global * nFields * sizeof(passivedouble);
+        displace[counter] = iPoint_Global * nFields * scalarSize;
         counter++;
       }
     }
-    MPI_Type_create_hindexed(GetnPointDomain(), blocklen, displace, MPI_DOUBLE, &filetype);
+    MPI_Type_create_hindexed(GetnPointDomain(), blocklen, displace, etype, &filetype);
     MPI_Type_commit(&filetype);
 
     /*--- Set the view for the MPI file write, i.e., describe the location in
@@ -8145,13 +8162,23 @@ void CPhysicalGeometry::SetSensitivity(CConfig* config) {
 
     Restart_Data = new passivedouble[nFields * GetnPointDomain()];
 
-    /*--- Collective call for all ranks to read from their view simultaneously. ---*/
+    /*--- Collective call for all ranks to read from their view simultaneously,
+     converting the data if the file precision does not match this build. ---*/
 
-    MPI_File_read_all(fhw, Restart_Data, nFields * GetnPointDomain(), MPI_DOUBLE, &status);
+    const unsigned long nScalars = static_cast<unsigned long>(nFields) * GetnPointDomain();
 
-    /*--- Free the derived datatype. ---*/
+    if (scalarSize == static_cast<int>(sizeof(passivedouble))) {
+      MPI_File_read_all(fhw, Restart_Data, nScalars, etype, &status);
+    } else {
+      vector<char> buffer(nScalars * scalarSize);
+      MPI_File_read_all(fhw, buffer.data(), nScalars, etype, &status);
+      SU2BinaryDataToPassive(buffer.data(), scalarSize, nScalars, Restart_Data);
+    }
+
+    /*--- Free the derived datatypes. ---*/
 
     MPI_Type_free(&filetype);
+    MPI_Type_free(&etype);
 
     /*--- Reset the file view before writing the metadata. ---*/
 
@@ -8162,14 +8189,15 @@ void CPhysicalGeometry::SetSensitivity(CConfig* config) {
     if (rank == MASTER_NODE) {
       /*--- External iteration. ---*/
       disp = (nRestart_Vars * sizeof(int) + nFields * CGNS_STRING_SIZE * sizeof(char) +
-              nFields * Restart_Vars[2] * sizeof(passivedouble));
+              static_cast<unsigned long>(nFields) * Restart_Vars[2] * scalarSize);
       MPI_File_read_at(fhw, disp, &Restart_Iter, 1, MPI_INT, MPI_STATUS_IGNORE);
 
       /*--- Additional doubles for AoA, AoS, etc. ---*/
 
-      disp = (nRestart_Vars * sizeof(int) + nFields * CGNS_STRING_SIZE * sizeof(char) +
-              nFields * Restart_Vars[2] * sizeof(passivedouble) + 1 * sizeof(int));
-      MPI_File_read_at(fhw, disp, Restart_Meta_Passive, 8, MPI_DOUBLE, MPI_STATUS_IGNORE);
+      disp += sizeof(int);
+      double meta_buf[8]; /*--- Large enough and correctly aligned for either precision. ---*/
+      MPI_File_read_at(fhw, disp, meta_buf, 8 * scalarSize, MPI_BYTE, MPI_STATUS_IGNORE);
+      SU2BinaryDataToPassive(meta_buf, scalarSize, 8, Restart_Meta_Passive);
     }
 
     /*--- Communicate metadata. ---*/
@@ -8277,7 +8305,7 @@ void CPhysicalGeometry::SetSensitivity(CConfig* config) {
     /*--- Check that this is an SU2 binary file. SU2 binary files
      have the hex representation of "SU2" as the first int in the file. ---*/
 
-    if (magic_number == 535532) {
+    if (magic_number == SU2_RESTART_MAGIC_NUMBER) {
       SU2_MPI::Error(string("File ") + string(fname) + string(" is a binary SU2 restart file, expected ASCII.\n") +
                          string("SU2 reads/writes binary restart files by default.\n") +
                          string("Note that backward compatibility for ASCII restart files is\n") +
@@ -8315,7 +8343,7 @@ void CPhysicalGeometry::SetSensitivity(CConfig* config) {
     /*--- Check that this is an SU2 binary file. SU2 binary files
      have the hex representation of "SU2" as the first int in the file. ---*/
 
-    if (magic_number == 535532) {
+    if (magic_number == SU2_RESTART_MAGIC_NUMBER) {
       SU2_MPI::Error(string("File ") + string(fname) + string(" is a binary SU2 restart file, expected ASCII.\n") +
                          string("SU2 reads/writes binary restart files by default.\n") +
                          string("Note that backward compatibility for ASCII restart files is\n") +

--- a/Common/src/geometry/CPhysicalGeometry.cpp
+++ b/Common/src/geometry/CPhysicalGeometry.cpp
@@ -8016,26 +8016,33 @@ void CPhysicalGeometry::SetSensitivity(CConfig* config) {
       SU2_MPI::Error("Error reading restart file.", CURRENT_FUNCTION);
     }
 
-    /*--- Compute (negative) displacements and grab the metadata. ---*/
+    /*--- Grab the metadata trailer, which only old files have. Without it the iteration
+     number and the metadata keep the zeros they were initialized with. ---*/
 
-    ret = sizeof(int) + 8 * scalarSize;
-    fseek(fhw, -ret, SEEK_END);
+    const int nMeta =
+        GetSU2BinaryMetadataSize(Restart_Vars[SU2_RESTART_PRECISION_IDX], Restart_Vars[SU2_RESTART_METADATA_IDX]);
+    if (nMeta > 0) {
+      /*--- Compute (negative) displacements and jump to the trailer. ---*/
 
-    /*--- Read the external iteration. ---*/
+      ret = sizeof(int) + nMeta * scalarSize;
+      fseek(fhw, -ret, SEEK_END);
 
-    ret = fread(&Restart_Iter, sizeof(int), 1, fhw);
-    if (ret != 1) {
-      SU2_MPI::Error("Error reading restart file.", CURRENT_FUNCTION);
+      /*--- Read the external iteration. ---*/
+
+      ret = fread(&Restart_Iter, sizeof(int), 1, fhw);
+      if (ret != 1) {
+        SU2_MPI::Error("Error reading restart file.", CURRENT_FUNCTION);
+      }
+
+      /*--- Read the metadata. ---*/
+
+      double meta_buf[SU2_RESTART_MAX_METADATA]; /*--- Correctly aligned for either precision. ---*/
+      ret = fread(meta_buf, scalarSize, nMeta, fhw);
+      if (ret != static_cast<unsigned long>(nMeta)) {
+        SU2_MPI::Error("Error reading restart file.", CURRENT_FUNCTION);
+      }
+      SU2BinaryDataToPassive(meta_buf, scalarSize, nMeta, Restart_Meta_Passive);
     }
-
-    /*--- Read the metadata. ---*/
-
-    double meta_buf[8]; /*--- Large enough and correctly aligned for either precision. ---*/
-    ret = fread(meta_buf, scalarSize, 8, fhw);
-    if (ret != 8) {
-      SU2_MPI::Error("Error reading restart file.", CURRENT_FUNCTION);
-    }
-    SU2BinaryDataToPassive(meta_buf, scalarSize, 8, Restart_Meta_Passive);
 
     /*--- Close the file. ---*/
 
@@ -8184,9 +8191,12 @@ void CPhysicalGeometry::SetSensitivity(CConfig* config) {
 
     MPI_File_set_view(fhw, 0, MPI_BYTE, MPI_BYTE, (char*)"native", MPI_INFO_NULL);
 
-    /*--- Access the metadata. ---*/
+    /*--- Access the metadata trailer, which only old files have. Without it the iteration
+     number and the metadata keep the zeros they were initialized with. ---*/
 
-    if (rank == MASTER_NODE) {
+    const int nMeta =
+        GetSU2BinaryMetadataSize(Restart_Vars[SU2_RESTART_PRECISION_IDX], Restart_Vars[SU2_RESTART_METADATA_IDX]);
+    if (nMeta > 0 && rank == MASTER_NODE) {
       /*--- External iteration. ---*/
       disp = (nRestart_Vars * sizeof(int) + nFields * CGNS_STRING_SIZE * sizeof(char) +
               static_cast<unsigned long>(nFields) * Restart_Vars[2] * scalarSize);
@@ -8195,9 +8205,9 @@ void CPhysicalGeometry::SetSensitivity(CConfig* config) {
       /*--- Additional doubles for AoA, AoS, etc. ---*/
 
       disp += sizeof(int);
-      double meta_buf[8]; /*--- Large enough and correctly aligned for either precision. ---*/
-      MPI_File_read_at(fhw, disp, meta_buf, 8 * scalarSize, MPI_BYTE, MPI_STATUS_IGNORE);
-      SU2BinaryDataToPassive(meta_buf, scalarSize, 8, Restart_Meta_Passive);
+      double meta_buf[SU2_RESTART_MAX_METADATA]; /*--- Correctly aligned for either precision. ---*/
+      MPI_File_read_at(fhw, disp, meta_buf, nMeta * scalarSize, MPI_BYTE, MPI_STATUS_IGNORE);
+      SU2BinaryDataToPassive(meta_buf, scalarSize, nMeta, Restart_Meta_Passive);
     }
 
     /*--- Communicate metadata. ---*/

--- a/SU2_CFD/src/output/filewriter/CSU2BinaryFileWriter.cpp
+++ b/SU2_CFD/src/output/filewriter/CSU2BinaryFileWriter.cpp
@@ -51,10 +51,14 @@ void CSU2BinaryFileWriter::WriteData(string val_filename){
   /*--- Prepare the first ints containing the counts. The first is a
    magic number that we can use to check for binary files (it is the hex
    representation for "SU2"). The second two values are number of variables
-   and number of points (DoFs). ---*/
+   and number of points (DoFs). The fourth is the size in bytes of the
+   floating point data, which lets builds of either precision read the
+   file (a 0 there, in files written before this field existed, means
+   double precision). ---*/
 
-  int var_buf_size = 5;
-  int var_buf[5] = {535532, nVar, (int)nPoint_Global, 0, 0};
+  int var_buf_size = SU2_RESTART_HEADER_SIZE;
+  int var_buf[SU2_RESTART_HEADER_SIZE] = {SU2_RESTART_MAGIC_NUMBER, nVar, (int)nPoint_Global,
+                                          (int)sizeof(passivedouble), 0};
 
   /*--- Open the file using MPI I/O ---*/
 

--- a/SU2_CFD/src/solvers/CBaselineSolver.cpp
+++ b/SU2_CFD/src/solvers/CBaselineSolver.cpp
@@ -106,8 +106,8 @@ void CBaselineSolver::SetOutputVariables(CGeometry *geometry, CConfig *config) {
 
     char fname[100];
     strcpy(fname, filename.c_str());
-    int nVar_Buf = 5;
-    int var_buf[5];
+    int nVar_Buf = SU2_RESTART_HEADER_SIZE;
+    int var_buf[SU2_RESTART_HEADER_SIZE];
 
 #ifndef HAVE_MPI
 
@@ -133,7 +133,7 @@ void CBaselineSolver::SetOutputVariables(CGeometry *geometry, CConfig *config) {
     /*--- Check that this is an SU2 binary file. SU2 binary files
      have the hex representation of "SU2" as the first int in the file. ---*/
 
-    if (var_buf[0] != 535532) {
+    if (var_buf[0] != SU2_RESTART_MAGIC_NUMBER) {
       SU2_MPI::Error(string("File ") + string(fname) + string(" is not a binary SU2 restart file.\n") +
                      string("SU2 reads/writes binary restart files by default.\n") +
                      string("Note that backward compatibility for ASCII restart files is\n") +
@@ -185,7 +185,7 @@ void CBaselineSolver::SetOutputVariables(CGeometry *geometry, CConfig *config) {
     /*--- Check that this is an SU2 binary file. SU2 binary files
      have the hex representation of "SU2" as the first int in the file. ---*/
 
-    if (var_buf[0] != 535532) {
+    if (var_buf[0] != SU2_RESTART_MAGIC_NUMBER) {
       SU2_MPI::Error(string("File ") + string(fname) + string(" is not a binary SU2 restart file.\n") +
                      string("SU2 reads/writes binary restart files by default.\n") +
                      string("Note that backward compatibility for ASCII restart files is\n") +
@@ -270,7 +270,7 @@ void CBaselineSolver::SetOutputVariables(CGeometry *geometry, CConfig *config) {
     /*--- Check that this is an SU2 binary file. SU2 binary files
      have the hex representation of "SU2" as the first int in the file. ---*/
 
-    if (magic_number == 535532) {
+    if (magic_number == SU2_RESTART_MAGIC_NUMBER) {
       SU2_MPI::Error(string("File ") + string(fname) + string(" is a binary SU2 restart file, expected ASCII.\n") +
                      string("SU2 reads/writes binary restart files by default.\n") +
                      string("Note that backward compatibility for ASCII restart files is\n") +
@@ -308,7 +308,7 @@ void CBaselineSolver::SetOutputVariables(CGeometry *geometry, CConfig *config) {
     /*--- Check that this is an SU2 binary file. SU2 binary files
      have the hex representation of "SU2" as the first int in the file. ---*/
 
-    if (magic_number == 535532) {
+    if (magic_number == SU2_RESTART_MAGIC_NUMBER) {
       SU2_MPI::Error(string("File ") + string(fname) + string(" is a binary SU2 restart file, expected ASCII.\n") +
                      string("SU2 reads/writes binary restart files by default.\n") +
                      string("Note that backward compatibility for ASCII restart files is\n") +

--- a/SU2_CFD/src/solvers/CBaselineSolver_FEM.cpp
+++ b/SU2_CFD/src/solvers/CBaselineSolver_FEM.cpp
@@ -111,8 +111,8 @@ void CBaselineSolver_FEM::SetOutputVariables(CGeometry *geometry, CConfig *confi
 
   if (config->GetRead_Binary_Restart()) {
 
-    int nVar_Buf = 5;
-    int var_buf[5];
+    int nVar_Buf = SU2_RESTART_HEADER_SIZE;
+    int var_buf[SU2_RESTART_HEADER_SIZE];
 
 #ifndef HAVE_MPI
 
@@ -138,7 +138,7 @@ void CBaselineSolver_FEM::SetOutputVariables(CGeometry *geometry, CConfig *confi
     /*--- Check that this is an SU2 binary file. SU2 binary files
      have the hex representation of "SU2" as the first int in the file. ---*/
 
-    if (var_buf[0] != 535532)
+    if (var_buf[0] != SU2_RESTART_MAGIC_NUMBER)
       SU2_MPI::Error(string("File ") + filename + string(" is not a binary SU2 restart file.\n") +
                      string("SU2 reads/writes binary restart files by default.\n") +
                      string("Note that backward compatibility for ASCII restart files is\n") +
@@ -181,7 +181,7 @@ void CBaselineSolver_FEM::SetOutputVariables(CGeometry *geometry, CConfig *confi
     /*--- Check that this is an SU2 binary file. SU2 binary files
      have the hex representation of "SU2" as the first int in the file. ---*/
 
-    if (var_buf[0] != 535532)
+    if (var_buf[0] != SU2_RESTART_MAGIC_NUMBER)
       SU2_MPI::Error(string("File ") + filename + string(" is not a binary SU2 restart file.\n") +
                      string("SU2 reads/writes binary restart files by default.\n") +
                      string("Note that backward compatibility for ASCII restart files is\n") +
@@ -228,7 +228,7 @@ void CBaselineSolver_FEM::SetOutputVariables(CGeometry *geometry, CConfig *confi
     /*--- Check that this is an SU2 binary file. SU2 binary files
      have the hex representation of "SU2" as the first int in the file. ---*/
 
-    if (magic_number == 535532)
+    if (magic_number == SU2_RESTART_MAGIC_NUMBER)
       SU2_MPI::Error(string("File ") + filename + string(" is a binary SU2 restart file, expected ASCII.\n") +
                      string("SU2 reads/writes binary restart files by default.\n") +
                      string("Note that backward compatibility for ASCII restart files is\n") +
@@ -266,7 +266,7 @@ void CBaselineSolver_FEM::SetOutputVariables(CGeometry *geometry, CConfig *confi
     /*--- Check that this is an SU2 binary file. SU2 binary files
      have the hex representation of "SU2" as the first int in the file. ---*/
 
-    if (magic_number == 535532)
+    if (magic_number == SU2_RESTART_MAGIC_NUMBER)
       SU2_MPI::Error(string("File ") + filename + string(" is a binary SU2 restart file, expected ASCII.\n") +
                      string("SU2 reads/writes binary restart files by default.\n") +
                      string("Note that backward compatibility for ASCII restart files is\n") +

--- a/SU2_CFD/src/solvers/CSolver.cpp
+++ b/SU2_CFD/src/solvers/CSolver.cpp
@@ -2856,7 +2856,7 @@ void CSolver::Read_SU2_Restart_ASCII(CGeometry *geometry, const CConfig *config,
   /*--- Check that this is an SU2 binary file. SU2 binary files
    have the hex representation of "SU2" as the first int in the file. ---*/
 
-  if (magic_number == 535532) {
+  if (magic_number == SU2_RESTART_MAGIC_NUMBER) {
     SU2_MPI::Error(string("File ") + string(fname) + string(" is a binary SU2 restart file, expected ASCII.\n") +
                    string("SU2 reads/writes binary restart files by default.\n") +
                    string("Note that backward compatibility for ASCII restart files is\n") +
@@ -2895,7 +2895,7 @@ void CSolver::Read_SU2_Restart_ASCII(CGeometry *geometry, const CConfig *config,
   /*--- Check that this is an SU2 binary file. SU2 binary files
    have the hex representation of "SU2" as the first int in the file. ---*/
 
-  if (magic_number == 535532) {
+  if (magic_number == SU2_RESTART_MAGIC_NUMBER) {
     SU2_MPI::Error(string("File ") + string(fname) + string(" is a binary SU2 restart file, expected ASCII.\n") +
                    string("SU2 reads/writes binary restart files by default.\n") +
                    string("Note that backward compatibility for ASCII restart files is\n") +
@@ -2979,7 +2979,7 @@ void CSolver::Read_SU2_Restart_Binary(CGeometry *geometry, const CConfig *config
 
   char str_buf[CGNS_STRING_SIZE], fname[100];
   strcpy(fname, val_filename.c_str());
-  const int nRestart_Vars = 5;
+  const int nRestart_Vars = SU2_RESTART_HEADER_SIZE;
   Restart_Vars.resize(nRestart_Vars);
   fields.clear();
 
@@ -3007,17 +3007,20 @@ void CSolver::Read_SU2_Restart_Binary(CGeometry *geometry, const CConfig *config
   /*--- Check that this is an SU2 binary file. SU2 binary files
    have the hex representation of "SU2" as the first int in the file. ---*/
 
-  if (Restart_Vars[0] != 535532) {
+  if (Restart_Vars[0] != SU2_RESTART_MAGIC_NUMBER) {
     SU2_MPI::Error(string("File ") + string(fname) + string(" is not a binary SU2 restart file.\n") +
                    string("SU2 reads/writes binary restart files by default.\n") +
                    string("Note that backward compatibility for ASCII restart files is\n") +
                    string("possible with the READ_BINARY_RESTART option."), CURRENT_FUNCTION);
   }
 
-  /*--- Store the number of fields and points to be read for clarity. ---*/
+  /*--- Store the number of fields and points to be read for clarity. The file may
+   have been written by a build of different precision, in which case the data needs
+   to be converted after reading it. ---*/
 
   const unsigned long nFields = Restart_Vars[1];
   const unsigned long nPointFile = Restart_Vars[2];
+  const int scalarSize = GetSU2BinaryScalarSize(Restart_Vars[SU2_RESTART_PRECISION_IDX]);
 
   /*--- Read the variable names from the file. Note that we are adopting a
    fixed length of 33 for the string length to match with CGNS. This is
@@ -3039,7 +3042,13 @@ void CSolver::Read_SU2_Restart_Binary(CGeometry *geometry, const CConfig *config
 
   /*--- Read in the data for the restart at all local points. ---*/
 
-  ret = fread(Restart_Data.data(), sizeof(passivedouble), nFields*nPointFile, fhw);
+  if (scalarSize == static_cast<int>(sizeof(passivedouble))) {
+    ret = fread(Restart_Data.data(), scalarSize, nFields*nPointFile, fhw);
+  } else {
+    vector<char> buffer(nFields*nPointFile*scalarSize);
+    ret = fread(buffer.data(), scalarSize, nFields*nPointFile, fhw);
+    SU2BinaryDataToPassive(buffer.data(), scalarSize, nFields*nPointFile, Restart_Data.data());
+  }
   if (ret != nFields*nPointFile) {
     SU2_MPI::Error("Error reading restart file.", CURRENT_FUNCTION);
   }
@@ -3077,17 +3086,20 @@ void CSolver::Read_SU2_Restart_Binary(CGeometry *geometry, const CConfig *config
   /*--- Check that this is an SU2 binary file. SU2 binary files
    have the hex representation of "SU2" as the first int in the file. ---*/
 
-  if (Restart_Vars[0] != 535532) {
+  if (Restart_Vars[0] != SU2_RESTART_MAGIC_NUMBER) {
     SU2_MPI::Error(string("File ") + string(fname) + string(" is not a binary SU2 restart file.\n") +
                    string("SU2 reads/writes binary restart files by default.\n") +
                    string("Note that backward compatibility for ASCII restart files is\n") +
                    string("possible with the READ_BINARY_RESTART option."), CURRENT_FUNCTION);
   }
 
-  /*--- Store the number of fields and points to be read for clarity. ---*/
+  /*--- Store the number of fields and points to be read for clarity. The file may
+   have been written by a build of different precision, in which case the data needs
+   to be converted after reading it. ---*/
 
   const unsigned long nFields = Restart_Vars[1];
   const unsigned long nPointFile = Restart_Vars[2];
+  const int scalarSize = GetSU2BinaryScalarSize(Restart_Vars[SU2_RESTART_PRECISION_IDX]);
 
   /*--- Read the variable names from the file. Note that we are adopting a
    fixed length of 33 for the string length to match with CGNS. This is
@@ -3124,9 +3136,12 @@ void CSolver::Read_SU2_Restart_Binary(CGeometry *geometry, const CConfig *config
 
   delete [] mpi_str_buf;
 
-  /*--- We're writing only su2doubles in the data portion of the file. ---*/
+  /*--- The data portion of the file holds scalars of the precision recorded in the
+   header, which is not necessarily that of this build. Describe them as opaque
+   blocks of bytes so that the file views do not depend on the build precision. ---*/
 
-  etype = MPI_DOUBLE;
+  MPI_Type_contiguous(scalarSize, MPI_BYTE, &etype);
+  MPI_Type_commit(&etype);
 
   /*--- We need to ignore the 4 ints describing the nVar_Restart and nPoints,
    along with the string names of the variables. ---*/
@@ -3152,7 +3167,7 @@ void CSolver::Read_SU2_Restart_Binary(CGeometry *geometry, const CConfig *config
     for (auto iPoint_Global = 0ul; iPoint_Global < geometry->GetGlobal_nPointDomain(); ++iPoint_Global) {
       if (geometry->GetGlobal_to_Local_Point(iPoint_Global) > -1) {
         blocklen[counter] = nFields;
-        displace[counter] = iPoint_Global*nFields*sizeof(passivedouble);
+        displace[counter] = iPoint_Global*nFields*scalarSize;
         counter++;
       }
     }
@@ -3167,10 +3182,10 @@ void CSolver::Read_SU2_Restart_Binary(CGeometry *geometry, const CConfig *config
     const auto partitioner = CLinearPartitioner(nPointFile,0);
 
     blocklen[0] = nFields*partitioner.GetSizeOnRank(rank);
-    displace[0] = nFields*partitioner.GetFirstIndexOnRank(rank)*sizeof(passivedouble);;
+    displace[0] = nFields*partitioner.GetFirstIndexOnRank(rank)*scalarSize;
   }
 
-  MPI_Type_create_hindexed(nBlock, blocklen, displace, MPI_DOUBLE, &filetype);
+  MPI_Type_create_hindexed(nBlock, blocklen, displace, etype, &filetype);
   MPI_Type_commit(&filetype);
 
   /*--- Set the view for the MPI file write, i.e., describe the location in
@@ -3183,17 +3198,25 @@ void CSolver::Read_SU2_Restart_Binary(CGeometry *geometry, const CConfig *config
   const int bufSize = nBlock*blocklen[0];
   Restart_Data.resize(bufSize);
 
-  /*--- Collective call for all ranks to read from their view simultaneously. ---*/
+  /*--- Collective call for all ranks to read from their view simultaneously,
+   converting the data if the file precision does not match this build. ---*/
 
-  MPI_File_read_all(fhw, Restart_Data.data(), bufSize, MPI_DOUBLE, &status);
+  if (scalarSize == static_cast<int>(sizeof(passivedouble))) {
+    MPI_File_read_all(fhw, Restart_Data.data(), bufSize, etype, &status);
+  } else {
+    vector<char> buffer(static_cast<unsigned long>(bufSize)*scalarSize);
+    MPI_File_read_all(fhw, buffer.data(), bufSize, etype, &status);
+    SU2BinaryDataToPassive(buffer.data(), scalarSize, bufSize, Restart_Data.data());
+  }
 
   /*--- All ranks close the file after writing. ---*/
 
   MPI_File_close(&fhw);
 
-  /*--- Free the derived datatype and release temp memory. ---*/
+  /*--- Free the derived datatypes and release temp memory. ---*/
 
   MPI_Type_free(&filetype);
+  MPI_Type_free(&etype);
 
   delete [] blocklen;
   delete [] displace;


### PR DESCRIPTION
## Proposed Changes
The 4th int of the header was written as 0 and never read, it now holds the size in bytes of the floating point data, so single and double precision builds can read each other's restart files. Files written before this field existed have a 0 there and were always double.

The MPI-IO read paths were hardcoded to MPI_DOUBLE, which is redefined to MPI_FLOAT in single precision builds and was therefore consistent within a build but not across builds. They now describe the payload as blocks of bytes of the size given by the header, and convert to the precision of the build when the two differ.

## PR Checklist
- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [X] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [X] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [X] I have added a test case that demonstrates my contribution, if necessary.
- [X] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
