### PR TITLE
Fix ASCII compact restarts

### DIFF
--- a/SU2_CFD/src/output/COutput.cpp
+++ b/SU2_CFD/src/output/COutput.cpp
@@ -433,12 +433,15 @@ void COutput::WriteToFile(CConfig *config, CGeometry *geometry, OUTPUT_TYPE form
       if (!config->GetWrt_Restart_Overwrite())
         filename_iter = config->GetFilename_Iter(fileName, curInnerIter, curOuterIter);
 
-      /*--- If we have compact restarts, we use only the required fields. ---*/
-      if (config->GetWrt_Restart_Compact())
-        volumeDataSorter->SetRequiredFieldNames(requiredVolumeFieldNames);
-
       LogOutputFiles("SU2 ASCII restart");
-      fileWriter = new CSU2FileWriter(volumeDataSorter);
+
+      if (config->GetWrt_Restart_Compact() && volumeDataSorterCompact != nullptr) {
+        /*--- If we have compact restarts, we use only the required fields. ---*/
+        volumeDataSorterCompact->SetRequiredFieldNames(requiredVolumeFieldNames);
+        fileWriter = new CSU2FileWriter(volumeDataSorterCompact);
+      } else {
+        fileWriter = new CSU2FileWriter(volumeDataSorter);
+      }
 
       break;
 

--- a/SU2_CFD/src/output/COutput.cpp
+++ b/SU2_CFD/src/output/COutput.cpp
@@ -435,7 +435,7 @@ void COutput::WriteToFile(CConfig *config, CGeometry *geometry, OUTPUT_TYPE form
 
       LogOutputFiles("SU2 ASCII restart");
 
-      if (config->GetWrt_Restart_Compact() && volumeDataSorterCompact != nullptr) {
+      if (config->GetWrt_Restart_Compact()) {
         /*--- If we have compact restarts, we use only the required fields. ---*/
         volumeDataSorterCompact->SetRequiredFieldNames(requiredVolumeFieldNames);
         fileWriter = new CSU2FileWriter(volumeDataSorterCompact);


### PR DESCRIPTION
## Proposed Changes
`CSU2FileWriter` takes its header from `dataSorter->GetRequiredFieldNames()` but reads data columns by positional index, so the sorter it's handed must be the one whose layout those names describe. The `RESTART_BINARY` branch directly below already does this correctly with `volumeDataSorterCompact` but for ASCII restarts where the user has specified `VOLUME_OUTPUT` fields outside the compact set, the columns become shifted and the outputted values are wrong.

## Related Work
N/A

## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR. If you have any questions, don't hesitate to ask! We want to help. These are a guide for you to know what the reviewers will be looking for in your contribution.*

- [X] I am submitting my contribution to the develop branch.
- [X] My contribution generates no new compiler warnings (try with --warnlevel=3 when using meson).
- [X] My contribution is commented and consistent with SU2 style (https://su2code.github.io/docs_v7/Style-Guide/).
- [X] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [X] I have added a test case that demonstrates my contribution, if necessary.
- [X] I have updated appropriate documentation (Tutorials, Docs Page, config_template.cpp), if necessary.
